### PR TITLE
✨ feat(RepositoryInterfaces): Vague 2 SOLID — FolderRepositoryInterface, UserRepositoryInterface, ShareRepositoryInterface (DIP)

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -11,11 +11,16 @@ parameters:
     app.encryption_key: '%env(base64:APP_ENCRYPTION_KEY)%'
 
 services:
+    # Bindings interfaces → implémentations (Dependency Inversion Principle)
+    App\Interface\FolderRepositoryInterface: '@App\Repository\FolderRepository'
+    App\Interface\UserRepositoryInterface:   '@App\Repository\UserRepository'
+    App\Interface\ShareRepositoryInterface:  '@App\Repository\ShareRepository'
+
     App\State\AlbumProcessor:
         arguments:
             $em: '@doctrine.orm.entity_manager'
             $albumRepository: '@App\Repository\AlbumRepository'
-            $userRepository: '@App\Repository\UserRepository'
+            $userRepository: '@App\Interface\UserRepositoryInterface'
             $provider: '@App\State\AlbumProvider'
             $authResolver: '@App\Service\AuthenticationResolver'
             $logger: '@logger'
@@ -74,8 +79,8 @@ services:
     App\State\FolderProcessor:
         arguments:
             $em: '@doctrine.orm.entity_manager'
-            $folderRepository: '@App\Repository\FolderRepository'
-            $userRepository: '@App\Repository\UserRepository'
+            $folderRepository: '@App\Interface\FolderRepositoryInterface'
+            $userRepository: '@App\Interface\UserRepositoryInterface'
             $provider: '@App\State\FolderProvider'
             $requestStack: '@request_stack'
             $authResolver: '@App\Service\AuthenticationResolver'

--- a/src/Interface/FolderRepositoryInterface.php
+++ b/src/Interface/FolderRepositoryInterface.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\Folder;
+use App\Entity\User;
+use Doctrine\DBAL\LockMode;
+
+/**
+ * Contrat pour l'accès aux données Folder.
+ * Respecte le Dependency Inversion Principle (SOLID D).
+ */
+interface FolderRepositoryInterface
+{
+    public function find(mixed $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null): ?Folder;
+
+    /** @param array<string, mixed> $criteria */
+    public function findOneBy(array $criteria, ?array $orderBy = null): ?Folder;
+
+    public function count(array $criteria = []): int;
+
+    /**
+     * @param array<string, mixed> $criteria
+     * @return Folder[]
+     */
+    public function findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null): array;
+
+    /**
+     * Retourne les UUIDs de tous les descendants (CTE récursive).
+     *
+     * @return string[]
+     */
+    public function findDescendantIds(Folder $folder): array;
+
+    /**
+     * Retourne les UUIDs de tous les ancêtres (CTE récursive).
+     *
+     * @return string[]
+     */
+    public function findAncestorIds(Folder $folder): array;
+
+    /**
+     * Retourne l'arborescence complète d'un owner pour la navigation.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function findAllAsTree(User $owner, ?Folder $currentFolder): array;
+
+    /**
+     * Recherche par nom (case-insensitive) pour un owner.
+     *
+     * @return Folder[]
+     */
+    public function searchByName(string $query, User $owner, int $limit = 20): array;
+}

--- a/src/Interface/ShareRepositoryInterface.php
+++ b/src/Interface/ShareRepositoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\Share;
+use App\Entity\User;
+use Doctrine\DBAL\LockMode;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Contrat pour l'accès aux données Share.
+ * Respecte le Dependency Inversion Principle (SOLID D).
+ */
+interface ShareRepositoryInterface
+{
+    public function find(mixed $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null): ?Share;
+
+    /** @return Share[] */
+    public function findByUser(User $user, int $limit = 20, int $offset = 0): array;
+
+    public function countByUser(User $user): int;
+
+    public function findActiveShare(User $guest, string $resourceType, Uuid $resourceId, string $permission): ?Share;
+}

--- a/src/Interface/UserRepositoryInterface.php
+++ b/src/Interface/UserRepositoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\User;
+use Doctrine\DBAL\LockMode;
+
+/**
+ * Contrat pour l'accès aux données User.
+ * Respecte le Dependency Inversion Principle (SOLID D).
+ */
+interface UserRepositoryInterface
+{
+    public function find(mixed $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null): ?User;
+
+    /** @param array<string, mixed> $criteria */
+    public function findOneBy(array $criteria, ?array $orderBy = null): ?User;
+}

--- a/src/Repository/FolderRepository.php
+++ b/src/Repository/FolderRepository.php
@@ -6,8 +6,9 @@ namespace App\Repository;
 
 use App\Entity\Folder;
 use App\Entity\User;
+use App\Interface\FolderRepositoryInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\ORM\LockMode;
+use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -17,7 +18,7 @@ use Doctrine\Persistence\ManagerRegistry;
  * @method Folder|null findOneBy(array $criteria, array $orderBy = null)
  * @method Folder[] findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
-class FolderRepository extends ServiceEntityRepository
+class FolderRepository extends ServiceEntityRepository implements FolderRepositoryInterface
 {
     private readonly ManagerRegistry $registry;
 
@@ -25,6 +26,32 @@ class FolderRepository extends ServiceEntityRepository
     {
         parent::__construct($registry, Folder::class);
         $this->registry = $registry;
+    }
+
+    public function find(mixed $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null): ?Folder
+    {
+        return parent::find($id, $lockMode, $lockVersion);
+    }
+
+    /** @param array<string, mixed> $criteria */
+    public function findOneBy(array $criteria, ?array $orderBy = null): ?Folder
+    {
+        return parent::findOneBy($criteria, $orderBy);
+    }
+
+    /** @param array<string, mixed> $criteria */
+    public function count(array $criteria = []): int
+    {
+        return parent::count($criteria);
+    }
+
+    /**
+     * @param array<string, mixed> $criteria
+     * @return Folder[]
+     */
+    public function findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null): array
+    {
+        return parent::findBy($criteria, $orderBy, $limit, $offset);
     }
 
     /**

--- a/src/Repository/ShareRepository.php
+++ b/src/Repository/ShareRepository.php
@@ -6,7 +6,9 @@ namespace App\Repository;
 
 use App\Entity\Share;
 use App\Entity\User;
+use App\Interface\ShareRepositoryInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Uid\Uuid;
 
@@ -18,11 +20,16 @@ use Symfony\Component\Uid\Uuid;
  * @method Share[]    findAll()
  * @method Share[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
-class ShareRepository extends ServiceEntityRepository
+class ShareRepository extends ServiceEntityRepository implements ShareRepositoryInterface
 {
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Share::class);
+    }
+
+    public function find(mixed $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null): ?Share
+    {
+        return parent::find($id, $lockMode, $lockVersion);
     }
 
     /** Partages où l'utilisateur est owner OU guest. */

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\User;
+use App\Interface\UserRepositoryInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\ORM\LockMode;
+use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -16,10 +17,21 @@ use Doctrine\Persistence\ManagerRegistry;
  * @method User|null findOneBy(array $criteria, array $orderBy = null)
  * @method User[] findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
-class UserRepository extends ServiceEntityRepository
+class UserRepository extends ServiceEntityRepository implements UserRepositoryInterface
 {
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, User::class);
+    }
+
+    public function find(mixed $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null): ?User
+    {
+        return parent::find($id, $lockMode, $lockVersion);
+    }
+
+    /** @param array<string, mixed> $criteria */
+    public function findOneBy(array $criteria, ?array $orderBy = null): ?User
+    {
+        return parent::findOneBy($criteria, $orderBy);
     }
 }

--- a/src/State/AlbumProcessor.php
+++ b/src/State/AlbumProcessor.php
@@ -12,7 +12,7 @@ use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\AlbumOutput;
 use App\Entity\Album;
 use App\Repository\AlbumRepository;
-use App\Repository\UserRepository;
+use App\Interface\UserRepositoryInterface;
 use App\Service\AuthenticationResolver;
 use App\Service\FilenameValidator;
 use Doctrine\ORM\EntityManagerInterface;
@@ -31,7 +31,7 @@ final class AlbumProcessor implements ProcessorInterface
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly AlbumRepository $albumRepository,
-        private readonly UserRepository $userRepository,
+        private readonly UserRepositoryInterface $userRepository,
         private readonly AlbumProvider $provider,
         private readonly AuthenticationResolver $authResolver,
         private readonly LoggerInterface $logger,

--- a/src/State/FolderProcessor.php
+++ b/src/State/FolderProcessor.php
@@ -14,8 +14,8 @@ use App\Dto\DeleteFolderInput;
 use App\Entity\Folder;
 use App\Enum\FolderMediaType;
 use App\Interface\DefaultFolderServiceInterface;
-use App\Repository\FolderRepository;
-use App\Repository\UserRepository;
+use App\Interface\FolderRepositoryInterface;
+use App\Interface\UserRepositoryInterface;
 use App\Service\AuthenticationResolver;
 use App\Service\FilenameValidator;
 use App\Service\IriExtractor;
@@ -47,8 +47,8 @@ final class FolderProcessor implements ProcessorInterface
 {
     public function __construct(
         private readonly EntityManagerInterface $em,
-        private readonly FolderRepository $folderRepository,
-        private readonly UserRepository $userRepository,
+        private readonly FolderRepositoryInterface $folderRepository,
+        private readonly UserRepositoryInterface $userRepository,
         /** Injecté pour convertir l'entité en DTO après persist (évite la duplication du mapping) */
         private readonly FolderProvider $provider,
         private readonly RequestStack $requestStack,

--- a/src/State/ShareProcessor.php
+++ b/src/State/ShareProcessor.php
@@ -12,8 +12,8 @@ use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\ShareOutput;
 use App\Entity\Share;
 use App\Entity\User;
-use App\Repository\ShareRepository;
-use App\Repository\UserRepository;
+use App\Interface\ShareRepositoryInterface;
+use App\Interface\UserRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -37,8 +37,8 @@ final class ShareProcessor implements ProcessorInterface
 
     public function __construct(
         private readonly EntityManagerInterface $em,
-        private readonly ShareRepository $shareRepository,
-        private readonly UserRepository $userRepository,
+        private readonly ShareRepositoryInterface $shareRepository,
+        private readonly UserRepositoryInterface $userRepository,
         private readonly ShareProvider $provider,
         private readonly Security $security,
     ) {}


### PR DESCRIPTION
## 🎯 Objectif

Vague 2 du plan SOLID — ticket `ct-repo-interfaces` :
Créer les interfaces de repository manquantes pour respecter le **Dependency Inversion Principle** (SOLID D).

---

## 📋 Changements

### Nouvelles interfaces (`src/Interface/`)

| Interface | Méthodes |
|---|---|
| `FolderRepositoryInterface` | `find`, `findBy`, `findOneBy`, `count`, `findDescendantIds`, `findAncestorIds`, `findAllAsTree`, `searchByName` |
| `UserRepositoryInterface` | `find`, `findOneBy` |
| `ShareRepositoryInterface` | `find`, `findByUser`, `countByUser`, `findActiveShare` |

### Repos mis à jour

- `FolderRepository implements FolderRepositoryInterface` + overrides typés (covariance `?Folder` vs `?object`)
- `UserRepository implements UserRepositoryInterface` + overrides typés
- `ShareRepository implements ShareRepositoryInterface` + override `find` typé

### Consommateurs mis à jour (DIP)

- `FolderProcessor` → `FolderRepositoryInterface` + `UserRepositoryInterface`
- `AlbumProcessor` → `UserRepositoryInterface`
- `ShareProcessor` → `ShareRepositoryInterface` + `UserRepositoryInterface`
- `services.yaml` : 3 bindings interface → implémentation

---

## ✅ Tests

287 tests, 605 assertions — tous passants

## 🔗 Référence

Plan : `.github/solid.md` — Vague 2 (`ct-repo-interfaces`)