### PR TITLE
♻️ refact(service): déplace FileNameGeneratorInterface

### DIFF
--- a/src/Controller/FileController.php
+++ b/src/Controller/FileController.php
@@ -3,7 +3,6 @@
 namespace App\Controller;
 
 use App\Entity\File;
-use App\Entity\User;
 use App\Service\FilePathService;
 use App\Security\FilePathSecurity;
 use App\Service\ZipArchiveService;

--- a/src/DataFixtures/PhotoAlbumFixture.php
+++ b/src/DataFixtures/PhotoAlbumFixture.php
@@ -8,7 +8,6 @@ use App\Entity\User;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
-use Doctrine\Common\Collections\ArrayCollection;
 
 class PhotoAlbumFixture extends Fixture implements DependentFixtureInterface
 {
@@ -43,7 +42,6 @@ class PhotoAlbumFixture extends Fixture implements DependentFixtureInterface
         ) {
             $photo = new Photo();
             $photo->setUser($user);
-            $photo->setAlbum($data['album']);
             $photo->setTitle($data['title']);
             $photo->setFilename($data['filename']);
             $photo->setOriginalName($data['filename']);

--- a/src/Form/FileUploadType.php
+++ b/src/Form/FileUploadType.php
@@ -6,7 +6,6 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
-use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 
 class FileUploadType extends AbstractType
 {

--- a/src/Form/Handler/PhotoUploadHandler.php
+++ b/src/Form/Handler/PhotoUploadHandler.php
@@ -2,16 +2,17 @@
 
 namespace App\Form\Handler;
 
+use Psr\Log\LoggerInterface;
 use App\Form\PhotoUploadType;
 use App\Service\PhotoUploader;
-use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Form\FormFactoryInterface;
-use App\Form\Validator\UploadedFilePresenceValidator;
 use App\Form\Dto\PhotoUploadData;
 use App\Form\Dto\PhotoUploadResult;
-use Psr\Log\LoggerInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Form\FormFactoryInterface;
+use App\Form\Validator\UploadedFilePresenceValidator;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 class PhotoUploadHandler
 {
@@ -76,14 +77,12 @@ class PhotoUploadHandler
         }
     }
 
-    // La méthode fail() n'est plus nécessaire (remplacée par PhotoUploadResult)
-
     /**
      * Extrait les données du formulaire d'upload photo (hors fichier)
      * @param \Symfony\Component\Form\FormInterface $form
      * @return PhotoUploadData
      */
-    private function extractFormData(\Symfony\Component\Form\FormInterface $form): PhotoUploadData
+    private function extractFormData(FormInterface $form): PhotoUploadData
     {
         return new PhotoUploadData(
             $form->get('title')->getData(),

--- a/src/Interface/FileNameGeneratorInterface.php
+++ b/src/Interface/FileNameGeneratorInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Service;
+namespace App\Interface;
 
 interface FileNameGeneratorInterface
 {

--- a/src/Service/DefaultFileNameGenerator.php
+++ b/src/Service/DefaultFileNameGenerator.php
@@ -2,6 +2,8 @@
 
 namespace App\Service;
 
+use App\Interface\FileNameGeneratorInterface;
+
 class DefaultFileNameGenerator implements FileNameGeneratorInterface
 {
     public function generate(string $originalName): string

--- a/src/Service/PhotoUploader.php
+++ b/src/Service/PhotoUploader.php
@@ -10,10 +10,9 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 use App\Service\ExifExtractor;
 use App\Service\PhotoMimeTypeValidator;
 use App\Form\Dto\PhotoUploadData;
-use App\Exception\PhotoUploadException;
 use App\Service\SafeFileMover;
 
-use App\Service\FileNameGeneratorInterface;
+use App\Interface\FileNameGeneratorInterface;
 
 class PhotoUploader
 {

--- a/tests/Unit/PhotoUploaderTest.php
+++ b/tests/Unit/PhotoUploaderTest.php
@@ -4,7 +4,6 @@ namespace App\Tests\Unit;
 
 use App\Entity\Photo;
 use App\Entity\User;
-use App\Service\PhotoUploader;
 use App\Form\Dto\PhotoUploadData;
 use App\Service\PhotoMimeTypeValidator;
 use App\Service\ExifExtractor;
@@ -37,8 +36,7 @@ class PhotoUploaderTest extends TestCase
         $fileMover = $this->createMock(\App\Service\SafeFileMover::class);
         $fileMover->expects($this->once())->method('move')->with($file, $targetDir, $this->anything());
 
-
-        $fileNameGenerator = $this->createMock(\App\Service\FileNameGeneratorInterface::class);
+        $fileNameGenerator = $this->createMock(\App\Interface\FileNameGeneratorInterface::class);
         $fileNameGenerator->expects($this->once())
             ->method('generate')
             ->with('test.jpg')


### PR DESCRIPTION
This pull request primarily refactors the `FileNameGeneratorInterface` by moving it from the `Service` namespace to a new `Interface` namespace and updates all references throughout the codebase. Additionally, it includes minor code cleanups and dependency ordering improvements in several files.

**Refactoring and namespace changes:**

* Renamed and moved `FileNameGeneratorInterface` from `src/Service/FileNameGeneratorInterface.php` to `src/Interface/FileNameGeneratorInterface.php`, changing its namespace from `App\Service` to `App\Interface`. All usages have been updated accordingly. [[1]](diffhunk://#diff-ca2c4e8739cb3e9af167bf40f6810b83d87c476343dce266fea891dfe661de7dL3-R3) [[2]](diffhunk://#diff-279c06137e1985a7a8f473dcb6b1682f16592095205605df9bf8894bc0b96260R5-R6) [[3]](diffhunk://#diff-56017ef5d9e74d28422b481e990b86cb29465ffb9d9ee01dda5d02e396d30c53L13-R15) [[4]](diffhunk://#diff-2bcd3a8dfb0db3855855d17ab51bcb7aeb4378f8fea5e17492ac2e4da7401c8bL40-R39)

**Dependency and import cleanups:**

* Removed unused imports from `FileController.php`, `PhotoAlbumFixture.php`, `FileUploadType.php`, and reordered/cleaned up imports in `PhotoUploadHandler.php` for clarity and consistency. [[1]](diffhunk://#diff-a4cfed039e6cad2086c061e9444541d5231bc03d6c452fc889f592c5378919d5L6) [[2]](diffhunk://#diff-6da1549521127861e2d6fc1a5e76b5774e3ec4e549e66100667f5d4dd8fa41a5L11) [[3]](diffhunk://#diff-44334b2d6c32f39c5b7a71dd0927a56821b2631b21e6696c20f2f68d49daa13dL9) [[4]](diffhunk://#diff-501a3623ed6247511ae67ae516690b8917f2dbd9546a1dbd73335c25e7749291R5-R15)
* Updated the type hint in `extractFormData` method of `PhotoUploadHandler` to use the imported `FormInterface`.

**Fixture and test updates:**

* Removed setting the album on `Photo` in `PhotoAlbumFixture.php` as part of fixture data loading.
* Cleaned up unused imports in `PhotoUploaderTest.php`.