### PR TITLE
♻️ refact(ui): découpe liste fichiers en sous-template

### DIFF
--- a/templates/home/_file_list.html.twig
+++ b/templates/home/_file_list.html.twig
@@ -1,0 +1,24 @@
+{# Liste des fichiers utilisateur, mobile-first #}
+{% if filesPager and filesPager.nbResults > 0 %}
+    <ul class="divide-y divide-gray-200">
+        {% for file in filesPager.currentPageResults %}
+            <li class="py-2 flex flex-col sm:flex-row sm:items-center justify-between">
+                <span class="font-mono text-sm break-all">{{ file.name }}</span>
+                <span class="text-xs text-gray-500">{{ file.size }} octets</span>
+                <span class="text-xs text-gray-400">{{ file.mimeType }}</span>
+                <a href="{{ path('file_download', {id: file.id}) }}" class="text-blue-600 hover:underline ml-2">Télécharger</a>
+            </li>
+        {% endfor %}
+    </ul>
+    <div class="mt-4 flex justify-center">
+        {% if filesPager.hasPreviousPage %}
+            <a href="?page={{ filesPager.previousPage }}" class="px-2 py-1 bg-gray-200 rounded-l hover:bg-gray-300">&lt; Précédent</a>
+        {% endif %}
+        <span class="px-3 py-1 bg-gray-100">Page {{ filesPager.currentPage }} / {{ filesPager.nbPages }}</span>
+        {% if filesPager.hasNextPage %}
+            <a href="?page={{ filesPager.nextPage }}" class="px-2 py-1 bg-gray-200 rounded-r hover:bg-gray-300">Suivant &gt;</a>
+        {% endif %}
+    </div>
+{% else %}
+    <p class="text-gray-500">Aucun fichier déposé pour l’instant.</p>
+{% endif %}

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -4,13 +4,19 @@
 {% endblock %}
 
 {% block body %}
-	<h1>Home Cloud</h1>
+	<h1 class="text-xl font-bold mb-4">Home Cloud</h1>
 
 	{% if not app.user %}
 		{% include 'home/_auth_link.html.twig' %}
 	{% endif %}
 
 	{% if app.user %}
-		{% include 'home/_upload_button.html.twig' %}
+		<div class="mb-6">
+			{% include 'home/_upload_button.html.twig' %}
+		</div>
+		<section class="bg-white rounded shadow p-4 mb-4">
+			<h2 class="text-lg font-semibold mb-2">Mes fichiers</h2>
+			{% include 'home/_file_list.html.twig' %}
+		</section>
 	{% endif %}
 {% endblock %}


### PR DESCRIPTION
This pull request improves the user file listing section on the home page by adding a paginated, mobile-friendly display of uploaded files, along with download links and file metadata. It also updates the overall layout and styling for better readability and user experience.

File listing and pagination:

* Added a new `home/_file_list.html.twig` template to display the user's files in a paginated, mobile-first list, showing file name, size, mime type, and a download link.
* Integrated the new file list template into the home page, wrapped in a styled section with a heading for clarity.

Styling and layout improvements:

* Updated the main heading and added spacing/styling to the upload button and file listing section for a cleaner, more modern look.