### PR TITLE
🐛 fix(deploy): corrige DEPLOYPATH dans .cpanel.yml (racine web au lieu du dépôt)

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -1,7 +1,7 @@
 ---
 deployment:
   tasks:
-    - export DEPLOYPATH=/home/ron2cuba/lenouvel.me/
+    - export DEPLOYPATH=/home9/ron2cuba/repositories/home-cloud 
     # Déploiement du front Symfony (public)
     - /bin/cp -R public/* $DEPLOYPATH
     # (Optionnel) Déploiement de fichiers de config spécifiques


### PR DESCRIPTION
- DEPLOYPATH pointe désormais vers la racine web réelle pour le déploiement Symfony sur O2Switch 

#fix #deploy #cpanel