### PR TITLE
Refactor/album controller

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,3 +1,22 @@
+    # Déclaration de la factory d’upload
+    App\Uploader\UploaderFactory:
+        arguments:
+            $uploaders: !tagged_iterator uploader.service
+
+    # Tag les uploaders pour la factory
+    App\Uploader\PhotoUploader:
+        tags: [ 'uploader.service' ]
+        arguments:
+            $targetDirectory: '%app.photos_dir%'
+            $exifExtractor: '@App\Photo\ExifExtractor'
+            $mimeTypeValidator: '@App\Photo\PhotoMimeTypeValidator'
+            $directoryManager: '@App\Uploader\UploadDirectoryManager'
+            $fileNameGenerator: '@App\Uploader\DefaultFileNameGenerator'
+
+    App\Uploader\FileUploader:
+        tags: [ 'uploader.service' ]
+        arguments:
+            $targetDirectory: '%app.files_dir%'
 # This file is the entry point to configure your own services.
 # Files in the packages/ subdirectory configure your dependencies.
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,22 +1,5 @@
-    # Déclaration de la factory d’upload
-    App\Uploader\UploaderFactory:
-        arguments:
-            $uploaders: !tagged_iterator uploader.service
-
-    # Tag les uploaders pour la factory
-    App\Uploader\PhotoUploader:
-        tags: [ 'uploader.service' ]
-        arguments:
-            $targetDirectory: '%app.photos_dir%'
-            $exifExtractor: '@App\Photo\ExifExtractor'
-            $mimeTypeValidator: '@App\Photo\PhotoMimeTypeValidator'
-            $directoryManager: '@App\Uploader\UploadDirectoryManager'
-            $fileNameGenerator: '@App\Uploader\DefaultFileNameGenerator'
-
-    App\Uploader\FileUploader:
-        tags: [ 'uploader.service' ]
-        arguments:
-            $targetDirectory: '%app.files_dir%'
+# This file is the entry point to configure your own services.
+# Files in the packages/ subdirectory configure your dependencies.
 # This file is the entry point to configure your own services.
 # Files in the packages/ subdirectory configure your dependencies.
 
@@ -54,6 +37,21 @@ parameters:
         - 'image/x-raw'
 
 services:
+    App\Uploader\UploaderFactory:
+        arguments:
+            $uploaders: !tagged_iterator uploader.service
+    App\Uploader\PhotoUploader:
+        tags: [ 'uploader.service' ]
+        arguments:
+            $targetDirectory: '%app.photos_dir%'
+            $exifExtractor: '@App\Photo\ExifExtractor'
+            $mimeTypeValidator: '@App\Photo\PhotoMimeTypeValidator'
+            $directoryManager: '@App\Uploader\UploadDirectoryManager'
+            $fileNameGenerator: '@App\Uploader\DefaultFileNameGenerator'
+    App\Uploader\FileUploader:
+        tags: [ 'uploader.service' ]
+        arguments:
+            $targetDirectory: '%app.files_dir%'
     # default configuration for services in *this* file
     _defaults:
         autowire: true      # Automatically injects dependencies in your services.
@@ -63,22 +61,9 @@ services:
     # this creates a service per class whose id is the fully-qualified class name
     App\:
         resource: '../src/'
-
-
-    # Injection explicite du répertoire cible pour FileUploader
-    App\Uploader\FileUploader:
-        arguments:
-            $targetDirectory: '%app.files_dir%'
-
-    # Injection explicite du répertoire cible et des dépendances pour PhotoUploader
-    App\Uploader\PhotoUploader:
-        arguments:
-            $targetDirectory: '%app.photos_dir%'
-            $exifExtractor: '@App\Photo\ExifExtractor'
-            $mimeTypeValidator: '@App\Photo\PhotoMimeTypeValidator'
-            $directoryManager: '@App\Uploader\UploadDirectoryManager'
-            $fileNameGenerator: '@App\Uploader\DefaultFileNameGenerator'
-
+        exclude:
+            - '../src/Uploader/FileUploader.php'
+            - '../src/Uploader/PhotoUploader.php'
 
     App\Photo\PhotoMimeTypeValidator:
         arguments:

--- a/src/Controller/AlbumController.php
+++ b/src/Controller/AlbumController.php
@@ -19,7 +19,11 @@ class AlbumController extends AbstractController
     #[Route('/', name: 'index', methods: ['GET'])]
     public function index(AlbumRepository $albumRepository): Response
     {
-        $albums = $albumRepository->findBy(['owner' => $this->getUser()]);
+        $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY');
+        $albums = $albumRepository->findBy(
+            ['owner' => $this->getUser()],
+            ['createdAt' => 'DESC']
+        );
         return $this->render('albums/index.html.twig', [
             'albums' => $albums,
         ]);

--- a/src/Controller/PhotoController.php
+++ b/src/Controller/PhotoController.php
@@ -8,7 +8,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\User\UserInterface;
-use App\Photo\PhotoFetcher;
 
 class PhotoController extends AbstractController
 {

--- a/src/Photo/PhotoMimeTypeValidator.php
+++ b/src/Photo/PhotoMimeTypeValidator.php
@@ -25,6 +25,7 @@ class PhotoMimeTypeValidator
             );
         }
     }
+
     /**
      * @param string[] $allowedMimeTypes
      */
@@ -43,5 +44,10 @@ class PhotoMimeTypeValidator
                 )
             );
         }
+    }
+
+    public function getAllowedMimeTypes(): array
+    {
+        return $this->allowedMimeTypes;
     }
 }

--- a/src/Uploader/UploaderFactory.php
+++ b/src/Uploader/UploaderFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Uploader;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class UploaderFactory
+{
+    /**
+     * @var UploaderInterface[]
+     */
+    private array $uploaders;
+
+    /**
+     * @param UploaderInterface[] $uploaders
+     */
+    public function __construct(iterable $uploaders)
+    {
+        $this->uploaders = [];
+        foreach ($uploaders as $uploader) {
+            $this->uploaders[] = $uploader;
+        }
+    }
+
+    /**
+     * Retourne l'uploader adapté selon le contexte (type ou support)
+     * @param UploadedFile $file
+     * @param array $context
+     * @return UploaderInterface
+     */
+    public function getUploader(UploadedFile $file, array $context = []): UploaderInterface
+    {
+        foreach ($this->uploaders as $uploader) {
+            if ($uploader->supports($file, $context)) {
+                return $uploader;
+            }
+        }
+        throw new \InvalidArgumentException('Aucun uploader ne supporte ce fichier.');
+    }
+}

--- a/templates/photos/index.html.twig
+++ b/templates/photos/index.html.twig
@@ -6,8 +6,9 @@
 {% block body %}
 	{{ component('Navbar', { title: 'MyPhotos' }) }}
 	<div class="flex flex-col items-center justify-center py-8">
-		<div class="w-full flex justify-end mb-4 px-4">
+		<div class="w-full flex flex-col items-end mb-4 px-4 gap-2">
 			{% include 'components/album_new_button.html.twig' %}
+			<a href="{{ path('album_index') }}" class="text-sm text-blue-300 hover:underline hover:text-blue-100 transition">&larr; Voir mes albums</a>
 		</div>
 		<h2 class="gallery-title text-2xl font-semibold text-white mb-4">Mes photos</h2>
 	</div>

--- a/tests/Unit/UploaderFactoryTest.php
+++ b/tests/Unit/UploaderFactoryTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Tests\Unit;
+
+use App\Uploader\UploaderFactory;
+use App\Uploader\UploaderInterface;
+use PHPUnit\Framework\TestCase;
+
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class DummyUploader implements UploaderInterface
+{
+    public function supports(UploadedFile $file, array $context = []): bool
+    {
+        return $file->getClientOriginalName() === 'dummy.txt';
+    }
+    public function upload(UploadedFile $file, array $context = []): string
+    {
+        return 'dummy-uploaded';
+    }
+    public function getTargetDirectory(): string
+    {
+        return '/tmp';
+    }
+}
+
+class FailingUploader implements UploaderInterface
+{
+    public function supports(UploadedFile $file, array $context = []): bool
+    {
+        return false;
+    }
+    public function upload(UploadedFile $file, array $context = []): string
+    {
+        throw new \LogicException('Should not be called');
+    }
+    public function getTargetDirectory(): string
+    {
+        return '/tmp';
+    }
+}
+
+class UploaderFactoryTest extends TestCase
+{
+    public function testReturnsCorrectUploader()
+    {
+        $dummy = new DummyUploader();
+        $factory = new UploaderFactory([
+            $dummy,
+            new FailingUploader(),
+        ]);
+        $file = $this->createMock(UploadedFile::class);
+        $file->method('getClientOriginalName')->willReturn('dummy.txt');
+        $uploader = $factory->getUploader($file);
+        $this->assertSame($dummy, $uploader);
+        $this->assertEquals('dummy-uploaded', $uploader->upload($file));
+    }
+
+    public function testThrowsIfNoUploaderSupportsFile()
+    {
+        $factory = new UploaderFactory([
+            new FailingUploader(),
+        ]);
+        $file = $this->createMock(UploadedFile::class);
+        $file->method('getClientOriginalName')->willReturn('unknown.txt');
+        $this->expectException(\InvalidArgumentException::class);
+        $factory->getUploader($file);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `UploaderFactory` to centralize and streamline file upload handling in the application. It refactors the upload process to use a factory that dynamically selects the appropriate uploader service based on the file type, making the system more extensible and maintainable. The changes also include updates to service configuration, controller logic, and supporting documentation, as well as new unit tests for the factory.

**Uploader Factory Implementation and Integration:**

- Added a new `UploaderFactory` class that receives all uploader services tagged with `uploader.service` and provides a `getUploader` method to select the correct uploader based on the file and context. This decouples controller logic from specific uploader implementations.
- Updated `services.yaml` to tag `PhotoUploader` and `FileUploader` with `uploader.service`, inject them into `UploaderFactory` via `!tagged_iterator`, and exclude these classes from automatic service registration to avoid conflicts.
- Refactored `AlbumController` to use `UploaderFactory` for handling file uploads, replacing previous logic with a call to the factory and the selected uploader's `upload` method. This simplifies the controller and supports future extensibility. [[1]](diffhunk://#diff-8f6bfb8a4b0f76e645a92c01c6c01bb6566148f36d4f1d337d8ba9ff8fc3da1fL22-R34) [[2]](diffhunk://#diff-8f6bfb8a4b0f76e645a92c01c6c01bb6566148f36d4f1d337d8ba9ff8fc3da1fL72-R98) [[3]](diffhunk://#diff-8f6bfb8a4b0f76e645a92c01c6c01bb6566148f36d4f1d337d8ba9ff8fc3da1fR7)

**Uploader Interface Enhancements:**

- Modified `PhotoUploader` to implement `UploaderInterface`, including a `supports` method to check if it can handle a given file and a generic `upload` method that delegates to the specific upload logic. [[1]](diffhunk://#diff-53db07d21df122675f22bd6c29583f525be1b35e55ce694f5e1853ccaae97be1L16-R19) [[2]](diffhunk://#diff-53db07d21df122675f22bd6c29583f525be1b35e55ce694f5e1853ccaae97be1R66-R90)
- Added a `getAllowedMimeTypes` method to `PhotoMimeTypeValidator` to support the `supports` logic in uploaders.

**Documentation and Testing:**

- Added detailed documentation (`factory-upload.md`) explaining the design, configuration, and usage of the new `UploaderFactory` pattern, including how to add new uploaders.
- Introduced unit tests for `UploaderFactory` to verify correct uploader selection and error handling when no suitable uploader is found.

**Other Improvements:**

- Improved album listing in `AlbumController` by sorting albums by creation date and enforcing authentication.
- Minor UI and code cleanups, such as enhancing navigation in the photo index template and removing unused imports. [[1]](diffhunk://#diff-51259747d3d4b1ce964cad955395181771755c7089b5c625d5b9ed2df6372e05L9-R11) [[2]](diffhunk://#diff-d4af87eb5fbcfe5816d918486c634422eb99b3e494c5994c362f3ce21afd5b32L11)

These changes collectively make the upload system more modular, testable, and easier to extend for new file types or business requirements.