### PR TITLE
🎨 style(ui): harmonise le style du bouton Télécharger

### DIFF
--- a/templates/home/_file_bulk_delete_form.html.twig
+++ b/templates/home/_file_bulk_delete_form.html.twig
@@ -37,8 +37,12 @@
 							<td class="p-2 align-middle text-xs text-gray-500">{{ file.uploadedAt|date('d/m/Y H:i') }}</td>
 							<td class="p-2 align-middle text-xs text-gray-500">{{ file.size|number_format(0, ',', ' ') }}
 								octets</td>
-							<td class="p-2 align-middle">
-								<a href="{{ path('file_download', {id: file.id}) }}" class="px-2 py-1 bg-blue-100 text-blue-700 rounded hover:bg-blue-200 text-xs transition" title="Télécharger le fichier">Télécharger</a>
+							<td class="p-2 align-middle flex gap-2">
+								<a href="{{ path('file_download', {id: file.id}) }}" class="btn btn-blue" title="Télécharger le fichier">Télécharger</a>
+								<form method="post" action="{{ path('file_delete', {id: file.id}) }}" style="display:inline" onsubmit="return confirm('Supprimer ce fichier ?')">
+									<input type="hidden" name="_token" value="{{ csrf_token('delete_' ~ file.id) }}">
+									<button type="submit" class="px-2 py-1 bg-red-600 text-white rounded hover:bg-red-700 text-xs transition" title="Supprimer le fichier">Supprimer</button>
+								</form>
 							</td>
 						</tr>
 					{% endfor %}


### PR DESCRIPTION
This pull request updates the file management UI to allow users to delete individual files directly from the bulk delete form. In addition to the download button, a delete button with a confirmation prompt and CSRF protection has been added for each file.

**UI/UX improvements:**

* Added a "Supprimer" (Delete) button next to each file in the bulk delete form, allowing users to delete individual files with a confirmation prompt and CSRF token for security.
* Updated the download button styling to use the `btn btn-blue` classes for consistency with the rest of the UI.Le lien de téléchargement utilise désormais la classe utilitaire `btn btn-blue` pour un rendu cohérent avec les autres boutons de l’interface.

- Améliore la lisibilité et l’UX
- Prêt pour customisation CSS centralisée