### PR TITLE
✅ test(security): retour 403 natif + injection uploadDir

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -22,3 +22,8 @@ services:
     App\Service\FileUploader:
         arguments:
             $targetDirectory: '%app.files_dir%'
+
+    # Injection explicite du répertoire upload pour FilePathSecurity
+    App\Security\FilePathSecurity:
+        arguments:
+            $uploadDir: '%app.files_dir%'

--- a/src/Controller/FileController.php
+++ b/src/Controller/FileController.php
@@ -27,12 +27,7 @@ class FileController extends AbstractController
             $this->addFlash('danger', $errorMsg);
             return $this->redirectToRoute('file_upload');
         }
-        try {
-            $fileAccessManager->assertDownloadAccess($file, $this->getUser());
-        } catch (\Symfony\Component\Security\Core\Exception\AccessDeniedException $e) {
-            $this->addFlash('danger', $errorMsg);
-            return $this->redirectToRoute('file_upload');
-        }
+        $fileAccessManager->assertDownloadAccess($file, $this->getUser());
         try {
             $realPath = $filePathSecurity->assertSafePath($file->getPath());
         } catch (\RuntimeException $e) {
@@ -60,12 +55,7 @@ class FileController extends AbstractController
             $this->addFlash('danger', $errorMsg);
             return $this->redirectToRoute('file_upload');
         }
-        try {
-            $fileAccessManager->assertDeleteAccess($file, $this->getUser());
-        } catch (\Symfony\Component\Security\Core\Exception\AccessDeniedException $e) {
-            $this->addFlash('danger', $errorMsg);
-            return $this->redirectToRoute('file_upload');
-        }
+        $fileAccessManager->assertDeleteAccess($file, $this->getUser());
         try {
             $realPath = $filePathSecurity->assertSafePath($file->getPath());
         } catch (\RuntimeException $e) {

--- a/src/Service/UploadLogger.php
+++ b/src/Service/UploadLogger.php
@@ -17,20 +17,24 @@ class UploadLogger
 
     public function logSuccess(UploadedFile $file, User $user): void
     {
+        $size = @file_exists($file->getPathname()) ? $file->getSize() : null;
+        $mimeType = @file_exists($file->getPathname()) ? $file->getMimeType() : null;
         $this->logger->info('Upload réussi', [
             'filename' => $file->getClientOriginalName(),
-            'size' => $file->getSize(),
-            'mimeType' => $file->getMimeType(),
+            'size' => $size,
+            'mimeType' => $mimeType,
             'user' => $user->getUserIdentifier(),
         ]);
     }
 
     public function logError(UploadedFile $file, User $user, string $error): void
     {
+        $size = @file_exists($file->getPathname()) ? $file->getSize() : null;
+        $mimeType = @file_exists($file->getPathname()) ? $file->getMimeType() : null;
         $this->logger->error('Erreur upload', [
             'filename' => $file->getClientOriginalName(),
-            'size' => $file->getSize(),
-            'mimeType' => $file->getMimeType(),
+            'size' => $size,
+            'mimeType' => $mimeType,
             'user' => $user->getUserIdentifier(),
             'error' => $error,
         ]);
@@ -38,10 +42,12 @@ class UploadLogger
 
     public function logValidation(UploadedFile $file, User $user, string $validation): void
     {
+        $size = @file_exists($file->getPathname()) ? $file->getSize() : null;
+        $mimeType = @file_exists($file->getPathname()) ? $file->getMimeType() : null;
         $this->logger->debug('Validation upload', [
             'filename' => $file->getClientOriginalName(),
-            'size' => $file->getSize(),
-            'mimeType' => $file->getMimeType(),
+            'size' => $size,
+            'mimeType' => $mimeType,
             'user' => $user->getUserIdentifier(),
             'validation' => $validation,
         ]);


### PR DESCRIPTION
This pull request introduces improvements to file upload security and logging, as well as refactors access control error handling in the file controller. The main changes are grouped into service configuration, controller logic, and logging enhancements.

**Service configuration:**

* Explicitly injects the upload directory (`%app.files_dir%`) into the `FilePathSecurity` service to ensure it has the correct path for validating file operations.

**Controller logic refactoring:**

* Removes redundant try/catch blocks for access control checks (`assertDownloadAccess` and `assertDeleteAccess`) in `FileController`, relying on direct exception propagation and simplifying error handling flow. [[1]](diffhunk://#diff-a4cfed039e6cad2086c061e9444541d5231bc03d6c452fc889f592c5378919d5L30-L35) [[2]](diffhunk://#diff-a4cfed039e6cad2086c061e9444541d5231bc03d6c452fc889f592c5378919d5L63-L68)

**Logging enhancements:**

* Updates `UploadLogger` methods to check if the uploaded file exists before retrieving its size and MIME type, preventing potential errors when logging file information.