### PR TITLE
✅ test(security): accès protégé à la page Photos + test fonctionnel

### DIFF
--- a/src/Controller/PhotosController.php
+++ b/src/Controller/PhotosController.php
@@ -11,6 +11,7 @@ class PhotosController extends AbstractController
   #[Route('/photos', name: 'photos_home')]
   public function index(): Response
   {
+    $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY');
     return $this->render('photos/index.html.twig');
   }
 }

--- a/tests/Application/PhotosAccessTest.php
+++ b/tests/Application/PhotosAccessTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Tests\Application;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class PhotosAccessTest extends WebTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Reset complet base + fixtures (pattern obligatoire API Platform)
+        shell_exec('php bin/console --env=test doctrine:schema:drop --force');
+        shell_exec('php bin/console --env=test doctrine:schema:create');
+        // Pas de création d'utilisateur ici
+    }
+
+    public function testPhotosPageRequiresAuthentication(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/photos');
+        $this->assertResponseRedirects('/login');
+    }
+
+    public function testPhotosPageAccessibleWhenAuthenticated(): void
+    {
+        // Création de l'utilisateur admin
+        $client = static::createClient();
+        $container = $client->getContainer();
+        $entityManager = $container->get('doctrine')->getManager();
+        $userClass = 'App\\Entity\\User';
+        $user = new $userClass();
+        $user->setUsername('admin');
+        $user->setRoles(['ROLE_ADMIN']);
+        $user->setPassword('$2y$13$a0scOYGb58lA.D1wSAKr3ubI8AMBwUlwuhX5IaMU91K3UyP4HmA6G');
+        $entityManager->persist($user);
+        $entityManager->flush();
+
+        // Simule un login via le formulaire
+        $crawler = $client->request('GET', '/login');
+        $form = $crawler->selectButton('Sign in')->form([
+            '_username' => 'admin',
+            '_password' => 'root',
+        ]);
+        $client->submit($form);
+        $client->followRedirect();
+
+        // Accès à la page protégée
+        $client->request('GET', '/photos');
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('body');
+    }
+}


### PR DESCRIPTION
- Ajout d'un test fonctionnel qui vérifie l'accès aut
This pull request improves the security of the `/photos` page by requiring authentication and adds automated tests to ensure this behavior. The main changes are the enforcement of authentication in the controller and the addition of a test suite verifying both unauthenticated and authenticated access.

**Authentication enforcement:**

* Added a call to `denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY')` in the `PhotosController::index` method to require users to be fully authenticated before accessing the `/photos` page.

**Testing:**

* Introduced a new test class `PhotosAccessTest` that:
  - Ensures unauthenticated users are redirected to the login page when accessing `/photos`.
  - Verifies that authenticated users can access the `/photos` page successfully.