### PR TITLE
🗑️ refactor: suppression de la classe AccessRight, gestion des droits directement dans Share

### DIFF
--- a/classes.puml
+++ b/classes.puml
@@ -46,19 +46,16 @@ class Share {
   +password : string
 }
 
-class AccessRight {
-  +id : int
-  +type : string ' (lecture, modification, suppression)
-  +grantedAt : datetime
-}
-
 class AccessLog {
   +id : int
   +shareId : int
   +accessedAt : datetime
   +ip : string
   +action : string
+  +userId : int
 }
+
+' Suppression de AccessRight (droit géré directement dans Share par accessLevel)
 
 User "1" -- "1" PrivateSpace : propriétaire >
 PrivateSpace "1" -- "1" Database : stocke >
@@ -66,7 +63,6 @@ PrivateSpace "1" -- "*" File : contient >
 File "1" -- "*" Share : partagé via >
 PrivateSpace "1" -- "*" Share : partage global >
 Share "*" -- "0..1" User : invité (optionnel)
-Share "1" -- "*" AccessRight : droits >
 Share "1" -- "*" AccessLog : journalise >
 
 ' NOTE: Chaque PrivateSpace est associé à un sous-domaine dédié (multi-tenant applicatif)


### PR DESCRIPTION
This pull request updates the `classes.puml` diagram to simplify the access rights model and enhance the `AccessLog` entity. The main changes involve removing the separate `AccessRight` class and managing access levels directly within the `Share` class, as well as adding a `userId` field to `AccessLog` for better traceability.

**Access rights model simplification:**

* Removed the `AccessRight` class; access rights are now managed directly in the `Share` class via an `accessLevel` property.
* Updated diagram associations to remove links to `AccessRight` and reflect the new model.

**Access log enhancements:**

* Added a `userId` field to the `AccessLog` class to record which user performed each action.