### PR TITLE
♻️ refactor(AuthenticationResolver,IriExtractor): Vague 1 SOLID — élimination des duplications auth et IRI

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -17,7 +17,7 @@ services:
             $albumRepository: '@App\Repository\AlbumRepository'
             $userRepository: '@App\Repository\UserRepository'
             $provider: '@App\State\AlbumProvider'
-            $tokenStorage: '@security.token_storage'
+            $authResolver: '@App\Service\AuthenticationResolver'
             $logger: '@logger'
 
     App\State\FileProcessor:
@@ -77,7 +77,7 @@ services:
             $userRepository: '@App\Repository\UserRepository'
             $provider: '@App\State\FolderProvider'
             $requestStack: '@request_stack'
-            $tokenStorage: '@security.token_storage'
+            $authResolver: '@App\Service\AuthenticationResolver'
             $logger: '@logger'
 
     App\Service\StorageService:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -30,6 +30,7 @@ services:
             $defaultFolderService: '@App\Service\DefaultFolderService'
             $fileActionService: '@App\Service\FileActionService'
             $requestStack: '@request_stack'
+            $iriExtractor: '@App\Service\IriExtractor'
     
     App\Service\AuthenticationResolver:
         arguments:
@@ -79,6 +80,7 @@ services:
             $requestStack: '@request_stack'
             $authResolver: '@App\Service\AuthenticationResolver'
             $logger: '@logger'
+            $iriExtractor: '@App\Service\IriExtractor'
 
     App\Service\StorageService:
         arguments:

--- a/src/Service/IriExtractor.php
+++ b/src/Service/IriExtractor.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * Centralise l'extraction d'UUID depuis une IRI API Platform.
+ * Élimine la duplication de basename()/strpos() dans FolderProcessor et FileProcessor.
+ */
+final readonly class IriExtractor
+{
+    public function __construct(
+        private LoggerInterface $logger,
+    ) {}
+
+    public function extractUuid(string $iri): string
+    {
+        // Cas 1 : IRI avec chemin (/api/folders/uuid) → extraire le segment final
+        if (str_contains($iri, '/')) {
+            if (!preg_match('#/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$#i', $iri, $matches)) {
+                $this->logger->error('Invalid IRI format', [
+                    'iri'     => $iri,
+                    'context' => 'iri_extractor',
+                ]);
+                throw new BadRequestHttpException('Invalid IRI format');
+            }
+            return $matches[1];
+        }
+
+        // Cas 2 : UUID brut — valider le format
+        if (!preg_match('#^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$#i', $iri)) {
+            $this->logger->error('Invalid UUID format', [
+                'value'   => $iri,
+                'context' => 'iri_extractor',
+            ]);
+            throw new BadRequestHttpException('Invalid IRI format');
+        }
+
+        return $iri;
+    }
+
+    /**
+     * Extrait plusieurs UUIDs depuis un tableau d'IRIs.
+     *
+     * @param string[] $iris
+     * @return string[]
+     */
+    public function extractUuids(array $iris): array
+    {
+        return array_map(
+            fn(string $iri) => $this->extractUuid($iri),
+            $iris
+        );
+    }
+}

--- a/src/State/AlbumProcessor.php
+++ b/src/State/AlbumProcessor.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace App\State;
 
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Patch;
@@ -16,8 +13,11 @@ use App\ApiResource\AlbumOutput;
 use App\Entity\Album;
 use App\Repository\AlbumRepository;
 use App\Repository\UserRepository;
+use App\Service\AuthenticationResolver;
 use App\Service\FilenameValidator;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -28,52 +28,15 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 final class AlbumProcessor implements ProcessorInterface
 {
-    /**
-     * Pattern recommandé : injection du TokenStorageInterface et LoggerInterface pour obtenir l'utilisateur courant de façon fiable (test/prod).
-     * Voir FolderProcessor pour l'implémentation complète.
-     */
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly AlbumRepository $albumRepository,
         private readonly UserRepository $userRepository,
         private readonly AlbumProvider $provider,
-        private readonly TokenStorageInterface $tokenStorage,
+        private readonly AuthenticationResolver $authResolver,
         private readonly LoggerInterface $logger,
         private readonly FilenameValidator $filenameValidator,
     ) {}
-
-    /**
-     * Récupère l'utilisateur authentifié depuis le TokenStorage (pattern commun).
-     */
-    private function getAuthenticatedUser(): ?\App\Entity\User
-    {
-        $token = $this->tokenStorage->getToken();
-        $this->logger->info('🔍 TokenStorage State', [
-            'has_token' => $token !== null,
-            'token_class' => $token ? get_class($token) : 'null',
-        ]);
-        if ($token === null) {
-            $this->logger->warning('⚠️ No token in TokenStorage');
-            return null;
-        }
-        $user = $token->getUser();
-        $this->logger->info('🔍 User from Token', [
-            'user_class' => $user ? get_class($user) : 'null',
-            'is_user_instance' => $user instanceof \App\Entity\User,
-        ]);
-        if ($user instanceof \App\Entity\User) {
-            return $user;
-        }
-        if (is_string($user) && filter_var($user, FILTER_VALIDATE_EMAIL)) {
-            $this->logger->info('🔍 User is string, searching by email', ['email' => $user]);
-            return $this->userRepository->findOneBy(['email' => $user]);
-        }
-        $this->logger->warning('⚠️ User type not recognized', [
-            'type' => gettype($user),
-            'value' => $user,
-        ]);
-        return null;
-    }
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
     {
@@ -110,7 +73,7 @@ final class AlbumProcessor implements ProcessorInterface
         $album = $this->albumRepository->find($uriVariables['id'])
             ?? throw new NotFoundHttpException('Album not found');
         // Ownership : seul le propriétaire peut modifier
-        $user = $this->getAuthenticatedUser();
+        $user = $this->authResolver->getAuthenticatedUser();
         if (!$user instanceof \App\Entity\User) {
             throw new AccessDeniedHttpException('You must be authenticated');
         }
@@ -130,7 +93,7 @@ final class AlbumProcessor implements ProcessorInterface
         $album = $this->albumRepository->find($uriVariables['id'])
             ?? throw new NotFoundHttpException('Album not found');
         // Ownership : seul le propriétaire peut supprimer
-        $user = $this->getAuthenticatedUser();
+        $user = $this->authResolver->getAuthenticatedUser();
         if (!$user instanceof \App\Entity\User) {
             throw new AccessDeniedHttpException('You must be authenticated');
         }

--- a/src/State/FileProcessor.php
+++ b/src/State/FileProcessor.php
@@ -14,6 +14,7 @@ use App\Repository\FileRepository;
 use App\Repository\MediaRepository;
 use App\Service\AuthenticationResolver;
 use App\Service\FileActionService;
+use App\Service\IriExtractor;
 use App\Interface\StorageServiceInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -43,6 +44,7 @@ final class FileProcessor implements ProcessorInterface
         private readonly DefaultFolderServiceInterface $defaultFolderService,
         private readonly FileActionService $fileActionService,
         private readonly RequestStack $requestStack,
+        private readonly IriExtractor $iriExtractor,
     ) {}
 
     /**
@@ -103,10 +105,8 @@ final class FileProcessor implements ProcessorInterface
                 // Aucun dossier fourni : résoudre au dossier par défaut (Uploads)
                 $targetFolder = $this->defaultFolderService->resolve(null, null, $user);
             } else {
-                // Nettoyer les chemins (bas… juste au cas où)
-                if (strpos($targetFolderId, '/') !== false) {
-                    $targetFolderId = basename($targetFolderId);
-                }
+                // Extraire l'UUID depuis l'IRI si nécessaire
+                $targetFolderId = $this->iriExtractor->extractUuid($targetFolderId);
                 $targetFolder = $this->em->getRepository(\App\Entity\Folder::class)->find($targetFolderId)
                     ?? throw new NotFoundHttpException('Target folder not found');
             }

--- a/src/State/FolderProcessor.php
+++ b/src/State/FolderProcessor.php
@@ -16,14 +16,14 @@ use App\Enum\FolderMediaType;
 use App\Interface\DefaultFolderServiceInterface;
 use App\Repository\FolderRepository;
 use App\Repository\UserRepository;
+use App\Service\AuthenticationResolver;
 use App\Service\FilenameValidator;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * Traite les opérations d'écriture sur la ressource Folder (POST, PATCH, DELETE).
@@ -51,8 +51,8 @@ final class FolderProcessor implements ProcessorInterface
         /** Injecté pour convertir l'entité en DTO après persist (évite la duplication du mapping) */
         private readonly FolderProvider $provider,
         private readonly RequestStack $requestStack,
-        private readonly TokenStorageInterface $tokenStorage, // ✅ Ajouté
-        private readonly LoggerInterface $logger, // ✅ Ajouté
+        private readonly AuthenticationResolver $authResolver,
+        private readonly LoggerInterface $logger,
         private readonly DefaultFolderServiceInterface $defaultFolderService,
         private readonly FilenameValidator $filenameValidator,
     ) {}
@@ -127,15 +127,10 @@ final class FolderProcessor implements ProcessorInterface
         $folder = $this->folderRepository->find($uriVariables['id'])
             ?? throw new NotFoundHttpException('Folder not found');
         // Ownership : seul le propriétaire peut modifier
-        $user = $this->getAuthenticatedUser();
-        $this->logger->info('🔍 PATCH Ownership Check', [
+        $user = $this->authResolver->getAuthenticatedUser();
+        $this->logger->info('Folder PATCH operation initiated', [
             'folder_id' => (string) $folder->getId(),
-            'folder_owner_id' => (string) $folder->getOwner()->getId(),
-            'folder_owner_email' => $folder->getOwner()->getEmail(),
-            'current_user' => $user ? get_class($user) : 'null',
-            'current_user_id' => $user ? (string) $user->getId() : 'null',
-            'current_user_email' => $user?->getEmail(),
-            'ids_match' => $user ? (string) $user->getId() === (string) $folder->getOwner()->getId() : false,
+            'user_id'   => $user ? (string) $user->getId() : null,
         ]);
         if (!$user instanceof \App\Entity\User) {
             throw new AccessDeniedHttpException('You must be authenticated');
@@ -221,7 +216,7 @@ final class FolderProcessor implements ProcessorInterface
     {
         $folder = $this->folderRepository->find($uriVariables['id'])
             ?? throw new NotFoundHttpException('Folder not found');
-        $user = $this->getAuthenticatedUser();
+        $user = $this->authResolver->getAuthenticatedUser();
         if (!$user || !$folder->getOwner()->getId()->equals($user->getId())) {
             throw new AccessDeniedHttpException('You are not the owner of this folder');
         }
@@ -271,39 +266,6 @@ final class FolderProcessor implements ProcessorInterface
 
         $this->em->remove($folder);
         $this->em->flush();
-        return null;
-    }
-
-    /**
-     * Récupère l'utilisateur authentifié depuis le token de sécurité (API Platform context)
-     */
-    private function getAuthenticatedUser(): ?\App\Entity\User
-    {
-        $token = $this->tokenStorage->getToken();
-        $this->logger->info('🔍 TokenStorage State', [
-            'has_token' => $token !== null,
-            'token_class' => $token ? get_class($token) : 'null',
-        ]);
-        if ($token === null) {
-            $this->logger->warning('⚠️ No token in TokenStorage');
-            return null;
-        }
-        $user = $token->getUser();
-        $this->logger->info('🔍 User from Token', [
-            'user_class' => $user ? get_class($user) : 'null',
-            'is_user_instance' => $user instanceof \App\Entity\User,
-        ]);
-        if ($user instanceof \App\Entity\User) {
-            return $user;
-        }
-        if (is_string($user) && filter_var($user, FILTER_VALIDATE_EMAIL)) {
-            $this->logger->info('🔍 User is string, searching by email', ['email' => $user]);
-            return $this->userRepository->findOneBy(['email' => $user]);
-        }
-        $this->logger->warning('⚠️ User type not recognized', [
-            'type' => gettype($user),
-            'value' => $user,
-        ]);
         return null;
     }
 }

--- a/src/State/FolderProcessor.php
+++ b/src/State/FolderProcessor.php
@@ -18,6 +18,7 @@ use App\Repository\FolderRepository;
 use App\Repository\UserRepository;
 use App\Service\AuthenticationResolver;
 use App\Service\FilenameValidator;
+use App\Service\IriExtractor;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -55,6 +56,7 @@ final class FolderProcessor implements ProcessorInterface
         private readonly LoggerInterface $logger,
         private readonly DefaultFolderServiceInterface $defaultFolderService,
         private readonly FilenameValidator $filenameValidator,
+        private readonly IriExtractor $iriExtractor,
     ) {}
 
     /**
@@ -88,11 +90,8 @@ final class FolderProcessor implements ProcessorInterface
             ?? throw new NotFoundHttpException('User not found');
         $parent = null;
         if ($data->parentId !== null) {
-            // Extraire l'UUID de l'IRI si nécessaire
-            $parentId = $data->parentId;
-            if (strpos($parentId, '/') !== false) {
-                $parentId = basename($parentId);
-            }
+            // Extraire l'UUID depuis l'IRI si nécessaire
+            $parentId = $this->iriExtractor->extractUuid($data->parentId);
             $parent = $this->folderRepository->find($parentId)
                 ?? throw new NotFoundHttpException('Parent folder not found');
         }
@@ -162,10 +161,7 @@ final class FolderProcessor implements ProcessorInterface
         );
         if (array_key_exists('parentId', $body ?? [])) {
             if ($body['parentId'] !== null) {
-                $parentId = $body['parentId'];
-                if (strpos($parentId, '/') !== false) {
-                    $parentId = basename($parentId);
-                }
+                $parentId = $this->iriExtractor->extractUuid($body['parentId']);
                 if ($parentId === (string) $uriVariables['id']) {
                     throw new BadRequestHttpException('A folder cannot be its own parent');
                 }

--- a/src/State/FolderProvider.php
+++ b/src/State/FolderProvider.php
@@ -10,9 +10,8 @@ use ApiPlatform\State\Pagination\TraversablePaginator;
 use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\FolderOutput;
 use App\Entity\Folder;
-use App\Entity\User;
 use App\Repository\FolderRepository;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use App\Service\AuthenticationResolver;
 
 /**
  * Fournit les données lues pour les opérations GET sur la ressource Folder.
@@ -31,7 +30,7 @@ final class FolderProvider implements ProviderInterface
     public function __construct(
         private readonly FolderRepository $repository,
         private readonly Pagination $pagination,
-        private readonly TokenStorageInterface $tokenStorage,
+        private readonly AuthenticationResolver $authResolver,
     ) {}
 
     /**
@@ -49,9 +48,9 @@ final class FolderProvider implements ProviderInterface
 
         [$page, $offset, $limit] = $this->pagination->getPagination($operation, $context);
         $criteria = [];
-        $token = $this->tokenStorage->getToken();
-        if ($token !== null && $token->getUser() instanceof User) {
-            $criteria['owner'] = $token->getUser();
+        $user = $this->authResolver->getAuthenticatedUser();
+        if ($user !== null) {
+            $criteria['owner'] = $user;
         }
         $total = $this->repository->count($criteria);
         $items = array_map($this->toOutput(...), $this->repository->findBy($criteria, [], $limit, $offset));

--- a/tests/Unit/Service/IriExtractorTest.php
+++ b/tests/Unit/Service/IriExtractorTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\IriExtractor;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+final class IriExtractorTest extends TestCase
+{
+    private IriExtractor $extractor;
+
+    protected function setUp(): void
+    {
+        $this->extractor = new IriExtractor(
+            logger: $this->createMock(LoggerInterface::class)
+        );
+    }
+
+    public function testExtractsValidUuid(): void
+    {
+        $uuid = '550e8400-e29b-41d4-a716-446655440000';
+        $iri = "/api/folders/{$uuid}";
+
+        $result = $this->extractor->extractUuid($iri);
+
+        $this->assertSame($uuid, $result);
+    }
+
+    public function testAcceptsRawUuid(): void
+    {
+        $uuid = '550e8400-e29b-41d4-a716-446655440000';
+
+        $this->assertSame($uuid, $this->extractor->extractUuid($uuid));
+    }
+
+    public function testExtractsUuidFromNestedIri(): void
+    {
+        $uuid = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+        $iri = "/api/v1/files/{$uuid}";
+
+        $this->assertSame($uuid, $this->extractor->extractUuid($iri));
+    }
+
+    #[DataProvider('invalidIrisProvider')]
+    public function testRejectsInvalidIris(string $iri): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+        $this->extractor->extractUuid($iri);
+    }
+
+    public static function invalidIrisProvider(): array
+    {
+        return [
+            'no uuid'       => ['/api/folders'],
+            'invalid uuid'  => ['/api/folders/not-a-uuid'],
+            'partial uuid'  => ['/api/folders/550e8400'],
+            'empty string'  => [''],
+        ];
+    }
+
+    public function testExtractsMultipleUuids(): void
+    {
+        $uuids = [
+            '550e8400-e29b-41d4-a716-446655440000',
+            '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+        ];
+        $iris = array_map(fn($uuid) => "/api/folders/{$uuid}", $uuids);
+
+        $result = $this->extractor->extractUuids($iris);
+
+        $this->assertSame($uuids, $result);
+    }
+
+    public function testExtractsMultipleUuidsThrowsOnFirstInvalid(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+        $this->extractor->extractUuids(['/api/folders/invalid', '/api/folders/550e8400-e29b-41d4-a716-446655440000']);
+    }
+}


### PR DESCRIPTION
## 🎯 Objectif

Vague 1 du plan SOLID/KISS/DRY — 2 tickets terminés :
- `qw-auth-resolver` — Supprimer `getAuthenticatedUser()` dupliqué
- `ct-iri-helper` — Centraliser l'extraction UUID depuis IRI

---

## 📋 Changements

### `qw-auth-resolver` — Injection de `AuthenticationResolver`

**Problème :** `getAuthenticatedUser()` dupliquée (≈ 30 lignes × 2) dans `FolderProcessor` et `AlbumProcessor`, et `TokenStorageInterface` injectée directement dans `FolderProvider`.

**Solution :**
- `FolderProcessor` : suppression de `getAuthenticatedUser()` et `TokenStorageInterface`, injection de `AuthenticationResolver`
- `AlbumProcessor` : idem
- `FolderProvider` : remplacement de `TokenStorageInterface` par `AuthenticationResolver::getAuthenticatedUser()`
- `services.yaml` : mise à jour des bindings DI

### `ct-iri-helper` — Création de `IriExtractor`

**Problème :** pattern `basename()/strpos('/'))` dupliqué 3× dans `FolderProcessor` (×2) et `FileProcessor` (×1).

**Solution :**
- Nouveau service `src/Service/IriExtractor.php` : `extractUuid()` + `extractUuids()`
- Gère les deux cas : IRI avec chemin (`/api/v1/folders/uuid`) et UUID brut
- Logging des tentatives invalides (12-Factor XI)
- Tests unitaires : `tests/Unit/Service/IriExtractorTest.php` (9 assertions)

---

## ✅ Tests

- 287 tests, 605 assertions — tous passants
- `IriExtractorTest` : 9 tests unitaires (TDD RED→GREEN)

## 📊 Impact

| Métrique | Avant | Après |
|----------|-------|-------|
| Lignes supprimées | — | −99 lignes |
| Duplication auth | 3 classes | 0 (centralisé) |
| Duplication IRI | 3 occurrences | 0 (centralisé) |

## 🔗 Référence

Plan : `.github/solid.md` — Vague 1 (Quick wins)