### PR TITLE
🔧 fix(UploadModal,layout): corriger route upload et ownerId manquant (400 + 404)

### DIFF
--- a/assets/js/upload-modal.js
+++ b/assets/js/upload-modal.js
@@ -13,7 +13,7 @@
 import '../components/hc-folder-list.js';
 import { apiFetch } from './api.js';
 
-const UPLOAD_API_ROUTE = '/_api_/v1/files_post';
+const UPLOAD_API_ROUTE = '/api/v1/files';
 const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024; // 5 GB
 
 let currentUploadQueue = null;

--- a/assets/js/upload-modal.js
+++ b/assets/js/upload-modal.js
@@ -46,6 +46,7 @@ function createUploadFn(token, folderId, newFolderName) {
             const formData = new FormData();
             
             formData.append('file', file);
+            formData.append('ownerId', window.HC?.userId || '');
             if (folderId) formData.append('folderId', folderId);
             if (newFolderName) formData.append('newFolderName', newFolderName);
 

--- a/templates/web/layout.html.twig
+++ b/templates/web/layout.html.twig
@@ -131,6 +131,7 @@
     var _tokenExp = 0;
 
     window.HC = {
+        userId: '{{ app.user ? app.user.id : '' }}',
         getToken: async function () {
             if (_token && Date.now() < _tokenExp) return _token;
             var res = await fetch('{{ path('app_web_token') }}');


### PR DESCRIPTION
## 🐛 Bugs corrigés

Deux régressions bloquaient l'upload multi-fichier depuis la Phase 5 (`c957223`).

---

### 1. `🔧 fix(UploadModal)` — Route incorrecte (404)

```js
// ❌ Nom de route interne Symfony — URL inexistante
const UPLOAD_API_ROUTE = '/_api_/v1/files_post';

// ✅ Vraie URL HTTP confirmée par bin/console debug:router
const UPLOAD_API_ROUTE = '/api/v1/files';
```

### 2. `🔧 fix(UploadModal,layout)` — `ownerId` manquant dans le FormData (400)

Le contrôleur PHP exige `ownerId` (UUID de l'utilisateur connecté).

```js
// Ajout dans window.HC (layout.html.twig)
window.HC = {
    userId: '{{ app.user ? app.user.id : '' }}',
    ...
};

// Utilisation dans createUploadFn
formData.append('ownerId', window.HC?.userId || '');
```

## 📊 Tests
43 tests JS ✅ — 0 régression