### PR TITLE
Feat/UI upload files

### DIFF
--- a/assets/file-table.js
+++ b/assets/file-table.js
@@ -1,0 +1,62 @@
+// JS pour tri et filtre du tableau des fichiers
+
+document.addEventListener('DOMContentLoaded', function () {
+    const checkboxes = document.querySelectorAll('.file-checkbox');
+    const btnDelete = document.getElementById('bulk-delete-btn');
+    const btnZip = document.getElementById('bulk-zip-btn');
+    function toggleBtns() {
+        let checked = false;
+        checkboxes.forEach(cb => {
+            if (cb.checked) checked = true;
+        });
+        btnDelete.classList.toggle('hidden', !checked);
+        btnZip.classList.toggle('hidden', !checked);
+    }
+    checkboxes.forEach(cb => {
+        cb.addEventListener('change', toggleBtns);
+    });
+    toggleBtns();
+
+    // Tri et filtre JS sur le tableau
+    const table = document.getElementById('file-table');
+    const getCellValue = (row, idx) => row.children[idx].innerText.trim();
+    function sortTable(idx, type = 'string', asc = true) {
+        const rows = Array.from(table.tBodies[0].rows);
+        rows.sort((a, b) => {
+            let v1 = getCellValue(a, idx);
+            let v2 = getCellValue(b, idx);
+            if (type === 'number') {
+                v1 = parseInt(v1.replace(/\D/g, '')) || 0;
+                v2 = parseInt(v2.replace(/\D/g, '')) || 0;
+            }
+            if (type === 'date') {
+                v1 = Date.parse(v1.split(' ')[0] + 'T' + (v1.split(' ')[1] || '00:00'));
+                v2 = Date.parse(v2.split(' ')[0] + 'T' + (v2.split(' ')[1] || '00:00'));
+            }
+            if (v1 < v2) return asc ? -1 : 1;
+            if (v1 > v2) return asc ? 1 : -1;
+            return 0;
+        });
+        rows.forEach(row => table.tBodies[0].appendChild(row));
+    }
+    let sortState = {name: true, date: true, size: true};
+    table.querySelectorAll('th[data-sort]').forEach((th, idx) => {
+        th.addEventListener('click', function () {
+            let type = th.dataset.sort === 'size' ? 'number' : (th.dataset.sort === 'date' ? 'date' : 'string');
+            sortTable(idx, type, sortState[th.dataset.sort]);
+            sortState[th.dataset.sort] = !sortState[th.dataset.sort];
+        });
+    });
+    // Filtrage
+    function filterTable() {
+        const nameVal = document.getElementById('filter-name').value.toLowerCase();
+        const dateVal = document.getElementById('filter-date').value.toLowerCase();
+        Array.from(table.tBodies[0].rows).forEach(row => {
+            const name = getCellValue(row, 1).toLowerCase();
+            const date = getCellValue(row, 2).toLowerCase();
+            row.style.display = (name.includes(nameVal) && date.includes(dateVal)) ? '' : 'none';
+        });
+    }
+    document.getElementById('filter-name').addEventListener('input', filterTable);
+    document.getElementById('filter-date').addEventListener('input', filterTable);
+});

--- a/src/Service/BulkFileDeleteService.php
+++ b/src/Service/BulkFileDeleteService.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\File;
+use App\Entity\User;
+use App\Security\FileAccessManager;
+use App\Security\FilePathSecurity;
+use Doctrine\ORM\EntityManagerInterface;
+
+class BulkFileDeleteService
+{
+    private EntityManagerInterface $em;
+    private FileAccessManager $fileAccessManager;
+    private FilePathSecurity $filePathSecurity;
+
+    public function __construct(EntityManagerInterface $em, FileAccessManager $fileAccessManager, FilePathSecurity $filePathSecurity)
+    {
+        $this->em = $em;
+        $this->fileAccessManager = $fileAccessManager;
+        $this->filePathSecurity = $filePathSecurity;
+    }
+
+    /**
+     * Supprime en masse les fichiers pour un utilisateur
+     * @param array $ids Liste des IDs de fichiers
+     * @param User $user Utilisateur courant
+     * @return int Nombre de fichiers supprimés
+     */
+    public function deleteFiles(array $ids, User $user): int
+    {
+        $count = 0;
+        foreach ($ids as $id) {
+            $file = $this->em->getRepository(File::class)->find($id);
+            if (!$file) {
+                continue;
+            }
+            try {
+                $this->fileAccessManager->assertDeleteAccess($file, $user);
+                $realPath = $this->filePathSecurity->assertSafePath($file->getPath());
+                $this->filePathSecurity->deleteFile($realPath);
+                $this->em->remove($file);
+                $count++;
+            } catch (\Throwable $e) {
+                continue;
+            }
+        }
+        $this->em->flush();
+        return $count;
+    }
+}

--- a/templates/home/_file_bulk_delete_form.html.twig
+++ b/templates/home/_file_bulk_delete_form.html.twig
@@ -3,14 +3,27 @@
 <form method="post" class="mb-4 flex flex-col gap-4">
 	<input type="hidden" name="_token" value="{{ csrf_token('bulk_delete') }}">
 	<div class="overflow-x-auto">
-		<table class="min-w-full border rounded shadow text-sm">
+		<table id="file-table" class="min-w-full border rounded shadow text-sm">
 			<thead class="bg-gray-50">
 				<tr>
 					<th class="p-2 text-left font-semibold">&nbsp;</th>
-					<th class="p-2 text-left font-semibold">Nom</th>
-					<th class="p-2 text-left font-semibold">Date</th>
-					<th class="p-2 text-left font-semibold">Taille</th>
+					<th class="p-2 text-left font-semibold cursor-pointer" data-sort="name">Nom
+						<span class="text-xs">⇅</span>
+					</th>
+					<th class="p-2 text-left font-semibold cursor-pointer" data-sort="date">Date
+						<span class="text-xs">⇅</span>
+					</th>
+					<th class="p-2 text-left font-semibold cursor-pointer" data-sort="size">Taille
+						<span class="text-xs">⇅</span>
+					</th>
 					<th class="p-2 text-left font-semibold">Actions</th>
+				</tr>
+				<tr>
+					<th></th>
+					<th><input type="text" class="w-full border rounded px-1 text-xs" placeholder="Filtrer nom" id="filter-name"></th>
+					<th><input type="text" class="w-full border rounded px-1 text-xs" placeholder="Filtrer date" id="filter-date"></th>
+					<th></th>
+					<th></th>
 				</tr>
 			</thead>
 			<tbody>
@@ -24,9 +37,7 @@
 						<td class="p-2 align-middle text-xs text-gray-500">{{ file.size|number_format(0, ',', ' ') }}
 							octets</td>
 						<td class="p-2 align-middle">
-							<a href="{{ path('file_download', {id: file.id}) }}" class="px-2 py-1 bg-blue-100 text-blue-700 rounded hover:bg-blue-200 text-xs transition" title="Télécharger le fichier">
-								Télécharger
-							</a>
+							<a href="{{ path('file_download', {id: file.id}) }}" class="px-2 py-1 bg-blue-100 text-blue-700 rounded hover:bg-blue-200 text-xs transition" title="Télécharger le fichier">Télécharger</a>
 						</td>
 					</tr>
 				{% endfor %}
@@ -34,35 +45,8 @@
 		</table>
 	</div>
 	<div class="flex gap-4 mt-4">
-		<button type="submit" formaction="{{ path('file_download_selected_zip') }}" id="bulk-zip-btn" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition hidden">
-			Télécharger ZIP
-		</button>
-		<button type="submit" formaction="{{ path('file_bulk_delete') }}" id="bulk-delete-btn" class="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition hidden" onclick="return confirm('Supprimer les fichiers sélectionnés ?')">
-			Supprimer
-		</button>
+		<button type="submit" formaction="{{ path('file_download_selected_zip') }}" id="bulk-zip-btn" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition hidden">Télécharger ZIP</button>
+		<button type="submit" formaction="{{ path('file_bulk_delete') }}" id="bulk-delete-btn" class="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition hidden" onclick="return confirm('Supprimer les fichiers sélectionnés ?')">Supprimer</button>
 	</div>
 </form>
-<script>
-	// Mobile first : boutons affichés uniquement si au moins une case est cochée
-document.addEventListener('DOMContentLoaded', function () {
-const checkboxes = document.querySelectorAll('.file-checkbox');
-const btnDelete = document.getElementById('bulk-delete-btn');
-const btnZip = document.getElementById('bulk-zip-btn');
-function toggleBtns() {
-let checked = false;
-checkboxes.forEach(cb => {
-if (cb.checked) 
-checked = true;
-
-
-
-});
-btnDelete.classList.toggle('hidden', ! checked);
-btnZip.classList.toggle('hidden', ! checked);
-}
-checkboxes.forEach(cb => {
-cb.addEventListener('change', toggleBtns);
-});
-toggleBtns();
-});
-</script>
+<script src="{{ asset('file-table.js') }}"></script>

--- a/templates/home/_file_bulk_delete_form.html.twig
+++ b/templates/home/_file_bulk_delete_form.html.twig
@@ -1,5 +1,4 @@
 {# Formulaire de suppression en masse des fichiers #}
-
 <form method="post" class="mb-4 flex flex-col gap-4">
 	<input type="hidden" name="_token" value="{{ csrf_token('bulk_delete') }}">
 	<div class="overflow-x-auto">


### PR DESCRIPTION
This pull request introduces significant improvements to the bulk file deletion feature and enhances the user experience for managing files in the file table. The main changes include refactoring the bulk delete logic into a dedicated service, adding client-side sorting and filtering for the file table, and updating the bulk delete form for better usability.

**Bulk file deletion logic refactor:**

* Introduced a new service, `BulkFileDeleteService`, which encapsulates the logic for securely deleting multiple files for a user, handling access checks and file removal. (`src/Service/BulkFileDeleteService.php`)
* Updated the `bulkDelete` controller method to use `BulkFileDeleteService` instead of handling deletion directly, simplifying the controller and improving separation of concerns. (`src/Controller/FileController.php`) [[1]](diffhunk://#diff-a4cfed039e6cad2086c061e9444541d5231bc03d6c452fc889f592c5378919d5L54-R64) [[2]](diffhunk://#diff-a4cfed039e6cad2086c061e9444541d5231bc03d6c452fc889f592c5378919d5R10)

**User interface enhancements for the file table:**

* Added a new JavaScript file, `assets/file-table.js`, which enables client-side sorting (by name, date, size) and filtering (by name and date) on the file table, as well as improved toggle behavior for bulk action buttons.
* Updated the bulk delete form to add sortable columns, filter inputs, and wire up the new JavaScript for enhanced interactivity. (`templates/home/_file_bulk_delete_form.html.twig`)
* Cleaned up and streamlined the form markup, removing inline scripts and improving button formatting for clarity and maintainability. (`templates/home/_file_bulk_delete_form.html.twig`)