### PR TITLE
🔧 fix(app.js): réimplémente closeModal pour fermeture fiable des modals

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -8,3 +8,13 @@ import './stimulus_bootstrap.js';
 import './styles/app.css';
 
 console.log('This log comes from assets/app.js - welcome to AssetMapper! 🎉');
+
+// Fonction globale pour fermer une modal
+window.closeModal = function(modalId) {
+	const modal = document.getElementById(modalId);
+	if (!modal) return;
+	modal.classList.remove('modal-open');
+	modal.classList.add('hidden');
+	// Optionnel : focus sur le body après fermeture
+	document.body.focus();
+}


### PR DESCRIPTION
## Correctif JS — Fermeture des modals

Ce correctif réimplémente la fonction globale `closeModal` dans assets/app.js pour garantir la fermeture fiable des modals via les classes `modal-open` et `hidden`.

- Ajout de la fonction JS globale `closeModal(modalId)`
- Gestion propre des classes CSS pour masquer la modal
- Focus sur le body après fermeture (accessibilité)

### Conformité
- Convention de commit respectée
- Branche de fix dédiée
- Commit atomique

Merci de valider et merger sur main.