### PR TITLE
Feat/albums

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,3 +1,4 @@
+import './photo-lazy-grid.js';
 import './stimulus_bootstrap.js';
 /*
  * Welcome to your app's main JavaScript file!
@@ -9,8 +10,8 @@ import './stimulus_bootstrap.js';
 import './styles/main.css';
 import './styles/custom-gallery.css';
 
-
-// --- Dark mode switch ---
+// Contrôleurs et initialiseurs
+import './controllers/album-photos-controller.js';
 document.addEventListener('DOMContentLoaded', () => {
 	const html = document.documentElement;
 	const btn = document.getElementById('dark-mode-toggle');

--- a/assets/controllers/album-photos-controller.js
+++ b/assets/controllers/album-photos-controller.js
@@ -1,20 +1,18 @@
-// assets/controllers/album-photos-controller.js
+// Contrôleur universel pour lazy grid (wizard album ou galerie)
 import { initPhotoLazyGrid } from '../photo-lazy-grid.js';
 
-// Auto-init sur les éléments avec data-controller="album-photos"
 document.addEventListener('DOMContentLoaded', () => {
     const photoGrid = document.getElementById('photo-grid');
-    const selectedInput = document.getElementById('selected_photos');
-    const apiUrl = photoGrid?.dataset.apiUrl || '';
-    const preselected = photoGrid?.dataset.preselected ? JSON.parse(photoGrid.dataset.preselected) : [];
-
-    if (photoGrid && selectedInput && apiUrl) {
-        initPhotoLazyGrid({
-            gridSelector: '#photo-grid',
-            inputSelector: '#selected_photos',
-            apiUrl: apiUrl,
-            preselected: preselected
-        });
-    }
+    if (!photoGrid) return;
+    const apiUrl = photoGrid.dataset.apiUrl || '';
+    const preselected = photoGrid.dataset.preselected ? JSON.parse(photoGrid.dataset.preselected) : [];
+    const input = document.getElementById('selected_photos');
+    if (!input || !apiUrl) return;
+    initPhotoLazyGrid({
+        gridSelector: '#photo-grid',
+        inputSelector: '#selected_photos',
+        apiUrl,
+        preselected
+    });
 });
 

--- a/assets/controllers/album-photos-controller.js
+++ b/assets/controllers/album-photos-controller.js
@@ -1,0 +1,20 @@
+// assets/controllers/album-photos-controller.js
+import { initPhotoLazyGrid } from '../photo-lazy-grid.js';
+
+// Auto-init sur les éléments avec data-controller="album-photos"
+document.addEventListener('DOMContentLoaded', () => {
+    const photoGrid = document.getElementById('photo-grid');
+    const selectedInput = document.getElementById('selected_photos');
+    const apiUrl = photoGrid?.dataset.apiUrl || '';
+    const preselected = photoGrid?.dataset.preselected ? JSON.parse(photoGrid.dataset.preselected) : [];
+
+    if (photoGrid && selectedInput && apiUrl) {
+        initPhotoLazyGrid({
+            gridSelector: '#photo-grid',
+            inputSelector: '#selected_photos',
+            apiUrl: apiUrl,
+            preselected: preselected
+        });
+    }
+});
+

--- a/assets/photo-lazy-grid.js
+++ b/assets/photo-lazy-grid.js
@@ -1,0 +1,82 @@
+// assets/photo-lazy-grid.js
+// Module réutilisable pour lazy loading + sélection de photos
+
+export function initPhotoLazyGrid({ gridSelector, inputSelector, apiUrl, preselected = [] }) {
+    const grid = document.querySelector(gridSelector);
+    const input = document.querySelector(inputSelector);
+    
+    if (!grid || !input) {
+        console.error('Grid ou input selector non trouvé');
+        return;
+    }
+
+    let page = 1;
+    let loading = false;
+    let allLoaded = false;
+    let selected = new Set(preselected);
+
+    function renderPhoto(photo) {
+        const figure = document.createElement('figure');
+        figure.className = 'glass-card group relative overflow-hidden flex items-center justify-center transition-all duration-300 hover:shadow-purple-400/60 cursor-pointer';
+        figure.dataset.photoId = photo.id;
+        figure.innerHTML = `<img src="${photo.url}" alt="${photo.title || photo.originalName}" loading="lazy" class="w-full h-full object-cover">`;
+        
+        if (selected.has(photo.id)) {
+            figure.classList.add('ring-4', 'ring-blue-500');
+        }
+        
+        figure.addEventListener('click', () => {
+            if (selected.has(photo.id)) {
+                selected.delete(photo.id);
+                figure.classList.remove('ring-4', 'ring-blue-500');
+            } else {
+                selected.add(photo.id);
+                figure.classList.add('ring-4', 'ring-blue-500');
+            }
+            input.value = JSON.stringify(Array.from(selected));
+        });
+        
+        return figure;
+    }
+
+    async function loadPhotos() {
+        if (loading || allLoaded) return;
+        loading = true;
+        
+        try {
+            const res = await fetch(`${apiUrl}?page=${page}`);
+            if (!res.ok) {
+                console.error('Erreur API photos:', res.status);
+                return;
+            }
+            
+            const data = await res.json();
+            if (!data.photos || data.photos.length === 0) {
+                allLoaded = true;
+                return;
+            }
+            
+            data.photos.forEach(photo => {
+                grid.appendChild(renderPhoto(photo));
+            });
+            page++;
+        } catch (error) {
+            console.error('Erreur lors du chargement des photos:', error);
+        } finally {
+            loading = false;
+        }
+    }
+
+    // Infinite scroll
+    window.addEventListener('scroll', () => {
+        if (allLoaded) return;
+        const rect = grid.getBoundingClientRect();
+        if (rect.bottom < window.innerHeight + 200) {
+            loadPhotos();
+        }
+    });
+
+    // Initial load
+    loadPhotos();
+}
+

--- a/assets/photo-lazy-grid.js
+++ b/assets/photo-lazy-grid.js
@@ -13,29 +13,81 @@ export function initPhotoLazyGrid({ gridSelector, inputSelector, apiUrl, presele
     let page = 1;
     let loading = false;
     let allLoaded = false;
-    let selected = new Set(preselected);
+    // On force les IDs en string pour éviter les problèmes de type
+    let selected = new Set(preselected.map(String));
 
     function renderPhoto(photo) {
         const figure = document.createElement('figure');
         figure.className = 'glass-card group relative overflow-hidden flex items-center justify-center transition-all duration-300 hover:shadow-purple-400/60 cursor-pointer';
-        figure.dataset.photoId = photo.id;
-        figure.innerHTML = `<img src="${photo.url}" alt="${photo.title || photo.originalName}" loading="lazy" class="w-full h-full object-cover">`;
-        
-        if (selected.has(photo.id)) {
-            figure.classList.add('ring-4', 'ring-blue-500');
-        }
-        
-        figure.addEventListener('click', () => {
-            if (selected.has(photo.id)) {
-                selected.delete(photo.id);
-                figure.classList.remove('ring-4', 'ring-blue-500');
-            } else {
-                selected.add(photo.id);
+        figure.dataset.photoId = String(photo.id);
+        figure.innerHTML = `
+            <span class="photo-select-circle" style="position:absolute;top:0.5rem;left:0.5rem;width:25px;height:25px;z-index:200;display:flex;align-items:center;justify-content:center;">
+                <!-- Cercle SVG toujours visible, fond semi-transparent et contour gris clair -->
+                <svg viewBox="0 0 25 25" style="width:25px;height:25px;" class="z-[201] select-svg pointer-events-none">
+                    <circle cx="12.5" cy="12.5" r="11" fill="#fff" fill-opacity="0.7" stroke="#e5e7eb" stroke-width="2" />
+                </svg>
+                <!-- Coche SVG superposée, masquée par défaut, couleur plus vive -->
+                <svg viewBox="0 0 24 24" style="width:25px;height:25px;" class="z-[202] check-svg absolute top-0 left-0 pointer-events-none">
+                    <path d="M7 13L12 18L19 8" stroke="#535454ff" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round" class="check-path transition-all duration-200" style="opacity:0;" />
+                </svg>
+            </span>
+            <img src="${photo.url}" alt="${photo.title || photo.originalName}" loading="lazy" class="w-full h-full object-cover">
+        `;
+
+        // Gestion de l'état sélectionné
+        const checkSvg = figure.querySelector('.check-svg');
+        const checkPath = checkSvg.querySelector('.check-path');
+        // Affiche la coche si sélectionné, sinon seulement au hover (CSS)
+        const updateVisual = () => {
+            if (selected.has(String(photo.id))) {
                 figure.classList.add('ring-4', 'ring-blue-500');
+                checkPath.style.opacity = '1';
+            } else {
+                figure.classList.remove('ring-4', 'ring-blue-500');
+                checkPath.style.opacity = '0';
+            }
+        };
+        updateVisual();
+
+        // Affichage de la coche au hover (CSS only)
+        figure.addEventListener('mouseenter', () => {
+            if (!selected.has(String(photo.id))) {
+                checkPath.style.opacity = '0.5';
+            }
+        });
+        figure.addEventListener('mouseleave', () => {
+            if (!selected.has(String(photo.id))) {
+                checkPath.style.opacity = '0';
+            }
+        });
+
+        // Clic sur la vignette ou le cercle
+        figure.addEventListener('click', (e) => {
+            console.log('Clic sur la vignette', photo.id, e.target);
+            // Ne pas sélectionner si clic sur un lien ou bouton interne
+            if (e.target.closest('a,button,[role="button"]')) return;
+            const idStr = String(photo.id);
+            if (selected.has(idStr)) {
+                selected.delete(idStr);
+            } else {
+                selected.add(idStr);
             }
             input.value = JSON.stringify(Array.from(selected));
+            updateVisual();
         });
-        
+        // Accessibilité : clic sur le cercle
+        figure.querySelector('.photo-select-circle').addEventListener('click', (e) => {
+            e.stopPropagation();
+            const idStr = String(photo.id);
+            if (selected.has(idStr)) {
+                selected.delete(idStr);
+            } else {
+                selected.add(idStr);
+            }
+            input.value = JSON.stringify(Array.from(selected));
+            updateVisual();
+        });
+
         return figure;
     }
 

--- a/assets/photo-lazy-grid.js
+++ b/assets/photo-lazy-grid.js
@@ -57,7 +57,10 @@ export function initPhotoLazyGrid({ gridSelector, inputSelector, apiUrl, presele
             }
             
             data.photos.forEach(photo => {
-                grid.appendChild(renderPhoto(photo));
+                // Empêche les doublons : ne pas ajouter si déjà présent dans le DOM
+                if (!grid.querySelector(`[data-photo-id="${photo.id}"]`)) {
+                    grid.appendChild(renderPhoto(photo));
+                }
             });
             page++;
         } catch (error) {

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "symfony/ux-twig-component": "^2.31",
         "symfony/validator": "7.3.*",
         "symfony/web-link": "7.3.*",
+        "symfony/workflow": "7.3.*",
         "symfony/yaml": "7.3.*",
         "twig/extra-bundle": "^2.12|^3.0",
         "twig/twig": "^2.12|^3.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "daf1f50592bd8ea5d0aedc50bee1344a",
+    "content-hash": "fac8229b97f4e2745e33cbaf07a04679",
     "packages": [
         {
             "name": "composer/semver",
@@ -7715,6 +7715,99 @@
                 }
             ],
             "time": "2025-05-19T13:28:18+00:00"
+        },
+        {
+            "name": "symfony/workflow",
+            "version": "v7.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/workflow.git",
+                "reference": "5276a31ca6e5727f2bd996cc39d4b12f5cc4ba10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/workflow/zipball/5276a31ca6e5727f2bd996cc39d4b12f5cc4ba10",
+                "reference": "5276a31ca6e5727f2bd996cc39d4b12f5cc4ba10",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "2.5|^3"
+            },
+            "conflict": {
+                "symfony/event-dispatcher": "<6.4"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/security-core": "^6.4|^7.0",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/validator": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Workflow\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Grégoire Pineau",
+                    "email": "lyrixx@lyrixx.info"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools for managing a workflow or finite state machine",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "petrinet",
+                "place",
+                "state",
+                "statemachine",
+                "transition",
+                "workflow"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/workflow/tree/v7.3.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-10-01T14:16:33+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/config/packages/workflows.yaml
+++ b/config/packages/workflows.yaml
@@ -2,31 +2,37 @@ framework:
     workflows:
         album_creation:
             type: 'state_machine'
+            marking_store:
+                type: 'method'
+                property: 'marking'
             supports:
                 - App\Entity\Album
             initial_marking: titre
             places:
                 - titre
-                - description
                 - photos
+                - description
                 - confirmation
                 - termine
             transitions:
-                titre_to_description:
+                titre_to_photos:
                     from: titre
-                    to: description
-                description_to_photos:
-                    from: description
                     to: photos
-                photos_to_confirmation:
+                photos_to_description:
                     from: photos
+                    to: description
+                description_to_confirmation:
+                    from: description
                     to: confirmation
                 confirmation_to_termine:
                     from: confirmation
                     to: termine
-                retour_description:
+                retour_titre:
                     from: photos
-                    to: description
+                    to: titre
                 retour_photos:
-                    from: confirmation
+                    from: description
                     to: photos
+                retour_description:
+                    from: confirmation
+                    to: description

--- a/config/packages/workflows.yaml
+++ b/config/packages/workflows.yaml
@@ -1,0 +1,32 @@
+framework:
+    workflows:
+        album_creation:
+            type: 'state_machine'
+            supports:
+                - App\Entity\Album
+            initial_marking: titre
+            places:
+                - titre
+                - description
+                - photos
+                - confirmation
+                - termine
+            transitions:
+                titre_to_description:
+                    from: titre
+                    to: description
+                description_to_photos:
+                    from: description
+                    to: photos
+                photos_to_confirmation:
+                    from: photos
+                    to: confirmation
+                confirmation_to_termine:
+                    from: confirmation
+                    to: termine
+                retour_description:
+                    from: photos
+                    to: description
+                retour_photos:
+                    from: confirmation
+                    to: photos

--- a/migrations/Version20251111120339.php
+++ b/migrations/Version20251111120339.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20251111120339 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE album ADD owner_id INT NOT NULL, ADD created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', ADD updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('ALTER TABLE album ADD CONSTRAINT FK_39986E437E3C61F9 FOREIGN KEY (owner_id) REFERENCES user (id)');
+        $this->addSql('CREATE INDEX IDX_39986E437E3C61F9 ON album (owner_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE album DROP FOREIGN KEY FK_39986E437E3C61F9');
+        $this->addSql('DROP INDEX IDX_39986E437E3C61F9 ON album');
+        $this->addSql('ALTER TABLE album DROP owner_id, DROP created_at, DROP updated_at');
+    }
+}

--- a/migrations/Version20251111122045.php
+++ b/migrations/Version20251111122045.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20251111122045 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE album_photo (album_id INT NOT NULL, photo_id INT NOT NULL, INDEX IDX_620FCE3E1137ABCF (album_id), INDEX IDX_620FCE3E7E9E4C8C (photo_id), PRIMARY KEY(album_id, photo_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE album_photo ADD CONSTRAINT FK_620FCE3E1137ABCF FOREIGN KEY (album_id) REFERENCES album (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE album_photo ADD CONSTRAINT FK_620FCE3E7E9E4C8C FOREIGN KEY (photo_id) REFERENCES photo (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE photo DROP FOREIGN KEY FK_14B784181137ABCF');
+        $this->addSql('DROP INDEX IDX_14B784181137ABCF ON photo');
+        $this->addSql('ALTER TABLE photo DROP album_id');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE album_photo DROP FOREIGN KEY FK_620FCE3E1137ABCF');
+        $this->addSql('ALTER TABLE album_photo DROP FOREIGN KEY FK_620FCE3E7E9E4C8C');
+        $this->addSql('DROP TABLE album_photo');
+        $this->addSql('ALTER TABLE photo ADD album_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE photo ADD CONSTRAINT FK_14B784181137ABCF FOREIGN KEY (album_id) REFERENCES album (id)');
+        $this->addSql('CREATE INDEX IDX_14B784181137ABCF ON photo (album_id)');
+    }
+}

--- a/src/Controller/PhotoApiController.php
+++ b/src/Controller/PhotoApiController.php
@@ -34,7 +34,7 @@ class PhotoApiController extends AbstractController
                 return [
                     'id' => $photo->getId(),
                     'url' => $this->generateUrl('photo_view', ['id' => $photo->getId()]),
-                    'title' => $photo->getName(),
+                    'title' => $photo->getFileName(),
                     'originalName' => method_exists($photo, 'getOriginalName') ? $photo->getOriginalName() : null,
                 ];
             }, $photos),

--- a/src/Controller/PhotoApiController.php
+++ b/src/Controller/PhotoApiController.php
@@ -1,0 +1,44 @@
+<?php
+// src/Controller/PhotoApiController.php
+
+namespace App\Controller;
+
+use App\Repository\PhotoRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/api/photos', name: 'api_photos_')]
+#[IsGranted('IS_AUTHENTICATED_FULLY')]
+class PhotoApiController extends AbstractController
+{
+    #[Route('/lazy', name: 'lazy', methods: ['GET'])]
+    public function lazy(Request $request, PhotoRepository $photoRepository): JsonResponse
+    {
+        $user = $this->getUser();
+        $page = max(1, (int)$request->query->get('page', 1));
+        $limit = 24;
+        $offset = ($page - 1) * $limit;
+        $photos = $photoRepository->createQueryBuilder('p')
+            ->andWhere('p.user = :user')
+            ->setParameter('user', $user)
+            ->orderBy('p.uploadedAt', 'DESC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+        $data = [
+            'photos' => array_map(function ($photo) {
+                return [
+                    'id' => $photo->getId(),
+                    'url' => $this->generateUrl('photo_view', ['id' => $photo->getId()]),
+                    'title' => $photo->getName(),
+                    'originalName' => method_exists($photo, 'getOriginalName') ? $photo->getOriginalName() : null,
+                ];
+            }, $photos),
+        ];
+        return $this->json($data);
+    }
+}

--- a/src/Entity/Album.php
+++ b/src/Entity/Album.php
@@ -3,30 +3,59 @@
 namespace App\Entity;
 
 use App\Repository\AlbumRepository;
+use App\Entity\User;
+use App\Entity\Photo;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ORM\Entity(repositoryClass: AlbumRepository::class)]
 class Album
 {
+    /**
+     * @var string|null
+     */
+    public $marking;
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
+    #[Groups(["album:read"])]
     private ?int $id = null;
 
-    #[ORM\Column(length: 255)]
+    /**
+     * @var string|null
+     */
+    #[ORM\Column(type: 'string', length: 255, nullable: false)]
+    #[Groups(["album:read", "album:write"])]
     private ?string $name = null;
 
     #[ORM\Column(length: 255, nullable: true)]
+    #[Groups(["album:read", "album:write"])]
     private ?string $description = null;
 
-    #[ORM\OneToMany(mappedBy: 'album', targetEntity: Photo::class, orphanRemoval: true)]
+    #[ORM\ManyToMany(targetEntity: Photo::class, inversedBy: 'albums')]
+    #[Groups(["album:read", "album:write"])]
     private Collection $photos;
+
+    #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'albums')]
+    #[ORM\JoinColumn(nullable: false)]
+    #[Groups(["album:read", "album:write"])]
+    private ?User $owner = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(["album:read"])]
+    private ?\DateTimeImmutable $createdAt = null;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[Groups(["album:read"])]
+    private ?\DateTimeImmutable $updatedAt = null;
 
     public function __construct()
     {
         $this->photos = new ArrayCollection();
+        $this->createdAt = new \DateTimeImmutable();
     }
 
     public function getId(): ?int
@@ -68,19 +97,46 @@ class Album
     {
         if (!$this->photos->contains($photo)) {
             $this->photos[] = $photo;
-            $photo->setAlbum($this);
         }
         return $this;
     }
 
     public function removePhoto(Photo $photo): self
     {
-        if ($this->photos->removeElement($photo)) {
-            // set the owning side to null (unless already changed)
-            if ($photo->getAlbum() === $this) {
-                $photo->setAlbum(null);
-            }
-        }
+        $this->photos->removeElement($photo);
+        return $this;
+    }
+
+    public function getOwner(): ?User
+    {
+        return $this->owner;
+    }
+
+    public function setOwner(?User $owner): self
+    {
+        $this->owner = $owner;
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?\DateTimeImmutable $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
         return $this;
     }
 }

--- a/src/Entity/Album.php
+++ b/src/Entity/Album.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Entity;
 
 use App\Repository\AlbumRepository;
@@ -13,11 +15,6 @@ use Symfony\Component\Serializer\Annotation\Groups;
 #[ORM\Entity(repositoryClass: AlbumRepository::class)]
 class Album
 {
-    /**
-     * @var string|null
-     */
-    public $marking;
-
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
@@ -27,6 +24,9 @@ class Album
     /**
      * @var string|null
      */
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    private ?string $marking = null;
+
     #[ORM\Column(type: 'string', length: 255, nullable: false)]
     #[Groups(["album:read", "album:write"])]
     private ?string $name = null;
@@ -56,6 +56,16 @@ class Album
     {
         $this->photos = new ArrayCollection();
         $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getMarking(): ?string
+    {
+        return $this->marking;
+    }
+
+    public function setMarking(?string $marking): void
+    {
+        $this->marking = $marking;
     }
 
     public function getId(): ?int
@@ -98,12 +108,14 @@ class Album
         if (!$this->photos->contains($photo)) {
             $this->photos[] = $photo;
         }
+
         return $this;
     }
 
     public function removePhoto(Photo $photo): self
     {
         $this->photos->removeElement($photo);
+
         return $this;
     }
 

--- a/src/Entity/Photo.php
+++ b/src/Entity/Photo.php
@@ -4,6 +4,9 @@ namespace App\Entity;
 
 use App\Repository\PhotoRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use App\Entity\Album;
 
 #[ORM\Entity(repositoryClass: PhotoRepository::class)]
 class Photo
@@ -50,22 +53,44 @@ class Photo
     #[ORM\Column]
     private array $exifData = [];
 
-    #[ORM\ManyToOne(targetEntity: Album::class, inversedBy: 'photos')]
-    private ?Album $album = null;
+
+    #[ORM\ManyToMany(targetEntity: Album::class, mappedBy: 'photos')]
+    private Collection $albums;
+
+
+    public function __construct()
+    {
+        $this->albums = new ArrayCollection();
+    }
 
     public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function getAlbum(): ?Album
+
+    /**
+     * @return Collection<int, Album>
+     */
+    public function getAlbums(): Collection
     {
-        return $this->album;
+        return $this->albums;
     }
 
-    public function setAlbum(?Album $album): self
+    public function addAlbum(Album $album): self
     {
-        $this->album = $album;
+        if (!$this->albums->contains($album)) {
+            $this->albums[] = $album;
+            $album->addPhoto($this);
+        }
+        return $this;
+    }
+
+    public function removeAlbum(Album $album): self
+    {
+        if ($this->albums->removeElement($album)) {
+            $album->removePhoto($this);
+        }
         return $this;
     }
 

--- a/src/Form/AlbumType.php
+++ b/src/Form/AlbumType.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\Album;
+use App\Entity\Photo;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Doctrine\ORM\EntityRepository;
+
+class AlbumType extends AbstractType
+{
+    private TokenStorageInterface $tokenStorage;
+
+    public function __construct(TokenStorageInterface $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $user = $this->tokenStorage->getToken() ? $this->tokenStorage->getToken()->getUser() : null;
+        $builder
+            ->add('name', TextType::class, [
+                'label' => 'Nom de l\'album',
+                'required' => true,
+            ])
+            ->add('description', TextareaType::class, [
+                'label' => 'Description',
+                'required' => false,
+            ])
+            ->add('photos', EntityType::class, [
+                'class' => Photo::class,
+                'label' => 'Photos à ajouter',
+                'multiple' => true,
+                'expanded' => false,
+                'choice_label' => 'title',
+                'query_builder' => function (EntityRepository $er) use ($user) {
+                    return $er->createQueryBuilder('p')
+                        ->where('p.user = :user')
+                        ->setParameter('user', $user);
+                },
+                'required' => false,
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Album::class,
+        ]);
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -364,6 +364,18 @@
             "config/packages/messenger.yaml"
         ]
     },
+    "symfony/workflow": {
+        "version": "7.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "3.3",
+            "ref": "3b2f8ca32a07fcb00f899649053943fa3d8bbfb6"
+        },
+        "files": [
+            "config/packages/workflow.yaml"
+        ]
+    },
     "twig/extra-bundle": {
         "version": "v3.22.0"
     }

--- a/templates/albums/_create_confirmation_step.html.twig
+++ b/templates/albums/_create_confirmation_step.html.twig
@@ -1,0 +1,32 @@
+{# templates/albums/_create_confirmation_step.html.twig #}
+<div class="max-w-2xl mx-auto mt-10 p-6 bg-white/90 rounded-xl shadow-lg">
+	<h2 class="text-xl font-bold mb-4">Confirmer la création de l'album</h2>
+	<div class="mb-4">
+		<div class="font-semibold">Titre :</div>
+		<div class="text-lg">{{ album.name }}</div>
+	</div>
+	{% if album.description %}
+		<div class="mb-4">
+			<div class="font-semibold">Description :</div>
+			<div>{{ album.description }}</div>
+		</div>
+	{% endif %}
+	<div class="mb-6">
+		<div class="font-semibold mb-2">Photos sélectionnées :</div>
+		<div class="gallery-grid">
+			{% for photo in album.photos %}
+				<figure class="glass-card group relative overflow-hidden flex items-center justify-center transition-all duration-300 hover:shadow-purple-400/60">
+					<img src="{{ path('photo_view', {id: photo.id}) }}" alt="{{ photo.title ?? photo.originalName }}" loading="lazy" class="w-full h-full object-cover">
+				</figure>
+			{% else %}
+				<div class="col-span-full text-center text-gray-300 py-8">Aucune photo sélectionnée.</div>
+			{% endfor %}
+		</div>
+	</div>
+	<form method="post" action="{{ path('album_new') }}">
+		<div class="flex gap-4">
+			<button type="submit" name="back_to_photos" class="px-6 py-2 bg-gray-200 text-gray-800 rounded hover:bg-gray-300 transition">Retour</button>
+			<button type="submit" class="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition">Valider et créer l'album</button>
+		</div>
+	</form>
+</div>

--- a/templates/albums/_create_photos_step.html.twig
+++ b/templates/albums/_create_photos_step.html.twig
@@ -1,0 +1,11 @@
+{# templates/albums/_create_photos_step.html.twig #}
+<div class="max-w-3xl mx-auto mt-10 p-6 bg-white/90 rounded-xl shadow-lg">
+	<h2 class="text-xl font-bold mb-4">Sélectionner les photos à ajouter à l'album</h2>
+	<form method="post" action="{{ path('album_new') }}" id="album-photos-form">
+		<div
+			id="photo-grid" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 mb-6" data-api-url="{{ path('api_photos_lazy') }}" data-preselected="{{ album is defined and album.photos|length > 0 ? album.photos|map(p => p.id)|json_encode : '[]' }}">{# Les vignettes seront chargées dynamiquement en JS (lazy loading/infinite scroll) #}
+		</div>
+		<input type="hidden" name="selected_photos" id="selected_photos" value="">
+		<button type="submit" class="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition">Continuer</button>
+	</form>
+</div>

--- a/templates/albums/_create_workflow.html.twig
+++ b/templates/albums/_create_workflow.html.twig
@@ -1,0 +1,11 @@
+{# templates/albums/_create_workflow.html.twig #}
+<div class="max-w-lg mx-auto mt-10 p-6 bg-white/90 rounded-xl shadow-lg">
+	<h1 class="text-2xl font-bold mb-6">Créer un nouvel album</h1>
+	<form method="post" action="{{ path('album_new') }}">
+		<div class="mb-6">
+			<label for="album_title" class="block text-lg font-semibold mb-2">Titre de l'album</label>
+			<input type="text" id="album_title" name="album_title" class="w-full px-4 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-blue-500 focus:outline-none" placeholder="Ex : Vacances 2025" required autofocus value="{{ album.name ?? '' }}">
+		</div>
+		<button type="submit" class="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition">Continuer</button>
+	</form>
+</div>

--- a/templates/albums/new.html.twig
+++ b/templates/albums/new.html.twig
@@ -1,0 +1,27 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Nouvel album
+{% endblock %}
+
+{% block body %}
+	{% if step == 'titre' %}
+		{# Étape 1 : uniquement le formulaire de titre #}
+		{% include 'albums/_create_workflow.html.twig' %}
+	{% elseif step == 'description' %}
+		<div class="max-w-lg mx-auto mt-10 p-6 bg-white/90 rounded-xl shadow-lg">
+			<h2 class="text-xl font-bold mb-4">Ajouter une description à l'album</h2>
+			<form method="post" action="{{ path('album_new') }}">
+				<div class="mb-6">
+					<label for="album_description" class="block text-lg font-semibold mb-2">Description</label>
+					<textarea id="album_description" name="album_description" class="w-full px-4 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-blue-500 focus:outline-none" rows="3" placeholder="Ex : Vacances d'été, souvenirs en famille...">{{ album.description ?? '' }}</textarea>
+				</div>
+				<button type="submit" class="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition">Continuer</button>
+			</form>
+		</div>
+	{% elseif step == 'photos' %}
+		{# Étape 3 : sélection des photos #}
+		{% include 'albums/_create_photos_step.html.twig' %}
+	{% elseif step == 'confirmation' %}
+		{% include 'albums/_create_confirmation_step.html.twig' %}
+	{% endif %}
+{% endblock %}

--- a/templates/components/album_new_button.html.twig
+++ b/templates/components/album_new_button.html.twig
@@ -1,0 +1,5 @@
+{# templates/components/album_new_button.html.twig #}
+<a href="{{ path('album_new') }}" class="inline-flex items-center px-5 py-2 bg-blue-600 text-white rounded-lg shadow hover:bg-blue-700 transition font-semibold">
+	<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewbox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
+	Nouvel album
+</a>

--- a/templates/components/photo_grid.html.twig
+++ b/templates/components/photo_grid.html.twig
@@ -1,0 +1,4 @@
+{# templates/components/photo_grid.html.twig #}
+<div
+	id="photo-grid" class="gallery-grid grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 mb-6" data-api-url="{{ api_url }}" data-preselected="{{ preselected|default('[]') }}">{# Les vignettes seront chargées dynamiquement en JS (lazy loading/infinite scroll) #}
+</div>

--- a/templates/photos/index.html.twig
+++ b/templates/photos/index.html.twig
@@ -5,7 +5,10 @@
 
 {% block body %}
 	{{ component('Navbar', { title: 'MyPhotos' }) }}
-	<div class="flex flex-col items-center justify-center py-16">
+	<div class="flex flex-col items-center justify-center py-8">
+		<div class="w-full flex justify-end mb-4 px-4">
+			{% include 'components/album_new_button.html.twig' %}
+		</div>
 		<h2 class="gallery-title text-2xl font-semibold text-white mb-4">Mes photos</h2>
 	</div>
 	<div class="w-full px-4">


### PR DESCRIPTION
This pull request introduces a multi-step album creation wizard using Symfony's Workflow component, enhances the album and photo data models, and implements a lazy-loading, selectable photo grid for album creation. It also includes backend API endpoints, JavaScript controllers, and related database migrations to support these features.

**Album Creation Wizard & Workflow Integration:**

* Added a new `AlbumController` with a multi-step wizard (`titre`, `photos`, `description`, `confirmation`) for album creation, leveraging Symfony's Workflow component to manage the wizard state and transitions. The controller handles step navigation, state persistence in session, and album saving.
* Introduced a workflow configuration (`workflows.yaml`) defining states and transitions for the album creation process.
* Updated the `Album` entity to support workflow state (`marking`), owner relationship, timestamps, and a many-to-many relationship with photos. [[1]](diffhunk://#diff-840f53d73e84e65feb762c47321e0ba7973e1d835c5162d843f2ff5a4488d441R3-R68) [[2]](diffhunk://#diff-840f53d73e84e65feb762c47321e0ba7973e1d835c5162d843f2ff5a4488d441L71-R151)

**Photo Selection & Lazy Loading:**

* Added a reusable JavaScript module (`photo-lazy-grid.js`) and controller (`album-photos-controller.js`) to provide infinite scrolling and interactive photo selection for the album wizard. [[1]](diffhunk://#diff-836855bfe927bf06a658bd3ee3c9658d0cdcc4bd4a55e709138bbab75a3ad4c5R1-R85) [[2]](diffhunk://#diff-90f47d69dc1104a10aed13e33a4caa7d66f2be492333a9e3d081b510458e47caR1-R18) [[3]](diffhunk://#diff-489e15dd56f2315dc02d3d1723571cdad5a1b6848609eb5aeb0b476118bb8236R1) [[4]](diffhunk://#diff-489e15dd56f2315dc02d3d1723571cdad5a1b6848609eb5aeb0b476118bb8236L12-R14)
* Implemented a backend API endpoint (`PhotoApiController`) to serve paginated, user-specific photo data for lazy loading.

**Database Schema Changes:**

* Added migrations to:
  - Add owner and timestamp fields to the `album` table.
  - Change the album-photo relationship to many-to-many via a join table, removing the direct `album_id` from the `photo` table.

**Dependency Updates:**

* Added `symfony/workflow` to project dependencies to enable workflow functionality.

**Entity Model Improvements:**

* Updated the `Photo` entity to support the new many-to-many relationship with albums.

---

**Album creation workflow and backend:**
- Added a multi-step album creation wizard in `AlbumController`, managing state with Symfony Workflow and session, and supporting navigation, validation, and persistence.
- Defined the album creation state machine in `workflows.yaml` with all steps and transitions.
- Updated the `Album` entity to support workflow state, owner, timestamps, and many-to-many photos. [[1]](diffhunk://#diff-840f53d73e84e65feb762c47321e0ba7973e1d835c5162d843f2ff5a4488d441R3-R68) [[2]](diffhunk://#diff-840f53d73e84e65feb762c47321e0ba7973e1d835c5162d843f2ff5a4488d441L71-R151)

**Photo selection and lazy loading:**
- Implemented a reusable, lazy-loading, selectable photo grid in `photo-lazy-grid.js` and its controller, integrated into the album wizard frontend. [[1]](diffhunk://#diff-836855bfe927bf06a658bd3ee3c9658d0cdcc4bd4a55e709138bbab75a3ad4c5R1-R85) [[2]](diffhunk://#diff-90f47d69dc1104a10aed13e33a4caa7d66f2be492333a9e3d081b510458e47caR1-R18) [[3]](diffhunk://#diff-489e15dd56f2315dc02d3d1723571cdad5a1b6848609eb5aeb0b476118bb8236R1) [[4]](diffhunk://#diff-489e15dd56f2315dc02d3d1723571cdad5a1b6848609eb5aeb0b476118bb8236L12-R14)
- Added a paginated photo API endpoint for the frontend to fetch user photos efficiently.

**Database and dependencies:**
- Added migrations to support the new album-photo many-to-many relationship and album metadata. [[1]](diffhunk://#diff-2ffa976b1978f5416c917ae3acd41c058e578cc975f36c7a82a8a3bf8c90b4e3R1-R35) [[2]](diffhunk://#diff-e71924af74054200293a84a5c33d55a90f08de315c424c211c3ddc9e47aa578bR1-R41)
- Added `symfony/workflow` as a dependency.
- Updated the `Photo` entity for many-to-many albums.