### PR TITLE
✨ feat(ui): dernier fichier uploadé en haut de la page

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -17,6 +17,7 @@ class HomeController extends AbstractController
     {
         $user = $this->getUser();
         $filesPager = null;
+        $lastFile = null;
         if ($user) {
             $page = max(1, (int) $request->query->get('page', 1));
             $query = $fileRepository->getFilesForUserQuery($user);
@@ -24,9 +25,11 @@ class HomeController extends AbstractController
             $pagerfanta->setMaxPerPage(10);
             $pagerfanta->setCurrentPage($page);
             $filesPager = $pagerfanta;
+            $lastFile = $fileRepository->getLastFileForUser($user);
         }
         return $this->render('home/index.html.twig', [
             'filesPager' => $filesPager,
+            'lastFile' => $lastFile,
         ]);
     }
 }

--- a/src/Repository/FileRepository.php
+++ b/src/Repository/FileRepository.php
@@ -10,6 +10,19 @@ use Doctrine\ORM\Query;
 
 class FileRepository extends ServiceEntityRepository
 {
+    /**
+     * Retourne le dernier fichier uploadé par un utilisateur
+     */
+    public function getLastFileForUser(User $user): ?File
+    {
+        return $this->createQueryBuilder('f')
+            ->andWhere('f.owner = :user')
+            ->setParameter('user', $user)
+            ->orderBy('f.uploadedAt', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, File::class);

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -11,9 +11,24 @@
 	{% endif %}
 
 	{% if app.user %}
-		<div class="mb-6">
-			{% include 'home/_upload_button.html.twig' %}
-		</div>
+		{% if lastFile %}
+			<div class="mb-4 p-3 bg-blue-50 border border-blue-200 rounded flex flex-col sm:flex-row sm:items-center justify-between">
+				<div>
+					<span class="font-semibold text-blue-700">Dernier fichier uploadé :</span>
+					<span class="font-mono text-sm break-all">{{ lastFile.name }}</span>
+					<span class="text-xs text-gray-500">({{ lastFile.size }}
+						octets,
+						{{ lastFile.mimeType }})</span>
+					<a href="{{ path('file_download', {id: lastFile.id}) }}" class="ml-2 text-blue-600 hover:underline">Télécharger</a>
+				</div>
+				<form method="post" action="{{ path('file_delete', {id: lastFile.id}) }}" class="inline">
+					<input type="hidden" name="_token" value="{{ csrf_token('delete' ~ lastFile.id) }}">
+					<button type="submit" class="ml-2 px-2 py-1 bg-red-600 text-white rounded hover:bg-red-700 text-xs transition" onclick="return confirm('Supprimer ce fichier uploadé ?')">
+						Supprimer
+					</button>
+				</form>
+			</div>
+		{% endif %}
 		<section class="bg-white rounded shadow p-4 mb-4">
 			<h2 class="text-lg font-semibold mb-2">Mes fichiers</h2>
 			{% include 'home/_file_bulk_delete_form.html.twig' %}


### PR DESCRIPTION
This pull request adds a feature to display the most recently uploaded file for the logged-in user on the home page, along with options to download or delete it. The changes involve backend logic to fetch the last file, passing it to the template, and updating the UI to show file details and actions.

**Backend enhancements:**

* Added a new method `getLastFileForUser` to `FileRepository` to fetch the latest uploaded file for a user, ordered by upload date.
* Updated the `index` method in `HomeController.php` to retrieve the last file for the current user and pass it to the template as `lastFile`.

**Frontend/UI improvements:**

* Modified `home/index.html.twig` to display a highlighted section for the last uploaded file, showing its name, size, mime type, and providing "Download" and "Delete" actions if a file exists.Affiche le dernier fichier uploadé par l’utilisateur en haut du template d’accueil, avec bouton de suppression et lien de téléchargement. Texte adapté pour la mise en avant du dernier upload.

- templates/home/index.html.twig

Refs #issue-num