### PR TITLE
♻️ refactor(OwnershipChecker): Vague 2 SOLID — centralisation ownership, suppression 5 checks manuels

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -22,8 +22,8 @@ services:
             $albumRepository: '@App\Repository\AlbumRepository'
             $userRepository: '@App\Interface\UserRepositoryInterface'
             $provider: '@App\State\AlbumProvider'
-            $authResolver: '@App\Service\AuthenticationResolver'
-            $logger: '@logger'
+            $filenameValidator: '@App\Service\FilenameValidator'
+            $ownershipChecker: '@App\Security\OwnershipChecker'
 
     App\State\FileProcessor:
         arguments:
@@ -86,6 +86,7 @@ services:
             $authResolver: '@App\Service\AuthenticationResolver'
             $logger: '@logger'
             $iriExtractor: '@App\Service\IriExtractor'
+            $ownershipChecker: '@App\Security\OwnershipChecker'
 
     App\Service\StorageService:
         arguments:

--- a/src/Security/OwnershipChecker.php
+++ b/src/Security/OwnershipChecker.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Entity\Album;
+use App\Entity\Folder;
+use App\Entity\Share;
+use App\Service\AuthenticationResolver;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * Centralise les vérifications d'ownership sur les ressources.
+ * Élimine les duplications de `getId() === getId()` dans les processors.
+ *
+ * Responsabilité : access control ownership uniquement.
+ * Utilise AuthenticationResolver pour résoudre l'utilisateur courant.
+ */
+final readonly class OwnershipChecker
+{
+    public function __construct(
+        private AuthenticationResolver $authResolver,
+        private LoggerInterface $logger,
+    ) {}
+
+    public function isOwner(Folder|Album|Share $resource): bool
+    {
+        $user = $this->authResolver->getAuthenticatedUser();
+
+        if ($user === null) {
+            return false;
+        }
+
+        $isOwner = $resource->getOwner()->getId()->equals($user->getId());
+
+        if (!$isOwner) {
+            $this->logger->warning('Ownership check failed', [
+                'user_id'       => (string) $user->getId(),
+                'resource_type' => (new \ReflectionClass($resource))->getShortName(),
+                'resource_id'   => (string) $resource->getId(),
+                'owner_id'      => (string) $resource->getOwner()->getId(),
+            ]);
+        }
+
+        return $isOwner;
+    }
+
+    public function denyUnlessOwner(Folder|Album|Share $resource): void
+    {
+        $user = $this->authResolver->getAuthenticatedUser();
+
+        if ($user === null) {
+            throw new AccessDeniedHttpException('You must be authenticated');
+        }
+
+        if (!$this->isOwner($resource)) {
+            throw new AccessDeniedHttpException(
+                sprintf('You are not the owner of this %s', (new \ReflectionClass($resource))->getShortName())
+            );
+        }
+    }
+}

--- a/src/State/AlbumProcessor.php
+++ b/src/State/AlbumProcessor.php
@@ -13,11 +13,9 @@ use App\ApiResource\AlbumOutput;
 use App\Entity\Album;
 use App\Repository\AlbumRepository;
 use App\Interface\UserRepositoryInterface;
-use App\Service\AuthenticationResolver;
+use App\Security\OwnershipChecker;
 use App\Service\FilenameValidator;
 use Doctrine\ORM\EntityManagerInterface;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -33,9 +31,8 @@ final class AlbumProcessor implements ProcessorInterface
         private readonly AlbumRepository $albumRepository,
         private readonly UserRepositoryInterface $userRepository,
         private readonly AlbumProvider $provider,
-        private readonly AuthenticationResolver $authResolver,
-        private readonly LoggerInterface $logger,
         private readonly FilenameValidator $filenameValidator,
+        private readonly OwnershipChecker $ownershipChecker,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
@@ -72,14 +69,7 @@ final class AlbumProcessor implements ProcessorInterface
     {
         $album = $this->albumRepository->find($uriVariables['id'])
             ?? throw new NotFoundHttpException('Album not found');
-        // Ownership : seul le propriétaire peut modifier
-        $user = $this->authResolver->getAuthenticatedUser();
-        if (!$user instanceof \App\Entity\User) {
-            throw new AccessDeniedHttpException('You must be authenticated');
-        }
-        if ((string) $user->getId() !== (string) $album->getOwner()->getId()) {
-            throw new AccessDeniedHttpException('You are not the owner of this album');
-        }
+        $this->ownershipChecker->denyUnlessOwner($album);
         if ($data->name !== '') {
             $this->filenameValidator->validate($data->name);
             $album->setName($data->name);
@@ -92,14 +82,7 @@ final class AlbumProcessor implements ProcessorInterface
     {
         $album = $this->albumRepository->find($uriVariables['id'])
             ?? throw new NotFoundHttpException('Album not found');
-        // Ownership : seul le propriétaire peut supprimer
-        $user = $this->authResolver->getAuthenticatedUser();
-        if (!$user instanceof \App\Entity\User) {
-            throw new AccessDeniedHttpException('You must be authenticated');
-        }
-        if ((string) $user->getId() !== (string) $album->getOwner()->getId()) {
-            throw new AccessDeniedHttpException('You are not the owner of this album');
-        }
+        $this->ownershipChecker->denyUnlessOwner($album);
         $this->em->remove($album);
         $this->em->flush();
         return null;

--- a/src/State/FolderProcessor.php
+++ b/src/State/FolderProcessor.php
@@ -16,6 +16,7 @@ use App\Enum\FolderMediaType;
 use App\Interface\DefaultFolderServiceInterface;
 use App\Interface\FolderRepositoryInterface;
 use App\Interface\UserRepositoryInterface;
+use App\Security\OwnershipChecker;
 use App\Service\AuthenticationResolver;
 use App\Service\FilenameValidator;
 use App\Service\IriExtractor;
@@ -57,6 +58,7 @@ final class FolderProcessor implements ProcessorInterface
         private readonly DefaultFolderServiceInterface $defaultFolderService,
         private readonly FilenameValidator $filenameValidator,
         private readonly IriExtractor $iriExtractor,
+        private readonly OwnershipChecker $ownershipChecker,
     ) {}
 
     /**
@@ -131,12 +133,7 @@ final class FolderProcessor implements ProcessorInterface
             'folder_id' => (string) $folder->getId(),
             'user_id'   => $user ? (string) $user->getId() : null,
         ]);
-        if (!$user instanceof \App\Entity\User) {
-            throw new AccessDeniedHttpException('You must be authenticated');
-        }
-        if ((string) $user->getId() !== (string) $folder->getOwner()->getId()) {
-            throw new AccessDeniedHttpException('You are not the owner of this folder');
-        }
+        $this->ownershipChecker->denyUnlessOwner($folder);
         if ($data->name !== '') {
             $this->filenameValidator->validate($data->name);
             // Unicité du nom dans le parent pour ce propriétaire
@@ -168,7 +165,7 @@ final class FolderProcessor implements ProcessorInterface
                 $parent = $this->folderRepository->find($parentId)
                     ?? throw new NotFoundHttpException('Parent folder not found');
                 // Sécurité : ownership du parent
-                if ((string) $parent->getOwner()->getId() !== (string) $user->getId()) {
+                if (!$this->ownershipChecker->isOwner($parent)) {
                     throw new AccessDeniedHttpException('You do not own the target parent folder');
                 }
                 // Détection de cycle profond
@@ -212,10 +209,8 @@ final class FolderProcessor implements ProcessorInterface
     {
         $folder = $this->folderRepository->find($uriVariables['id'])
             ?? throw new NotFoundHttpException('Folder not found');
+        $this->ownershipChecker->denyUnlessOwner($folder);
         $user = $this->authResolver->getAuthenticatedUser();
-        if (!$user || !$folder->getOwner()->getId()->equals($user->getId())) {
-            throw new AccessDeniedHttpException('You are not the owner of this folder');
-        }
 
         $input = new DeleteFolderInput();
         $content = $this->requestStack->getCurrentRequest()?->getContent() ?? '{}';

--- a/src/State/ShareProcessor.php
+++ b/src/State/ShareProcessor.php
@@ -11,12 +11,11 @@ use ApiPlatform\Metadata\Post;
 use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\ShareOutput;
 use App\Entity\Share;
-use App\Entity\User;
 use App\Interface\ShareRepositoryInterface;
 use App\Interface\UserRepositoryInterface;
+use App\Security\OwnershipChecker;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Uid\Uuid;
@@ -41,6 +40,7 @@ final class ShareProcessor implements ProcessorInterface
         private readonly UserRepositoryInterface $userRepository,
         private readonly ShareProvider $provider,
         private readonly Security $security,
+        private readonly OwnershipChecker $ownershipChecker,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
@@ -138,11 +138,7 @@ final class ShareProcessor implements ProcessorInterface
             throw new NotFoundHttpException('Partage introuvable.');
         }
 
-        /** @var User $currentUser */
-        $currentUser = $this->security->getUser();
-        if (!$share->getOwner()->getId()->equals($currentUser->getId())) {
-            throw new AccessDeniedHttpException('Seul le propriétaire peut modifier ou supprimer ce partage.');
-        }
+        $this->ownershipChecker->denyUnlessOwner($share);
 
         return $share;
     }


### PR DESCRIPTION
## 🎯 Objectif

Vague 2 — ticket `qw-auth-checker` :
Éliminer les 5 duplications `getOwner()->getId() === $user->getId()` en créant `OwnershipChecker`.

## 📋 Changements

### Nouveau service `src/Security/OwnershipChecker.php`

- `isOwner(Folder|Album|Share $resource): bool` — vérifie sans lever d'exception
- `denyUnlessOwner(Folder|Album|Share $resource): void` — 403 si non-owner
- Utilise `AuthenticationResolver` en interne (pas de passage explicite de `User`)
- Logging structuré des tentatives refusées (12-Factor XI)

### Consommateurs refactorés

| Fichier | Checks remplacés |
|---|---|
| `FolderProcessor::handlePatch` | 1 ownership + 1 parent ownership |
| `FolderProcessor::handleDelete` | 1 ownership |
| `AlbumProcessor::handlePatch` | 1 ownership |
| `AlbumProcessor::handleDelete` | 1 ownership |
| `ShareProcessor::getShareAsOwner` | 1 ownership |

**Total : 5 checks manuels → 0**

## ✅ Tests

287 tests, 605 assertions — tous passants

## 🔗 Référence

Plan : `.github/solid.md` — Vague 2 (`qw-auth-checker`)