### PR TITLE
✨ feat(ui): affichage fichiers en tableau + actions individuelles

### DIFF
--- a/src/Controller/FileController.php
+++ b/src/Controller/FileController.php
@@ -2,20 +2,53 @@
 
 namespace App\Controller;
 
+use ZipArchive;
 use App\Entity\File;
-use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Http\Attribute\IsGranted;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
-use App\Security\FileAccessManager;
 use App\Security\FilePathSecurity;
+use App\Security\FileAccessManager;
 use App\Security\FileMimeTypeGuesser;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
 class FileController extends AbstractController
 {
+
+    #[Route('/files/download-zip', name: 'file_download_zip')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function downloadZip(EntityManagerInterface $em): BinaryFileResponse|RedirectResponse
+    {
+        $user = $this->getUser();
+        $userId = ($user instanceof \App\Entity\User && method_exists($user, 'getId')) ? $user->getId() : 'unknown';
+        $files = $em->getRepository(File::class)->findBy(['owner' => $user]);
+
+        if (!$files || count($files) === 0) {
+            $this->addFlash('warning', 'Aucun fichier à télécharger.');
+            return $this->redirectToRoute('app_home');
+        }
+        $zipPath = sys_get_temp_dir() . '/homecloud_' . $userId . '_' . time() . '.zip';
+        $zip = new ZipArchive();
+        if ($zip->open($zipPath, ZipArchive::CREATE) !== true) {
+            $this->addFlash('danger', 'Impossible de créer l’archive.');
+            return $this->redirectToRoute('app_home');
+        }
+        foreach ($files as $file) {
+            $zip->addFile($file->getPath(), $file->getName());
+        }
+        $zip->close();
+        $response = new BinaryFileResponse($zipPath);
+        $response->setContentDisposition(
+            ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+            'mes-fichiers-homecloud.zip'
+        );
+        $response->headers->set('Content-Type', 'application/zip');
+        $response->deleteFileAfterSend(true);
+        return $response;
+    }
     #[Route('/files/bulk-delete', name: 'file_bulk_delete', methods: ['POST'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function bulkDelete(EntityManagerInterface $em, FileAccessManager $fileAccessManager, FilePathSecurity $filePathSecurity): RedirectResponse
@@ -101,5 +134,43 @@ class FileController extends AbstractController
         $em->flush();
         $this->addFlash('success', 'Fichier supprimé avec succès.');
         return $this->redirectToRoute('file_upload');
+    }
+
+    #[Route('/files/download-selected-zip', name: 'file_download_selected_zip', methods: ['POST'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function downloadSelectedZip(EntityManagerInterface $em): BinaryFileResponse|RedirectResponse
+    {
+        $request = $this->container->get('request_stack')->getCurrentRequest();
+        $ids = $request->request->all('files');
+        $user = $this->getUser();
+        $userId = ($user instanceof \App\Entity\User && method_exists($user, 'getId')) ? $user->getId() : 'unknown';
+        if (!is_array($ids) || empty($ids)) {
+            $this->addFlash('warning', 'Aucun fichier sélectionné.');
+            return $this->redirectToRoute('app_home');
+        }
+        // On ne prend que les fichiers appartenant à l'utilisateur
+        $files = $em->getRepository(File::class)->findBy(['id' => $ids, 'owner' => $user]);
+        if (!$files || count($files) === 0) {
+            $this->addFlash('warning', 'Aucun fichier à télécharger.');
+            return $this->redirectToRoute('app_home');
+        }
+        $zipPath = sys_get_temp_dir() . '/homecloud_' . $userId . '_' . time() . '.zip';
+        $zip = new ZipArchive();
+        if ($zip->open($zipPath, ZipArchive::CREATE) !== true) {
+            $this->addFlash('danger', 'Impossible de créer l’archive.');
+            return $this->redirectToRoute('app_home');
+        }
+        foreach ($files as $file) {
+            $zip->addFile($file->getPath(), $file->getName());
+        }
+        $zip->close();
+        $response = new BinaryFileResponse($zipPath);
+        $response->setContentDisposition(
+            ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+            'mes-fichiers-homecloud.zip'
+        );
+        $response->headers->set('Content-Type', 'application/zip');
+        $response->deleteFileAfterSend(true);
+        return $response;
     }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -11,8 +11,17 @@ use Symfony\Component\Security\Core\User\UserInterface;
 #[ORM\UniqueConstraint(name: 'UNIQ_IDENTIFIER_USERNAME', fields: ['username'])]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 180)]
+    private ?string $username = null;
+
     #[ORM\Column(length: 180, unique: true, nullable: true)]
     private ?string $email = null;
+
     public function getEmail(): ?string
     {
         return $this->email;
@@ -23,13 +32,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $this->email = $email;
         return $this;
     }
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column]
-    private ?int $id = null;
-
-    #[ORM\Column(length: 180)]
-    private ?string $username = null;
 
     /**
      * @var list<string> The user roles

--- a/templates/home/_file_bulk_delete_form.html.twig
+++ b/templates/home/_file_bulk_delete_form.html.twig
@@ -1,40 +1,68 @@
 {# Formulaire de suppression en masse des fichiers #}
-<form method="post" action="{{ path('file_bulk_delete') }}" class="mb-4">
+
+<form method="post" class="mb-4 flex flex-col gap-4">
 	<input type="hidden" name="_token" value="{{ csrf_token('bulk_delete') }}">
-	<ul class="divide-y divide-gray-200">
-		{% for file in filesPager.currentPageResults %}
-			<li class="py-2 flex flex-col sm:flex-row sm:items-center justify-between">
-				<label class="flex items-center gap-2">
-					<input type="checkbox" name="files[]" value="{{ file.id }}" class="form-checkbox">
-					<span class="font-mono text-sm break-all">{{ file.name }}</span>
-				</label>
-				<span class="text-xs text-gray-500">{{ file.size }}
-					octets</span>
-				<span class="text-xs text-gray-400">{{ file.mimeType }}</span>
-			</li>
-		{% endfor %}
-	</ul>
-	<button type="submit" id="bulk-delete-btn" class="mt-4 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition hidden" onclick="return confirm('Supprimer les fichiers sélectionnés ?')">
-		Supprimer les fichiers sélectionnés
-	</button>
+	<div class="overflow-x-auto">
+		<table class="min-w-full border rounded shadow text-sm">
+			<thead class="bg-gray-50">
+				<tr>
+					<th class="p-2 text-left font-semibold">&nbsp;</th>
+					<th class="p-2 text-left font-semibold">Nom</th>
+					<th class="p-2 text-left font-semibold">Date</th>
+					<th class="p-2 text-left font-semibold">Taille</th>
+					<th class="p-2 text-left font-semibold">Actions</th>
+				</tr>
+			</thead>
+			<tbody>
+				{% for file in filesPager.currentPageResults %}
+					<tr class="border-b">
+						<td class="p-2 align-middle">
+							<input type="checkbox" name="files[]" value="{{ file.id }}" class="form-checkbox file-checkbox">
+						</td>
+						<td class="p-2 align-middle font-mono break-all">{{ file.name }}</td>
+						<td class="p-2 align-middle text-xs text-gray-500">{{ file.uploadedAt|date('d/m/Y H:i') }}</td>
+						<td class="p-2 align-middle text-xs text-gray-500">{{ file.size|number_format(0, ',', ' ') }}
+							octets</td>
+						<td class="p-2 align-middle">
+							<a href="{{ path('file_download', {id: file.id}) }}" class="px-2 py-1 bg-blue-100 text-blue-700 rounded hover:bg-blue-200 text-xs transition" title="Télécharger le fichier">
+								Télécharger
+							</a>
+						</td>
+					</tr>
+				{% endfor %}
+			</tbody>
+		</table>
+	</div>
+	<div class="flex gap-4 mt-4">
+		<button type="submit" formaction="{{ path('file_download_selected_zip') }}" id="bulk-zip-btn" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition hidden">
+			Télécharger ZIP
+		</button>
+		<button type="submit" formaction="{{ path('file_bulk_delete') }}" id="bulk-delete-btn" class="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition hidden" onclick="return confirm('Supprimer les fichiers sélectionnés ?')">
+			Supprimer
+		</button>
+	</div>
 </form>
 <script>
-	// Mobile first : bouton affiché uniquement si au moins une case est cochée
+	// Mobile first : boutons affichés uniquement si au moins une case est cochée
 document.addEventListener('DOMContentLoaded', function () {
 const checkboxes = document.querySelectorAll('.file-checkbox');
-const btn = document.getElementById('bulk-delete-btn');
-function toggleBtn() {
+const btnDelete = document.getElementById('bulk-delete-btn');
+const btnZip = document.getElementById('bulk-zip-btn');
+function toggleBtns() {
 let checked = false;
 checkboxes.forEach(cb => {
 if (cb.checked) 
 checked = true;
 
+
+
 });
-btn.classList.toggle('hidden', ! checked);
+btnDelete.classList.toggle('hidden', ! checked);
+btnZip.classList.toggle('hidden', ! checked);
 }
 checkboxes.forEach(cb => {
-cb.addEventListener('change', toggleBtn);
+cb.addEventListener('change', toggleBtns);
 });
-toggleBtn();
+toggleBtns();
 });
 </script>

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -11,6 +11,12 @@
 	{% endif %}
 
 	{% if app.user %}
+		<div class="mb-6 flex flex-col sm:flex-row sm:items-center justify-between gap-2">
+			{% include 'home/_upload_button.html.twig' %}
+			<a href="{{ path('file_download_zip') }}" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition text-sm">
+				Télécharger tous les fichiers (zip)
+			</a>
+		</div>
 		{% if lastFile %}
 			<div class="mb-4 p-3 bg-blue-50 border border-blue-200 rounded flex flex-col sm:flex-row sm:items-center justify-between">
 				<div>


### PR DESCRIPTION
This pull request adds bulk ZIP download functionality for user files, improves the bulk file management UI, and refactors related backend and frontend code. Users can now download all their files or selected files as a ZIP archive, with updated forms and buttons for easier access. The changes also include a refactor in the `User` entity and enhancements to the file listing table.

**Bulk ZIP download features:**

* Added `downloadZip` action to `FileController` allowing authenticated users to download all their files as a ZIP archive.
* Added `downloadSelectedZip` action to `FileController` enabling ZIP download of only selected files via a POST request.

**Frontend UI improvements:**

* Refactored `home/_file_bulk_delete_form.html.twig` to use a table layout for file listing, added checkboxes for selection, and introduced two buttons: one for bulk ZIP download and one for bulk deletion. Button visibility now depends on selection.
* Updated `home/index.html.twig` to include a prominent button for downloading all files as a ZIP archive.

**Entity refactor:**

* Moved the `id` and `username` property definitions to the top of the `User` entity class for improved clarity and structure. [[1]](diffhunk://#diff-29168649467ab681a1c7891011f17d64e2cae8a6efd8f976111521bb308ea372R14-R24) [[2]](diffhunk://#diff-29168649467ab681a1c7891011f17d64e2cae8a6efd8f976111521bb308ea372L26-L32)- Affiche la liste des fichiers sous forme de tableau (nom, date, taille, actions)
- Ajoute le bouton de téléchargement individuel sur chaque ligne
- Le bouton ZIP n’apparaît que pour la sélection multiple
- UX mobile first, responsive et accessible

Closes #<numéro_issue_si_applicable>