### PR TITLE
Feat/UI upload files

### DIFF
--- a/templates/file/upload.html.twig
+++ b/templates/file/upload.html.twig
@@ -5,6 +5,12 @@
 
 {% block body %}
 	<h1 class="text-2xl font-bold mb-4">Uploader un fichier</h1>
+	{% if largeFile %}
+	<div class="mb-4 p-3 bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 rounded">
+		⚠️ Le fichier sélectionné est volumineux (&gt; 10 Mo). L’envoi peut prendre du temps.<br>
+		Merci de patienter pendant l’upload. Aucune limite n’est imposée côté application.
+	</div>
+	{% endif %}
 	{{ form_start(form, {'attr': {'enctype': 'multipart/form-data'}}) }}
 	{{ form_widget(form) }}
 	<button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Envoyer</button>

--- a/templates/file/upload.html.twig
+++ b/templates/file/upload.html.twig
@@ -5,9 +5,20 @@
 
 {% block body %}
 	<h1 class="text-2xl font-bold mb-4">Uploader un fichier</h1>
-	{% if largeFile %}
+	{% set tooLargeError = false %}
+	{% for label, messages in app.flashes %}
+		{% if label == 'danger' %}
+			{% for message in messages %}
+				{% if 'too large' in message or 'trop volumineux' in message %}
+					{% set tooLargeError = true %}
+				{% endif %}
+			{% endfor %}
+		{% endif %}
+	{% endfor %}
+	{% if largeFile or tooLargeError %}
 	<div class="mb-4 p-3 bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 rounded">
-		⚠️ Le fichier sélectionné est volumineux (&gt; 10 Mo). L’envoi peut prendre du temps.<br>
+		⚠️ Le fichier sélectionné est volumineux ou dépasse la limite serveur.<br>
+		L’envoi peut prendre du temps ou échouer si la taille dépasse la configuration PHP.<br>
 		Merci de patienter pendant l’upload. Aucune limite n’est imposée côté application.
 	</div>
 	{% endif %}

--- a/templates/home/_file_delete_button.html.twig
+++ b/templates/home/_file_delete_button.html.twig
@@ -1,0 +1,6 @@
+<form method="post" action="{{ path('file_delete', {id: file.id}) }}" class="inline">
+    <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ file.id) }}">
+    <button type="submit" class="ml-2 px-2 py-1 bg-red-600 text-white rounded hover:bg-red-700 text-xs transition" onclick="return confirm('Supprimer ce fichier ?')">
+        Supprimer
+    </button>
+</form>

--- a/templates/home/_file_list.html.twig
+++ b/templates/home/_file_list.html.twig
@@ -7,6 +7,7 @@
                 <span class="text-xs text-gray-500">{{ file.size }} octets</span>
                 <span class="text-xs text-gray-400">{{ file.mimeType }}</span>
                 <a href="{{ path('file_download', {id: file.id}) }}" class="text-blue-600 hover:underline ml-2">Télécharger</a>
+                {% include 'home/_file_delete_button.html.twig' with {file: file} %}
             </li>
         {% endfor %}
     </ul>


### PR DESCRIPTION
This pull request improves the file upload experience by adding better handling and user feedback for large files, and introduces a delete button for files in the list view. The main changes are grouped below:

**File upload handling and user feedback:**

* The upload controller now detects if an uploaded file is larger than 10 MB, sets a `largeFile` flag, and passes it to the template for user feedback.
* All upload responses now render the `file/upload.html.twig` template directly, passing success/error states and messages, as well as the `largeFile` flag, instead of using separate feedback managers.
* The upload form template (`file/upload.html.twig`) displays a warning message if the file is large or if a server-side "too large" error is detected, informing users about possible delays or failures due to server configuration.
* The index action now always passes `largeFile: false` to the upload template for consistency.

**File deletion feature:**

* Added a delete button for each file in the file list, using a new partial template (`home/_file_delete_button.html.twig`) with CSRF protection and a confirmation prompt. [[1]](diffhunk://#diff-780c9aec6bf66c93827dcf79e87901949fc19bc18e6f4c5d5e6c4b9b36ea39a9R1-R6) [[2]](diffhunk://#diff-e84e7a2b4c1b2a6707e2276e0832bd58fd1375c61f482c75ecaf7dbab6ce4e51R10)