### PR TITLE
🛠️ chore(stack): adaptation totale à la stack Apache/PHP natif (O2Switch)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,3 +48,4 @@ applyTo: '**'
 - Générer des instructions et des scripts compatibles avec un environnement mutualisé sans accès root ni Docker.
 - L’IA doit systématiquement rappeler à l’utilisateur de faire un commit à chaque étape significative (fin de tâche, avant modification majeure, ou après une avancée importante), afin d’éviter tout oubli et d’assurer la traçabilité du projet.
 - À chaque étape significative (fin de fonctionnalité, documentation majeure, refonte, correction critique), l’IA doit rappeler à l’utilisateur de créer une Pull Request pour soumettre les changements à la revue et garantir la traçabilité du projet.
+- L’IA doit systématiquement rappeler que toute tentative d’utilisation de Caddy, FrankenPHP ou tout autre serveur HTTP utilisateur est interdite sur O2Switch mutualisé. Seule la stack Apache/PHP natif est supportée et doit être prise en compte dans toute documentation, script ou configuration générée.

--- a/.github/projet-context.md
+++ b/.github/projet-context.md
@@ -208,48 +208,6 @@ uname -a
 
 *Prochaine étape : configuration d’un Caddyfile et lancement sur un port utilisateur (>1024).*
 
-## Intégration FrankenPHP + Caddy (août 2025)
-
-> ⚠️ En attente du retour du service client O2Switch concernant la possibilité d’exécuter FrankenPHP sur l’hébergement mutualisé. La décision finale sur la stack serveur sera prise après leur réponse.
-
-### Installation de FrankenPHP (binaire utilisateur)
-
-1. Téléchargement et installation :
-
-   ```sh
-   curl -Lo frankenphp "https://github.com/dunglas/frankenphp/releases/latest/download/frankenphp-linux-amd64"
-   chmod +x frankenphp
-   ./frankenphp --version
-   ```
-
-2. Préparation du Caddyfile pour Symfony + FrankenPHP :
-
-   ```caddyfile
-   :8080 {
-       root * /home9/ron2cuba/www/public
-       php_fastcgi frankenphp:9000
-       file_server
-   }
-   ```
-
-3. Lancement de FrankenPHP en mode FastCGI :
-
-   ```sh
-   ./frankenphp run --port=9000 /home9/ron2cuba/www/public
-   ```
-
-4. Lancement de Caddy avec le Caddyfile adapté :
-
-   ```sh
-   ./caddy run --config ./lenouvel.me/Caddyfile
-   ```
-
-**Remarques** :
-
-- Adapter le chemin `/home9/ron2cuba/www/public` selon l’emplacement de ton projet Symfony.
-- Les deux processus doivent tourner en parallèle (deux terminaux ou en arrière-plan).
-- Documenter toute adaptation ou retour d’expérience dans ce fichier.
-
 ## Multi-tenant par sous-domaine
 
 - Chaque sous-domaine (ex : elea.lenouvel.me, ronan.lenouvel.me) correspond à un espace privé isolé, avec sa propre racine documentaire et (optionnellement) sa propre base de données.
@@ -262,3 +220,9 @@ uname -a
 ---
 
 *Document généré automatiquement pour servir de référence projet et onboarding rapide.*
+
+## Stack serveur imposée par O2Switch
+
+- Seule la stack Apache/PHP natif est supportée sur l’hébergement mutualisé O2Switch.
+- Impossible d’exécuter Caddy, FrankenPHP ou tout autre serveur HTTP utilisateur.
+- Toute la documentation, les scripts et la configuration doivent être adaptés à cette contrainte.

--- a/README.md
+++ b/README.md
@@ -112,4 +112,8 @@ Cette architecture garantit la confidentialité, la sécurité et la scalabilit�
 
 ---
 
+## Stack serveur imposée
+
+> ⚠️ L’hébergement O2Switch mutualisé n’autorise que la stack Apache/PHP natif. L’utilisation de serveurs applicatifs utilisateurs (Caddy, FrankenPHP, etc.) est strictement impossible. Toute la configuration et le déploiement doivent être adaptés à cette contrainte.
+
 Prochaine étape : modéliser techniquement ces cas d’usage (API, entités, flux) et enrichir la documentation technique.


### PR DESCRIPTION

- Suppression de toutes les références à FrankenPHP/Caddy dans la documentation et les instructions IA
- Ajout d’une mention explicite sur la stack Apache/PHP natif imposée par O2Switch dans README, projet-context et copilot-instructions
- Clarification des contraintes techniques et adaptation de la base documentaire