### PR TITLE
Feat/UI upload files

### DIFF
--- a/templates/home/_file_bulk_delete_form.html.twig
+++ b/templates/home/_file_bulk_delete_form.html.twig
@@ -1,19 +1,40 @@
 {# Formulaire de suppression en masse des fichiers #}
 <form method="post" action="{{ path('file_bulk_delete') }}" class="mb-4">
-    <input type="hidden" name="_token" value="{{ csrf_token('bulk_delete') }}">
-    <ul class="divide-y divide-gray-200">
-        {% for file in filesPager.currentPageResults %}
-            <li class="py-2 flex flex-col sm:flex-row sm:items-center justify-between">
-                <label class="flex items-center gap-2">
-                    <input type="checkbox" name="files[]" value="{{ file.id }}" class="form-checkbox">
-                    <span class="font-mono text-sm break-all">{{ file.name }}</span>
-                </label>
-                <span class="text-xs text-gray-500">{{ file.size }} octets</span>
-                <span class="text-xs text-gray-400">{{ file.mimeType }}</span>
-            </li>
-        {% endfor %}
-    </ul>
-    <button type="submit" class="mt-4 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition" onclick="return confirm('Supprimer les fichiers sélectionnés ?')">
-        Supprimer la sélection
-    </button>
+	<input type="hidden" name="_token" value="{{ csrf_token('bulk_delete') }}">
+	<ul class="divide-y divide-gray-200">
+		{% for file in filesPager.currentPageResults %}
+			<li class="py-2 flex flex-col sm:flex-row sm:items-center justify-between">
+				<label class="flex items-center gap-2">
+					<input type="checkbox" name="files[]" value="{{ file.id }}" class="form-checkbox">
+					<span class="font-mono text-sm break-all">{{ file.name }}</span>
+				</label>
+				<span class="text-xs text-gray-500">{{ file.size }}
+					octets</span>
+				<span class="text-xs text-gray-400">{{ file.mimeType }}</span>
+			</li>
+		{% endfor %}
+	</ul>
+	<button type="submit" id="bulk-delete-btn" class="mt-4 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition hidden" onclick="return confirm('Supprimer les fichiers sélectionnés ?')">
+		Supprimer les fichiers sélectionnés
+	</button>
 </form>
+<script>
+	// Mobile first : bouton affiché uniquement si au moins une case est cochée
+document.addEventListener('DOMContentLoaded', function () {
+const checkboxes = document.querySelectorAll('.file-checkbox');
+const btn = document.getElementById('bulk-delete-btn');
+function toggleBtn() {
+let checked = false;
+checkboxes.forEach(cb => {
+if (cb.checked) 
+checked = true;
+
+});
+btn.classList.toggle('hidden', ! checked);
+}
+checkboxes.forEach(cb => {
+cb.addEventListener('change', toggleBtn);
+});
+toggleBtn();
+});
+</script>

--- a/templates/home/_file_bulk_delete_form.html.twig
+++ b/templates/home/_file_bulk_delete_form.html.twig
@@ -1,0 +1,19 @@
+{# Formulaire de suppression en masse des fichiers #}
+<form method="post" action="{{ path('file_bulk_delete') }}" class="mb-4">
+    <input type="hidden" name="_token" value="{{ csrf_token('bulk_delete') }}">
+    <ul class="divide-y divide-gray-200">
+        {% for file in filesPager.currentPageResults %}
+            <li class="py-2 flex flex-col sm:flex-row sm:items-center justify-between">
+                <label class="flex items-center gap-2">
+                    <input type="checkbox" name="files[]" value="{{ file.id }}" class="form-checkbox">
+                    <span class="font-mono text-sm break-all">{{ file.name }}</span>
+                </label>
+                <span class="text-xs text-gray-500">{{ file.size }} octets</span>
+                <span class="text-xs text-gray-400">{{ file.mimeType }}</span>
+            </li>
+        {% endfor %}
+    </ul>
+    <button type="submit" class="mt-4 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition" onclick="return confirm('Supprimer les fichiers sélectionnés ?')">
+        Supprimer la sélection
+    </button>
+</form>

--- a/templates/home/_file_delete_button.html.twig
+++ b/templates/home/_file_delete_button.html.twig
@@ -1,6 +1,1 @@
-<form method="post" action="{{ path('file_delete', {id: file.id}) }}" class="inline">
-    <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ file.id) }}">
-    <button type="submit" class="ml-2 px-2 py-1 bg-red-600 text-white rounded hover:bg-red-700 text-xs transition" onclick="return confirm('Supprimer ce fichier ?')">
-        Supprimer
-    </button>
-</form>
+{# Suppression individuelle désactivée, remplacée par bulk delete #}

--- a/templates/home/_file_list.html.twig
+++ b/templates/home/_file_list.html.twig
@@ -1,25 +1,2 @@
 {# Liste des fichiers utilisateur, mobile-first #}
-{% if filesPager and filesPager.nbResults > 0 %}
-    <ul class="divide-y divide-gray-200">
-        {% for file in filesPager.currentPageResults %}
-            <li class="py-2 flex flex-col sm:flex-row sm:items-center justify-between">
-                <span class="font-mono text-sm break-all">{{ file.name }}</span>
-                <span class="text-xs text-gray-500">{{ file.size }} octets</span>
-                <span class="text-xs text-gray-400">{{ file.mimeType }}</span>
-                <a href="{{ path('file_download', {id: file.id}) }}" class="text-blue-600 hover:underline ml-2">Télécharger</a>
-                {% include 'home/_file_delete_button.html.twig' with {file: file} %}
-            </li>
-        {% endfor %}
-    </ul>
-    <div class="mt-4 flex justify-center">
-        {% if filesPager.hasPreviousPage %}
-            <a href="?page={{ filesPager.previousPage }}" class="px-2 py-1 bg-gray-200 rounded-l hover:bg-gray-300">&lt; Précédent</a>
-        {% endif %}
-        <span class="px-3 py-1 bg-gray-100">Page {{ filesPager.currentPage }} / {{ filesPager.nbPages }}</span>
-        {% if filesPager.hasNextPage %}
-            <a href="?page={{ filesPager.nextPage }}" class="px-2 py-1 bg-gray-200 rounded-r hover:bg-gray-300">Suivant &gt;</a>
-        {% endif %}
-    </div>
-{% else %}
-    <p class="text-gray-500">Aucun fichier déposé pour l’instant.</p>
-{% endif %}
+{# Désormais gérée par le formulaire bulk delete #}

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -16,7 +16,7 @@
 		</div>
 		<section class="bg-white rounded shadow p-4 mb-4">
 			<h2 class="text-lg font-semibold mb-2">Mes fichiers</h2>
-			{% include 'home/_file_list.html.twig' %}
+			{% include 'home/_file_bulk_delete_form.html.twig' %}
 		</section>
 	{% endif %}
 {% endblock %}


### PR DESCRIPTION
This pull request introduces a bulk file deletion feature, replacing the previous individual file deletion approach in both backend logic and frontend UI. The main changes include a new controller action for bulk deletion, a corresponding form in the UI, and the removal of individual delete buttons and logic.

**Bulk File Deletion Feature:**

* Added a new `bulkDelete` action to `FileController` for handling bulk file deletions, including access checks, file removal, and feedback to the user.
* Created the `templates/home/_file_bulk_delete_form.html.twig` template, which provides a form with checkboxes for selecting multiple files and a submit button that appears only when files are selected.
* Updated `templates/home/index.html.twig` to include the new bulk delete form instead of the old file list.

**Removal of Individual File Deletion:**

* Removed the individual file delete button from `templates/home/_file_delete_button.html.twig`, commenting that it is now replaced by bulk delete.
* Removed the old file list and individual delete logic from `templates/home/_file_list.html.twig`, noting that file listing and deletion are now managed by the bulk delete form.

**Minor Route Update:**

* Fixed the route regex for the individual delete endpoint in `FileController` to use a non-escaped digit pattern for consistency, though individual deletion is now deprecated.