### PR TITLE
🛠️ chore(doctrine): compatibilité MariaDB et suppression des options …

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -1,6 +1,7 @@
 doctrine:
     dbal:
         url: '%env(resolve:DATABASE_URL)%'
+        server_version: '10.9.3-MariaDB'
 
         # IMPORTANT: You MUST configure your server version,
         # either here or in the DATABASE_URL env var (see .env file)
@@ -11,7 +12,6 @@ doctrine:
     orm:
         auto_generate_proxy_classes: true
         enable_lazy_ghost_objects: true
-        report_fields_where_declared: true
         validate_xml_mapping: true
         naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
         identity_generation_preferences:
@@ -37,7 +37,6 @@ when@prod:
     doctrine:
         orm:
             auto_generate_proxy_classes: false
-            proxy_dir: '%kernel.build_dir%/doctrine/orm/Proxies'
             query_cache_driver:
                 type: pool
                 pool: doctrine.system_cache_pool


### PR DESCRIPTION
This pull request updates the Doctrine configuration to improve compatibility and simplify settings. The most important changes are related to specifying the database server version and removing some configuration options for ORM.

**Database configuration updates:**

* Explicitly sets the `server_version` to `'10.9.3-MariaDB'` in the `dbal` section to ensure proper database compatibility.

**ORM configuration simplification:**

* Removes the `report_fields_where_declared` option from the `orm` section, which may reduce unnecessary reporting and simplify configuration.
* Removes the `proxy_dir` configuration from the production environment, likely relying on default proxy directory settings.