### PR TITLE
✅ test(MoveModalWebTest): tests fonctionnels ouverture modale déplacement folder/file (WebTestCase)

### DIFF
--- a/tests/Web/MoveModalWebTest.php
+++ b/tests/Web/MoveModalWebTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Tests fonctionnels UI : déplacement dossier/fichier via la modale web.
+ */
+final class MoveModalWebTest extends WebTestCase
+{
+    public function testOpenMoveModalAndMoveFolder(): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', '/');
+
+        // Vérifie que le bouton "Déplacer" est présent pour un dossier
+        $this->assertGreaterThan(0, $crawler->filter('[data-testid^="move-folder-btn-"]')->count());
+
+        // Simule le clic sur le bouton "Déplacer" du premier dossier
+        $button = $crawler->filter('[data-testid^="move-folder-btn-"]')->first();
+        $client->executeScript('openMoveModal("folder", "' . $button->attr('data-testid') . '")');
+
+        // Vérifie que la modale s'affiche
+        $this->assertFalse($crawler->filter('#move-modal')->hasClass('hidden'));
+    }
+
+    public function testOpenMoveModalAndMoveFile(): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', '/');
+
+        // Vérifie que le bouton "Déplacer" est présent pour un fichier
+        $this->assertGreaterThan(0, $crawler->filter('[data-testid^="move-file-btn-"]')->count());
+
+        // Simule le clic sur le bouton "Déplacer" du premier fichier
+        $button = $crawler->filter('[data-testid^="move-file-btn-"]')->first();
+        $client->executeScript('openMoveModal("file", "' . $button->attr('data-testid') . '")');
+
+        // Vérifie que la modale s'affiche
+        $this->assertFalse($crawler->filter('#move-modal')->hasClass('hidden'));
+    }
+
+    // À compléter : tests de soumission PATCH, toast, reload, erreurs, etc.
+}


### PR DESCRIPTION
 ## Description
Ajout de tests fonctionnels Symfony WebTestCase pour la modale de déplacement (MoveModal) :
Vérifie l’ouverture de la modale via le bouton "Déplacer" pour un dossier et un fichier.
Prépare la base pour des scénarios complets (soumission PATCH, gestion erreurs, toast, reload).=

### Checklist PR

- [x] Branche dédiée : `test/move-modal-web`
- [x] Commit atomique, scope explicite
- [x] Convention de commit respectée (`✅ test(MoveModalWebTest): ...`)
- [x] Aucun impact sur main
- [x] PR prête à merger
- [x] Tests fonctionnels UI présents
- [ ] Scénarios complets à enrichir si besoin (soumission PATCH, erreurs, toast, reload)
- [ ] Revue et validation par un pair

---

#### Description rapide

Ajout des premiers tests fonctionnels WebTestCase pour la modale de déplacement (MoveModal) :
- Vérifie l’ouverture de la modale via le bouton "Déplacer" pour dossier et fichier.
- Prépare la base pour des scénarios UI plus avancés.
À faire
Ajouter des scénarios complets (soumission, validation, erreurs) si besoin
Revue et validation