### PR TITLE
♻️ refact(security): adaptation FileVoter pour compatibilité Symfony 7.3

### DIFF
--- a/src/Security/Voter/FileVoter.php
+++ b/src/Security/Voter/FileVoter.php
@@ -19,13 +19,13 @@ class FileVoter extends Voter
             && $subject instanceof File;
     }
 
-/**
+    /**
      * @param string $attribute
-     * @param File $subject
+     * @param mixed $subject
      * @param TokenInterface $token
-     * TODO Symfony 7+ : adapter la signature selon la nouvelle API Voter
+     * TODO Symfony 7.4+ : ajouter l'argument Vote|null $vote à la signature
      */
-    protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
     {
         $user = $token->getUser();
         if (!$user instanceof UserInterface) {


### PR DESCRIPTION
This pull request updates the method signature in the `FileVoter` class to align with recent Symfony API changes. The main change is the use of the `mixed` type for the `$subject` parameter and the addition of a note for future compatibility with Symfony 7.4+.

Symfony API compatibility update:

* Changed the `$subject` parameter type from `File` to `mixed` and updated the method signature in `voteOnAttribute` to use `mixed`, preparing for future Symfony 7.4+ changes.
* Updated the method documentation to reflect the new parameter type and added a TODO comment regarding the upcoming `Vote|null $vote` argument in Symfony 7.4+.