### PR TITLE
Feat/secure photo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Documentation générale.
 - [🏠 Home Cloud](#-home-cloud)
   - [📚 Sommaire](#-sommaire)
   - [🚀 Fonctionnalités principales](#-fonctionnalités-principales)
-  - [📚 Documentation technique](#-documentation-technique)
   - [🧩 Services métier](#-services-métier)
 
 ---
@@ -23,8 +22,6 @@ Documentation générale.
 
 ---
 
-## 📚 Documentation technique
-
 - [Mise en place de l’environnement de développement](docs/dev-setup.md)
 - [Gestion paginée des fichiers utilisateur](docs/user-files.md)
 - [Pattern contrôleur ultra-lean](docs/controller-ultra-lean.md)
@@ -33,6 +30,7 @@ Documentation générale.
 - [Fixtures & jeux de données](docs/fixtures.md)
 - [Tests & Qualité](docs/tests.md)
 - [Import Google Photos](docs/google-photos-api.md)
+- [Sécurisation de la diffusion des photos](docs/photo-securisation.md)
 
 ---
 

--- a/docs/photo-securisation.md
+++ b/docs/photo-securisation.md
@@ -1,0 +1,63 @@
+# 📸 Sécurisation de la diffusion des photos utilisateur
+
+## Objectif
+
+Garantir que les fichiers photos uploadés ne soient **jamais exposés directement** via le web, même en environnement mutualisé, tout en permettant leur affichage sécurisé dans l’application.
+
+---
+
+## Logique d'accès sécurisé
+
+- **Aucun accès direct** au dossier `uploads/photos` (hors de `public/`).
+- Les images sont servies **uniquement via un contrôleur Symfony** dédié (`PhotoServeController`).
+- Ce contrôleur :
+  1. Vérifie l’authentification de l’utilisateur
+  2. Récupère la photo en base (par son id)
+  3. Vérifie les droits d’accès (voter ou logique métier)
+  4. Lit le fichier sur le disque (jamais exposé en public)
+  5. Retourne le fichier en streaming HTTP avec le bon Content-Type et le nom d’origine
+
+---
+
+## Exemple d’URL d’accès sécurisé
+
+```
+/photo/view/{id}
+```
+
+Dans le composant Twig, chaque image est affichée ainsi :
+
+```twig
+<img src="{{ path('photo_view', {id: photo.id}) }}" ... >
+```
+
+---
+
+## Avantages
+
+- **Sécurité maximale** : contrôle d’accès à chaque requête
+- **Aucune copie temporaire** ni symlink
+- **Compatible mutualisé**
+- **Traçabilité** et extension facile (logs, quotas, watermark, etc)
+
+---
+
+## À retenir
+
+- Le dossier d’upload (`uploads/photos`) reste privé.
+- Toute tentative d’accès direct à une photo est impossible.
+- Le contrôleur peut être enrichi (voter, logs, quotas, etc).
+
+---
+
+## Référence
+
+Voir le contrôleur : `src/Controller/PhotoServeController.php`
+
+---
+
+## Pour aller plus loin
+
+- Ajouter des tests fonctionnels sur l’accès sécurisé
+- Personnaliser le voter d’accès selon la logique métier
+- Ajouter un watermark ou une limitation de bande passante

--- a/src/Controller/PhotoController.php
+++ b/src/Controller/PhotoController.php
@@ -8,14 +8,18 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\User\UserInterface;
+use App\Service\PhotoFetcher;
 
 class PhotoController extends AbstractController
 {
     #[Route('/photos', name: 'photos_home')]
-    public function index(): Response
+    public function index(PhotoFetcher $photoFetcher, UserInterface $user): Response
     {
         $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY');
-        return $this->render('photos/index.html.twig');
+        $photos = $photoFetcher->forUser($user);
+        return $this->render('photos/index.html.twig', [
+            'photos' => $photos,
+        ]);
     }
 
     #[Route('/photos/upload', name: 'photo_upload')]

--- a/src/Controller/PhotoServeController.php
+++ b/src/Controller/PhotoServeController.php
@@ -17,9 +17,15 @@ class PhotoServeController extends AbstractController
     public function view(int $id, PhotoRepository $repo): BinaryFileResponse
     {
         $photo = $repo->find($id);
+        if (!$photo) {
+            throw $this->createNotFoundException('Photo introuvable.');
+        }
         $this->denyAccessUnlessGranted('view', $photo); // Voter ou logique d'accès
 
         $file = $this->getParameter('app.photos_dir') . '/' . $photo->getFilename();
+        if (!is_file($file)) {
+            throw $this->createNotFoundException('Fichier photo manquant sur le serveur.');
+        }
         return (new BinaryFileResponse($file))
             ->setContentDisposition(ResponseHeaderBag::DISPOSITION_INLINE, $photo->getOriginalName());
     }

--- a/src/Controller/PhotoServeController.php
+++ b/src/Controller/PhotoServeController.php
@@ -1,0 +1,26 @@
+<?php
+// src/Controller/PhotoServeController.php
+
+namespace App\Controller;
+
+use App\Repository\PhotoRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+class PhotoServeController extends AbstractController
+{
+    #[Route('/photo/view/{id}', name: 'photo_view')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function view(int $id, PhotoRepository $repo): BinaryFileResponse
+    {
+        $photo = $repo->find($id);
+        $this->denyAccessUnlessGranted('view', $photo); // Voter ou logique d'accès
+
+        $file = $this->getParameter('app.photos_dir') . '/' . $photo->getFilename();
+        return (new BinaryFileResponse($file))
+            ->setContentDisposition(ResponseHeaderBag::DISPOSITION_INLINE, $photo->getOriginalName());
+    }
+}

--- a/src/Security/Voter/PhotoVoter.php
+++ b/src/Security/Voter/PhotoVoter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Security\Voter;
+
+use App\Entity\Photo;
+use App\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class PhotoVoter extends Voter
+{
+    public const VIEW = 'view';
+
+    protected function supports(string $attribute, $subject): bool
+    {
+        return $attribute === self::VIEW && $subject instanceof Photo;
+    }
+
+    /**
+     * Autorise l'accès si l'utilisateur est propriétaire de la photo ou admin.
+     */
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (!$user instanceof UserInterface) {
+            return false;
+        }
+        // Propriétaire de la photo
+        if ($subject->getUser() instanceof User && $user instanceof User && $subject->getUser()->getId() === $user->getId()) {
+            return true;
+        }
+        // Admin
+        if (method_exists($user, 'getRoles') && in_array('ROLE_ADMIN', $user->getRoles(), true)) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/Service/PhotoFetcher.php
+++ b/src/Service/PhotoFetcher.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Photo;
+use App\Entity\User;
+use App\Repository\PhotoRepository;
+
+class PhotoFetcher
+{
+    public function __construct(private PhotoRepository $photoRepository) {}
+
+    /**
+     * Retourne les photos de l'utilisateur connecté (triées par date desc)
+     * @param User $user
+     * @return Photo[]
+     */
+    public function forUser(User $user): array
+    {
+        return $this->photoRepository->findBy([
+            'user' => $user
+        ], [
+            'uploadedAt' => 'DESC'
+        ]);
+    }
+}

--- a/templates/components/photo/Gallery.html.twig
+++ b/templates/components/photo/Gallery.html.twig
@@ -1,0 +1,16 @@
+{# templates/components/photo/Gallery.html.twig #}
+{% if photos is empty %}
+	<div class="text-gray-500 text-center py-8">Aucune photo enregistrée pour l’instant.</div>
+{% else %}
+	<div class="grid grid-cols-2 md:grid-cols-4 gap-4 w-full max-w-4xl mx-auto">
+		{% for photo in photos %}
+			<div class="bg-white rounded shadow p-2 flex flex-col items-center">
+				<div class="w-full aspect-square bg-gray-200 flex items-center justify-center overflow-hidden mb-2">
+					<img src="{{ path('photo_view', {id: photo.id}) }}" alt="{{ photo.title ?: photo.originalName }}" class="object-cover w-full h-full" loading="lazy">
+				</div>
+				<div class="text-sm text-gray-700 font-semibold truncate w-full text-center">{{ photo.title ?: photo.originalName }}</div>
+				<div class="text-xs text-gray-400 w-full text-center">{{ photo.uploadedAt|date('d/m/Y H:i') }}</div>
+			</div>
+		{% endfor %}
+	</div>
+{% endif %}

--- a/templates/photos/index.html.twig
+++ b/templates/photos/index.html.twig
@@ -9,7 +9,7 @@
 		{{ component('Navbar', { title: 'MyPhotos' }) }}
 	</div>
 	<div class="bg-gray-100 min-h-[60vh] flex flex-col items-center justify-center py-16">
-		<h2 class="text-2xl font-semibold text-gray-700 mb-4">Bienvenue dans MyPhotos</h2>
-		<p class="text-gray-500">Votre galerie privée et sécurisée. (Fonctionnalités à venir)</p>
+		<h2 class="text-2xl font-semibold text-gray-700 mb-4">Mes photos</h2>
+		{{ component('photo/Gallery', { photos: photos }) }}
 	</div>
 {% endblock %}


### PR DESCRIPTION
This pull request introduces a secure mechanism for serving user photos, ensuring that uploaded images are never exposed directly via the web. Instead, photos are accessed only through authenticated and authorized requests, with access logic centralized in a dedicated controller and enforced by a voter. The gallery view is updated to display user-specific photos securely, and comprehensive documentation is added.

**Secure photo serving and access control:**

* Added a new `PhotoServeController` that streams photos from a private directory after verifying user authentication and access rights, preventing any direct access to uploaded files. (`src/Controller/PhotoServeController.php`)
* Implemented a `PhotoVoter` to enforce that only the photo owner or an admin can view a photo, ensuring fine-grained access control. (`src/Security/Voter/PhotoVoter.php`)

**User-specific photo listing:**

* Introduced a `PhotoFetcher` service to fetch photos belonging to the authenticated user, sorted by upload date. (`src/Service/PhotoFetcher.php`)
* Modified the `PhotoController` to use `PhotoFetcher`, passing the user's photos to the view. (`src/Controller/PhotoController.php`)

**Frontend and documentation updates:**

* Updated the gallery component to display user photos using secure URLs generated by the new controller, and improved the gallery UI. (`templates/components/photo/Gallery.html.twig`, `templates/photos/index.html.twig`) [[1]](diffhunk://#diff-288a95f13d32c6765501c81995810d1a0b42705ca2fee2b040c4eae3399a46acR1-R16) [[2]](diffhunk://#diff-51259747d3d4b1ce964cad955395181771755c7089b5c625d5b9ed2df6372e05L12-R13)
* Added detailed documentation describing the secure photo serving mechanism, its benefits, and implementation details. (`docs/photo-securisation.md`, `README.md`) [[1]](diffhunk://#diff-a60587b023bc7ae90cb02862f25c527c219d7b5f122f614bda0f7bdc6007ae79R1-R63) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L12) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-L27) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R33)