### PR TITLE
♻️ refactor(AlbumRepositoryInterface): Vague 2 SOLID — DIP complet sur Album

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -12,6 +12,7 @@ parameters:
 
 services:
     # Bindings interfaces → implémentations (Dependency Inversion Principle)
+    App\Interface\AlbumRepositoryInterface:  '@App\Repository\AlbumRepository'
     App\Interface\FolderRepositoryInterface: '@App\Repository\FolderRepository'
     App\Interface\UserRepositoryInterface:   '@App\Repository\UserRepository'
     App\Interface\ShareRepositoryInterface:  '@App\Repository\ShareRepository'
@@ -19,7 +20,7 @@ services:
     App\State\AlbumProcessor:
         arguments:
             $em: '@doctrine.orm.entity_manager'
-            $albumRepository: '@App\Repository\AlbumRepository'
+            $albumRepository: '@App\Interface\AlbumRepositoryInterface'
             $userRepository: '@App\Interface\UserRepositoryInterface'
             $provider: '@App\State\AlbumProvider'
             $filenameValidator: '@App\Service\FilenameValidator'

--- a/src/Controller/AlbumAddMediaController.php
+++ b/src/Controller/AlbumAddMediaController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
-use App\Repository\AlbumRepository;
+use App\Interface\AlbumRepositoryInterface;
 use App\Repository\MediaRepository;
 use App\State\AlbumProvider;
 use Doctrine\ORM\EntityManagerInterface;
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * Ajoute un média à un album.
@@ -30,7 +31,7 @@ use Symfony\Component\Routing\Attribute\Route;
 final class AlbumAddMediaController extends AbstractController
 {
     public function __construct(
-        private readonly AlbumRepository $albumRepository,
+        private readonly AlbumRepositoryInterface $albumRepository,
         private readonly MediaRepository $mediaRepository,
         private readonly EntityManagerInterface $em,
         private readonly AlbumProvider $provider,
@@ -38,7 +39,7 @@ final class AlbumAddMediaController extends AbstractController
 
     public function __invoke(string $id, Request $request): JsonResponse
     {
-        $album = $this->albumRepository->find($id)
+        $album = $this->albumRepository->findById(Uuid::fromString($id))
             ?? throw new NotFoundHttpException('Album not found');
 
         $body = json_decode((string) $request->getContent(), true);

--- a/src/Controller/AlbumRemoveMediaController.php
+++ b/src/Controller/AlbumRemoveMediaController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
-use App\Repository\AlbumRepository;
+use App\Interface\AlbumRepositoryInterface;
 use App\Repository\MediaRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * Retire un média d'un album.
@@ -25,14 +26,14 @@ use Symfony\Component\Routing\Attribute\Route;
 final class AlbumRemoveMediaController extends AbstractController
 {
     public function __construct(
-        private readonly AlbumRepository $albumRepository,
+        private readonly AlbumRepositoryInterface $albumRepository,
         private readonly MediaRepository $mediaRepository,
         private readonly EntityManagerInterface $em,
     ) {}
 
     public function __invoke(string $id, string $mediaId): JsonResponse
     {
-        $album = $this->albumRepository->find($id)
+        $album = $this->albumRepository->findById(Uuid::fromString($id))
             ?? throw new NotFoundHttpException('Album not found');
 
         $media = $this->mediaRepository->find($mediaId)

--- a/src/State/AlbumProcessor.php
+++ b/src/State/AlbumProcessor.php
@@ -11,13 +11,14 @@ use ApiPlatform\Metadata\Post;
 use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\AlbumOutput;
 use App\Entity\Album;
-use App\Repository\AlbumRepository;
+use App\Interface\AlbumRepositoryInterface;
 use App\Interface\UserRepositoryInterface;
 use App\Security\OwnershipChecker;
 use App\Service\FilenameValidator;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * Traite les opérations d'écriture sur la ressource Album (POST, PATCH, DELETE).
@@ -28,7 +29,7 @@ final class AlbumProcessor implements ProcessorInterface
 {
     public function __construct(
         private readonly EntityManagerInterface $em,
-        private readonly AlbumRepository $albumRepository,
+        private readonly AlbumRepositoryInterface $albumRepository,
         private readonly UserRepositoryInterface $userRepository,
         private readonly AlbumProvider $provider,
         private readonly FilenameValidator $filenameValidator,
@@ -67,7 +68,7 @@ final class AlbumProcessor implements ProcessorInterface
 
     private function handlePatch(AlbumOutput $data, array $uriVariables): AlbumOutput
     {
-        $album = $this->albumRepository->find($uriVariables['id'])
+        $album = $this->albumRepository->findById(Uuid::fromString((string) $uriVariables['id']))
             ?? throw new NotFoundHttpException('Album not found');
         $this->ownershipChecker->denyUnlessOwner($album);
         if ($data->name !== '') {
@@ -80,7 +81,7 @@ final class AlbumProcessor implements ProcessorInterface
 
     private function handleDelete(array $uriVariables): null
     {
-        $album = $this->albumRepository->find($uriVariables['id'])
+        $album = $this->albumRepository->findById(Uuid::fromString((string) $uriVariables['id']))
             ?? throw new NotFoundHttpException('Album not found');
         $this->ownershipChecker->denyUnlessOwner($album);
         $this->em->remove($album);


### PR DESCRIPTION
## 🎯 Objectif

Vague 2 — ticket `ct-album-repo-interface` :
Compléter l'inversion de dépendances pour la ressource Album.

## 📋 Changements

### Consommateurs mis à jour

| Fichier | Avant | Après |
|---|---|---|
| `AlbumProcessor` | `AlbumRepository` | `AlbumRepositoryInterface` |
| `AlbumAddMediaController` | `AlbumRepository` | `AlbumRepositoryInterface` |
| `AlbumRemoveMediaController` | `AlbumRepository` | `AlbumRepositoryInterface` |

- Appels `->find($id)` → `->findById(Uuid::fromString($id))` (interface typée)
- Binding `AlbumRepositoryInterface → AlbumRepository` ajouté dans `services.yaml`

## ✅ Tests

287 tests, 605 assertions — tous passants

## 🔗 Référence

Plan : `.github/solid.md` — Vague 2 (`ct-album-repo-interface`)