### PR TITLE
♻️ refactor(FolderProcessorSRP): extraction FolderService — SRP Vague 3

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -12,10 +12,13 @@ parameters:
 
 services:
     # Bindings interfaces → implémentations (Dependency Inversion Principle)
-    App\Interface\AlbumRepositoryInterface:  '@App\Repository\AlbumRepository'
-    App\Interface\FolderRepositoryInterface: '@App\Repository\FolderRepository'
-    App\Interface\UserRepositoryInterface:   '@App\Repository\UserRepository'
-    App\Interface\ShareRepositoryInterface:  '@App\Repository\ShareRepository'
+    App\Interface\AlbumRepositoryInterface:       '@App\Repository\AlbumRepository'
+    App\Interface\FolderRepositoryInterface:      '@App\Repository\FolderRepository'
+    App\Interface\UserRepositoryInterface:        '@App\Repository\UserRepository'
+    App\Interface\ShareRepositoryInterface:       '@App\Repository\ShareRepository'
+    App\Interface\FilenameValidatorInterface:     '@App\Service\FilenameValidator'
+    App\Interface\OwnershipCheckerInterface:      '@App\Security\OwnershipChecker'
+    App\Interface\AuthenticationResolverInterface: '@App\Service\AuthenticationResolver'
 
     App\State\AlbumProcessor:
         arguments:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -82,15 +82,23 @@ services:
     # Déclaration explicite du FolderProcessor pour garantir l'injection
     App\State\FolderProcessor:
         arguments:
-            $em: '@doctrine.orm.entity_manager'
+            $folderService:    '@App\Service\FolderService'
             $folderRepository: '@App\Interface\FolderRepositoryInterface'
-            $userRepository: '@App\Interface\UserRepositoryInterface'
-            $provider: '@App\State\FolderProvider'
-            $requestStack: '@request_stack'
-            $authResolver: '@App\Service\AuthenticationResolver'
-            $logger: '@logger'
-            $iriExtractor: '@App\Service\IriExtractor'
-            $ownershipChecker: '@App\Security\OwnershipChecker'
+            $userRepository:   '@App\Interface\UserRepositoryInterface'
+            $provider:         '@App\State\FolderProvider'
+            $requestStack:     '@request_stack'
+            $iriExtractor:     '@App\Service\IriExtractor'
+
+    App\Service\FolderService:
+        arguments:
+            $folderRepository:     '@App\Interface\FolderRepositoryInterface'
+            $filenameValidator:    '@App\Interface\FilenameValidatorInterface'
+            $ownershipChecker:     '@App\Interface\OwnershipCheckerInterface'
+            $authResolver:         '@App\Interface\AuthenticationResolverInterface'
+            $defaultFolderService: '@App\Service\DefaultFolderService'
+            $em:                   '@doctrine.orm.entity_manager'
+            $logger:               '@logger'
+            $stopwatch:            '@debug.stopwatch'
 
     App\Service\StorageService:
         arguments:

--- a/src/Interface/AuthenticationResolverInterface.php
+++ b/src/Interface/AuthenticationResolverInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\User;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+
+/**
+ * Contrat de résolution de l'utilisateur authentifié depuis le contexte de sécurité.
+ * Respecte le Dependency Inversion Principle (SOLID D).
+ */
+interface AuthenticationResolverInterface
+{
+    public function getAuthenticatedUser(): ?User;
+
+    /**
+     * @throws UnauthorizedHttpException si aucun utilisateur authentifié
+     */
+    public function requireUser(): User;
+}

--- a/src/Interface/FilenameValidatorInterface.php
+++ b/src/Interface/FilenameValidatorInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+/**
+ * Contrat de validation des noms de fichiers et dossiers.
+ * Respecte le Dependency Inversion Principle (SOLID D).
+ */
+interface FilenameValidatorInterface
+{
+    /**
+     * @throws \Symfony\Component\HttpKernel\Exception\BadRequestHttpException si le nom est invalide
+     */
+    public function validate(string $name): void;
+}

--- a/src/Interface/OwnershipCheckerInterface.php
+++ b/src/Interface/OwnershipCheckerInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\Album;
+use App\Entity\Folder;
+use App\Entity\Share;
+
+/**
+ * Contrat de vérification de l'ownership des ressources.
+ * Respecte le Dependency Inversion Principle (SOLID D).
+ */
+interface OwnershipCheckerInterface
+{
+    public function isOwner(Folder|Album|Share $resource): bool;
+
+    /**
+     * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException si non propriétaire
+     */
+    public function denyUnlessOwner(Folder|Album|Share $resource): void;
+}

--- a/src/Security/OwnershipChecker.php
+++ b/src/Security/OwnershipChecker.php
@@ -7,7 +7,8 @@ namespace App\Security;
 use App\Entity\Album;
 use App\Entity\Folder;
 use App\Entity\Share;
-use App\Service\AuthenticationResolver;
+use App\Interface\AuthenticationResolverInterface;
+use App\Interface\OwnershipCheckerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
@@ -18,10 +19,10 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
  * Responsabilité : access control ownership uniquement.
  * Utilise AuthenticationResolver pour résoudre l'utilisateur courant.
  */
-final readonly class OwnershipChecker
+final readonly class OwnershipChecker implements OwnershipCheckerInterface
 {
     public function __construct(
-        private AuthenticationResolver $authResolver,
+        private AuthenticationResolverInterface $authResolver,
         private LoggerInterface $logger,
     ) {}
 

--- a/src/Service/AuthenticationResolver.php
+++ b/src/Service/AuthenticationResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\Service;
 
 use App\Entity\User;
+use App\Interface\AuthenticationResolverInterface;
 use App\Repository\UserRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
@@ -15,7 +16,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  *
  * Responsibility: Token → User mapping only.
  */
-final class AuthenticationResolver
+final class AuthenticationResolver implements AuthenticationResolverInterface
 {
     public function __construct(
         private readonly TokenStorageInterface $tokenStorage,

--- a/src/Service/FilenameValidator.php
+++ b/src/Service/FilenameValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Interface\FilenameValidatorInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
@@ -11,7 +12,7 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  *
  * Forbidden characters: \ / : * ? " < > |  (Windows + Unix filesystem)
  */
-final class FilenameValidator
+final class FilenameValidator implements FilenameValidatorInterface
 {
     private const MAX_LENGTH = 255;
     private const FORBIDDEN_CHARS_PATTERN = '/[\\\\\/\:\*\?\"\<\>\|]/u';

--- a/src/Service/FolderService.php
+++ b/src/Service/FolderService.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Folder;
+use App\Entity\User;
+use App\Enum\FolderMediaType;
+use App\Interface\AuthenticationResolverInterface;
+use App\Interface\DefaultFolderServiceInterface;
+use App\Interface\FilenameValidatorInterface;
+use App\Interface\FolderRepositoryInterface;
+use App\Interface\OwnershipCheckerInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+/**
+ * Logique métier des opérations sur les dossiers.
+ *
+ * Extrait de FolderProcessor pour respecter le Single Responsibility Principle :
+ * ce service est responsable des règles métier uniquement (validation, ownership,
+ * cycle detection, persistance). FolderProcessor délègue ici et reste un pur
+ * dispatcher HTTP → domaine.
+ *
+ * Responsabilités :
+ * - createFolder : validation nom, unicité, persist
+ * - updateFolder : ownership, rename, mediaType, déplacement avec détection de cycle
+ * - deleteFolder : ownership, suppression avec ou sans migration des fichiers
+ */
+final class FolderService
+{
+    public function __construct(
+        private readonly FolderRepositoryInterface $folderRepository,
+        private readonly FilenameValidatorInterface $filenameValidator,
+        private readonly OwnershipCheckerInterface $ownershipChecker,
+        private readonly AuthenticationResolverInterface $authResolver,
+        private readonly DefaultFolderServiceInterface $defaultFolderService,
+        private readonly EntityManagerInterface $em,
+        private readonly LoggerInterface $logger,
+        private readonly Stopwatch $stopwatch,
+    ) {}
+
+    /**
+     * Crée un dossier après validation du nom et vérification de l'unicité dans le parent.
+     */
+    public function createFolder(User $owner, string $name, ?Folder $parent, FolderMediaType $mediaType): Folder
+    {
+        $event = $this->stopwatch->start('folder.create');
+
+        $this->filenameValidator->validate($name);
+
+        $criteria = ['name' => $name, 'owner' => $owner, 'parent' => $parent];
+        if ($this->folderRepository->findOneBy($criteria) !== null) {
+            throw new BadRequestHttpException('A folder with this name already exists in the parent');
+        }
+
+        $folder = new Folder($name, $owner, $parent);
+        $folder->setMediaType($mediaType);
+        $this->em->persist($folder);
+        $this->em->flush();
+
+        $event->stop();
+        $this->logger->info('Folder created', [
+            'folder_id' => (string) $folder->getId(),
+            'name'      => $name,
+            'duration'  => $event->getDuration() . 'ms',
+        ]);
+
+        return $folder;
+    }
+
+    /**
+     * Met à jour un dossier (rename, mediaType, déplacement).
+     *
+     * @param string           $newName       Nouveau nom — vide = pas de changement
+     * @param FolderMediaType|null $newMediaType  null = pas de changement
+     * @param bool             $parentChanged true si parentId était présent dans le body JSON
+     * @param Folder|null      $newParent     null = déplacement à la racine (si $parentChanged=true)
+     */
+    public function updateFolder(
+        Folder $folder,
+        string $newName,
+        ?FolderMediaType $newMediaType,
+        bool $parentChanged,
+        ?Folder $newParent,
+    ): void {
+        $event = $this->stopwatch->start('folder.update');
+
+        $this->logger->info('Folder PATCH operation initiated', [
+            'folder_id' => (string) $folder->getId(),
+        ]);
+
+        $this->ownershipChecker->denyUnlessOwner($folder);
+
+        if ($newName !== '') {
+            $this->filenameValidator->validate($newName);
+            $criteria = ['name' => $newName, 'owner' => $folder->getOwner(), 'parent' => $folder->getParent()];
+            $existing = $this->folderRepository->findOneBy($criteria);
+            if ($existing !== null && !$existing->getId()->equals($folder->getId())) {
+                throw new BadRequestHttpException('A folder with this name already exists in the parent');
+            }
+            $folder->setName($newName);
+        }
+
+        if ($newMediaType !== null) {
+            $folder->setMediaType($newMediaType);
+        }
+
+        if ($parentChanged) {
+            if ($newParent !== null) {
+                if ($newParent->getId()->equals($folder->getId())) {
+                    throw new BadRequestHttpException('A folder cannot be its own parent');
+                }
+                if (!$this->ownershipChecker->isOwner($newParent)) {
+                    throw new AccessDeniedHttpException('You do not own the target parent folder');
+                }
+                if ($this->wouldCreateCycle($folder, $newParent)) {
+                    throw new BadRequestHttpException('Moving this folder would create a cycle');
+                }
+            }
+            $folder->setParent($newParent);
+        }
+
+        $this->em->flush();
+
+        $event->stop();
+        $this->logger->info('Folder updated', [
+            'folder_id' => (string) $folder->getId(),
+            'duration'  => $event->getDuration() . 'ms',
+        ]);
+    }
+
+    /**
+     * Supprime un dossier.
+     *
+     * Si $deleteContents=false : déplace tous les fichiers des sous-dossiers vers
+     * le dossier Uploads avant de supprimer l'arborescence.
+     * Si $deleteContents=true : supprime directement (cascade Doctrine).
+     */
+    public function deleteFolder(Folder $folder, bool $deleteContents): void
+    {
+        $event = $this->stopwatch->start('folder.delete');
+
+        $this->ownershipChecker->denyUnlessOwner($folder);
+
+        if (!$deleteContents) {
+            $user          = $this->authResolver->getAuthenticatedUser();
+            $uploadsFolder = $this->defaultFolderService->resolve(null, null, $user);
+
+            $descendantIds = $this->folderRepository->findDescendantIds($folder);
+
+            // Déplace les fichiers du dossier principal (entité déjà chargée)
+            foreach ($folder->getFiles() as $file) {
+                $file->setFolder($uploadsFolder);
+            }
+
+            // Déplace les fichiers des sous-dossiers
+            foreach ($descendantIds as $descId) {
+                $f = $this->folderRepository->find($descId);
+                if ($f === null) {
+                    continue;
+                }
+                foreach ($f->getFiles() as $file) {
+                    $file->setFolder($uploadsFolder);
+                }
+            }
+
+            // Flush les déplacements de fichiers (crée Uploads si besoin)
+            $this->em->flush();
+
+            // Supprime sous-dossiers puis dossier lui-même.
+            // refresh() recharge depuis la DB : collection files vide après déplacement.
+            foreach ($descendantIds as $descId) {
+                $desc = $this->folderRepository->find($descId);
+                if ($desc !== null) {
+                    $this->em->refresh($desc);
+                    $this->em->remove($desc);
+                }
+            }
+            $this->em->refresh($folder);
+            $this->em->remove($folder);
+            $this->em->flush();
+        } else {
+            $this->em->remove($folder);
+            $this->em->flush();
+        }
+
+        $event->stop();
+        $this->logger->info('Folder deleted', [
+            'folder_id'      => (string) $folder->getId(),
+            'deleteContents' => $deleteContents,
+            'duration'       => $event->getDuration() . 'ms',
+        ]);
+    }
+
+    /**
+     * Vérifie si définir $newParent comme parent de $folder créerait un cycle.
+     * Utilise une CTE récursive (1 requête SQL) pour remonter tous les ancêtres
+     * de $newParent. Si $folder est parmi eux → cycle.
+     */
+    private function wouldCreateCycle(Folder $folder, Folder $newParent): bool
+    {
+        $ancestorIds = $this->folderRepository->findAncestorIds($newParent);
+        $folderId    = strtolower(str_replace('-', '', (string) $folder->getId()));
+        foreach ($ancestorIds as $ancestorId) {
+            if (strtolower(str_replace('-', '', $ancestorId)) === $folderId) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/State/FolderProcessor.php
+++ b/src/State/FolderProcessor.php
@@ -10,61 +10,38 @@ use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\FolderOutput;
-use App\Dto\DeleteFolderInput;
-use App\Entity\Folder;
 use App\Enum\FolderMediaType;
-use App\Interface\DefaultFolderServiceInterface;
 use App\Interface\FolderRepositoryInterface;
 use App\Interface\UserRepositoryInterface;
-use App\Security\OwnershipChecker;
-use App\Service\AuthenticationResolver;
-use App\Service\FilenameValidator;
+use App\Service\FolderService;
 use App\Service\IriExtractor;
-use Doctrine\ORM\EntityManagerInterface;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
- * Traite les opérations d'écriture sur la ressource Folder (POST, PATCH, DELETE).
+ * Dispatcher HTTP → FolderService pour les opérations d'écriture (POST, PATCH, DELETE).
  *
- * Rôle : couche d'écriture — reçoit un FolderOutput désérialisé depuis le corps
- * de la requête, applique les règles métier, persiste via Doctrine, puis retourne
- * le DTO mis à jour (sauf DELETE qui retourne null → 204).
- *
- * Choix :
- * - Le dispatch par type d'opération (match + instanceof) évite un processeur
- *   par opération tout en gardant chaque handler focalisé.
- * - FolderProvider est injecté pour réutiliser toOutput() après persist,
- *   garantissant une sérialisation cohérente entre lecture et écriture.
- * - Les exceptions Symfony (BadRequest, NotFound) sont automatiquement
- *   converties en réponses JSON avec le bon code HTTP par API Platform.
+ * Rôle : couche transport uniquement.
+ * - Reçoit le FolderOutput désérialisé depuis le corps JSON
+ * - Résout les entités (owner, parent) depuis les IDs/IRIs
+ * - Délègue toute la logique métier à FolderService
+ * - Retourne le DTO mis à jour (ou null pour 204 sur DELETE)
  *
  * @implements ProcessorInterface<FolderOutput, FolderOutput|null>
  */
 final class FolderProcessor implements ProcessorInterface
 {
     public function __construct(
-        private readonly EntityManagerInterface $em,
+        private readonly FolderService $folderService,
         private readonly FolderRepositoryInterface $folderRepository,
         private readonly UserRepositoryInterface $userRepository,
         /** Injecté pour convertir l'entité en DTO après persist (évite la duplication du mapping) */
         private readonly FolderProvider $provider,
         private readonly RequestStack $requestStack,
-        private readonly AuthenticationResolver $authResolver,
-        private readonly LoggerInterface $logger,
-        private readonly DefaultFolderServiceInterface $defaultFolderService,
-        private readonly FilenameValidator $filenameValidator,
         private readonly IriExtractor $iriExtractor,
-        private readonly OwnershipChecker $ownershipChecker,
     ) {}
 
-    /**
-     * Point d'entrée unique : délègue au bon handler selon le type d'opération.
-     * $data est le FolderOutput désérialisé depuis le corps JSON de la requête.
-     */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
     {
         return match (true) {
@@ -76,8 +53,7 @@ final class FolderProcessor implements ProcessorInterface
     }
 
     /**
-     * POST /api/v1/folders — crée un dossier.
-     * Champs requis : name, ownerId. Champ optionnel : parentId.
+     * POST /api/v1/folders — résout owner + parent, délègue la création à FolderService.
      */
     private function handlePost(FolderOutput $data): FolderOutput
     {
@@ -87,176 +63,72 @@ final class FolderProcessor implements ProcessorInterface
         if (empty($data->ownerId)) {
             throw new BadRequestHttpException('ownerId is required');
         }
-        $this->filenameValidator->validate($data->name);
+
         $owner = $this->userRepository->find($data->ownerId)
             ?? throw new NotFoundHttpException('User not found');
+
         $parent = null;
         if ($data->parentId !== null) {
-            // Extraire l'UUID depuis l'IRI si nécessaire
             $parentId = $this->iriExtractor->extractUuid($data->parentId);
-            $parent = $this->folderRepository->find($parentId)
+            $parent   = $this->folderRepository->find($parentId)
                 ?? throw new NotFoundHttpException('Parent folder not found');
         }
-        // Unicité du nom dans le parent pour ce propriétaire
-        $criteria = ['name' => $data->name, 'owner' => $owner];
-        if ($parent) {
-            $criteria['parent'] = $parent;
-        } else {
-            $criteria['parent'] = null;
-        }
-        if ($this->folderRepository->findOneBy($criteria)) {
-            throw new BadRequestHttpException('A folder with this name already exists in the parent');
-        }
+
         $mediaType = FolderMediaType::General;
         if ($data->mediaType !== 'general') {
             $mediaType = FolderMediaType::tryFrom($data->mediaType)
                 ?? throw new BadRequestHttpException('Invalid mediaType: ' . $data->mediaType);
         }
-        $folder = new Folder($data->name, $owner, $parent);
-        $folder->setMediaType($mediaType);
-        $this->em->persist($folder);
-        $this->em->flush();
+
+        $folder = $this->folderService->createFolder($owner, $data->name, $parent, $mediaType);
         return $this->provider->toOutput($folder);
     }
 
     /**
-     * PATCH /api/v1/folders/{id} — mise à jour partielle.
-     * Seuls les champs présents dans le corps sont modifiés.
+     * PATCH /api/v1/folders/{id} — résout les entités, délègue la mise à jour à FolderService.
+     * Lit le corps JSON brut pour distinguer parentId absent/null/valeur.
      */
     private function handlePatch(FolderOutput $data, array $uriVariables): FolderOutput
     {
         $folder = $this->folderRepository->find($uriVariables['id'])
             ?? throw new NotFoundHttpException('Folder not found');
-        // Ownership : seul le propriétaire peut modifier
-        $user = $this->authResolver->getAuthenticatedUser();
-        $this->logger->info('Folder PATCH operation initiated', [
-            'folder_id' => (string) $folder->getId(),
-            'user_id'   => $user ? (string) $user->getId() : null,
-        ]);
-        $this->ownershipChecker->denyUnlessOwner($folder);
-        if ($data->name !== '') {
-            $this->filenameValidator->validate($data->name);
-            // Unicité du nom dans le parent pour ce propriétaire
-            $parent = $folder->getParent();
-            $criteria = ['name' => $data->name, 'owner' => $folder->getOwner()];
-            $criteria['parent'] = $parent;
-            $existing = $this->folderRepository->findOneBy($criteria);
-            if ($existing && !$existing->getId()->equals($folder->getId())) {
-                throw new BadRequestHttpException('A folder with this name already exists in the parent');
-            }
-            $folder->setName($data->name);
-        }
+
+        $newMediaType = null;
         if ($data->mediaType !== 'general') {
-            $mediaType = FolderMediaType::tryFrom($data->mediaType)
+            $newMediaType = FolderMediaType::tryFrom($data->mediaType)
                 ?? throw new BadRequestHttpException('Invalid mediaType: ' . $data->mediaType);
-            $folder->setMediaType($mediaType);
         }
-        // Lecture JSON brute pour distinguer parentId absent/null
-        $body = json_decode(
-            $this->requestStack->getCurrentRequest()?->getContent() ?? '{}',
-            true
-        );
-        if (array_key_exists('parentId', $body ?? [])) {
-            if ($body['parentId'] !== null) {
-                $parentId = $this->iriExtractor->extractUuid($body['parentId']);
-                if ($parentId === (string) $uriVariables['id']) {
-                    throw new BadRequestHttpException('A folder cannot be its own parent');
-                }
-                $parent = $this->folderRepository->find($parentId)
-                    ?? throw new NotFoundHttpException('Parent folder not found');
-                // Sécurité : ownership du parent
-                if (!$this->ownershipChecker->isOwner($parent)) {
-                    throw new AccessDeniedHttpException('You do not own the target parent folder');
-                }
-                // Détection de cycle profond
-                if ($this->wouldCreateCycle($folder, $parent)) {
-                    throw new BadRequestHttpException('Moving this folder would create a cycle');
-                }
-            } else {
-                $parent = null; // Mise à la racine
-            }
-            $folder->setParent($parent);
+
+        $body          = json_decode($this->requestStack->getCurrentRequest()?->getContent() ?? '{}', true);
+        $parentChanged = array_key_exists('parentId', $body ?? []);
+        $newParent     = null;
+
+        if ($parentChanged && $body['parentId'] !== null) {
+            $parentId  = $this->iriExtractor->extractUuid($body['parentId']);
+            $newParent = $this->folderRepository->find($parentId)
+                ?? throw new NotFoundHttpException('Parent folder not found');
         }
-        $this->em->flush();
+
+        $this->folderService->updateFolder($folder, $data->name, $newMediaType, $parentChanged, $newParent);
         return $this->provider->toOutput($folder);
     }
 
     /**
-     * Vérifie si définir $newParent comme parent de $folder créerait un cycle.
-     * Utilise FolderRepository::findAncestorIds() (CTE récursif, 1 seule requête SQL)
-     * pour récupérer tous les ancêtres de $newParent.
-     * Si $folder apparaît parmi ces ancêtres → cycle → retourne true.
-     */
-    private function wouldCreateCycle(Folder $folder, Folder $newParent): bool
-    {
-        $ancestorIds = $this->folderRepository->findAncestorIds($newParent);
-        $folderId    = strtolower(str_replace('-', '', (string) $folder->getId()));
-        foreach ($ancestorIds as $ancestorId) {
-            if (strtolower(str_replace('-', '', $ancestorId)) === $folderId) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * DELETE /api/v1/folders/{id} — supprime le dossier.
-     * Lit le body JSON pour l'option deleteContents (défaut: true).
-     * Si deleteContents=false : déplace tous les fichiers vers le dossier Uploads avant suppression.
+     * DELETE /api/v1/folders/{id} — lit le flag deleteContents, délègue à FolderService.
      * Retourne null → API Platform génère une réponse 204 No Content.
      */
     private function handleDelete(array $uriVariables): null
     {
         $folder = $this->folderRepository->find($uriVariables['id'])
             ?? throw new NotFoundHttpException('Folder not found');
-        $this->ownershipChecker->denyUnlessOwner($folder);
-        $user = $this->authResolver->getAuthenticatedUser();
 
-        $input = new DeleteFolderInput();
-        $content = $this->requestStack->getCurrentRequest()?->getContent() ?? '{}';
-        $body = json_decode($content, true);
-        if (is_array($body) && array_key_exists('deleteContents', $body)) {
-            $input->deleteContents = (bool) $body['deleteContents'];
-        }
+        $content        = $this->requestStack->getCurrentRequest()?->getContent() ?? '{}';
+        $body           = json_decode($content, true);
+        $deleteContents = !is_array($body) || !array_key_exists('deleteContents', $body)
+            || (bool) $body['deleteContents'];
 
-        if (!$input->deleteContents) {
-            $uploadsFolder = $this->defaultFolderService->resolve(null, null, $user);
-
-            $descendantIds = $this->folderRepository->findDescendantIds($folder);
-            $allFolderIds = array_merge([$folder->getId()->toRfc4122()], $descendantIds);
-
-            foreach ($allFolderIds as $folderId) {
-                $f = $this->folderRepository->find($folderId);
-                if ($f === null) {
-                    continue;
-                }
-                foreach ($f->getFiles() as $file) {
-                    $file->setFolder($uploadsFolder);
-                }
-            }
-
-            // Persiste le dossier Uploads (création lazy) et les déplacements de fichiers
-            $this->em->flush();
-
-            // Supprime les sous-dossiers puis le dossier lui-même.
-            // refresh() force le rechargement depuis la DB : la collection files est vide
-            // (fichiers déplacés), donc cascade: remove ne supprimera pas les fichiers déplacés.
-            foreach ($descendantIds as $descId) {
-                $desc = $this->folderRepository->find($descId);
-                if ($desc !== null) {
-                    $this->em->refresh($desc);
-                    $this->em->remove($desc);
-                }
-            }
-            $this->em->refresh($folder);
-            $this->em->remove($folder);
-            $this->em->flush();
-
-            return null;
-        }
-
-        $this->em->remove($folder);
-        $this->em->flush();
+        $this->folderService->deleteFolder($folder, $deleteContents);
         return null;
     }
 }
+

--- a/tests/Unit/Service/FolderServiceTest.php
+++ b/tests/Unit/Service/FolderServiceTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\User;
+use App\Enum\FolderMediaType;
+use App\Interface\AuthenticationResolverInterface;
+use App\Interface\DefaultFolderServiceInterface;
+use App\Interface\FilenameValidatorInterface;
+use App\Interface\FolderRepositoryInterface;
+use App\Interface\OwnershipCheckerInterface;
+use App\Service\FolderService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+final class FolderServiceTest extends TestCase
+{
+    /** @var FolderRepositoryInterface&MockObject */
+    private FolderRepositoryInterface $folderRepository;
+
+    /** @var FilenameValidatorInterface&MockObject */
+    private FilenameValidatorInterface $filenameValidator;
+
+    /** @var OwnershipCheckerInterface&MockObject */
+    private OwnershipCheckerInterface $ownershipChecker;
+
+    /** @var AuthenticationResolverInterface&MockObject */
+    private AuthenticationResolverInterface $authResolver;
+
+    /** @var DefaultFolderServiceInterface&MockObject */
+    private DefaultFolderServiceInterface $defaultFolderService;
+
+    /** @var EntityManagerInterface&MockObject */
+    private EntityManagerInterface $em;
+
+    private FolderService $service;
+
+    protected function setUp(): void
+    {
+        $this->folderRepository    = $this->createMock(FolderRepositoryInterface::class);
+        $this->filenameValidator   = $this->createMock(FilenameValidatorInterface::class);
+        $this->ownershipChecker    = $this->createMock(OwnershipCheckerInterface::class);
+        $this->authResolver        = $this->createMock(AuthenticationResolverInterface::class);
+        $this->defaultFolderService = $this->createMock(DefaultFolderServiceInterface::class);
+        $this->em                  = $this->createMock(EntityManagerInterface::class);
+
+        $this->service = new FolderService(
+            folderRepository:     $this->folderRepository,
+            filenameValidator:    $this->filenameValidator,
+            ownershipChecker:     $this->ownershipChecker,
+            authResolver:         $this->authResolver,
+            defaultFolderService: $this->defaultFolderService,
+            em:                   $this->em,
+            logger:               $this->createMock(LoggerInterface::class),
+            stopwatch:            new Stopwatch(),
+        );
+    }
+
+    // ─── createFolder ────────────────────────────────────────────────────────
+
+    public function testCreateFolderValidatesFilename(): void
+    {
+        $owner = new User('owner@example.com', 'Owner');
+        $this->filenameValidator->expects($this->once())->method('validate')->with('mon-dossier');
+        $this->folderRepository->method('findOneBy')->willReturn(null);
+        $this->em->expects($this->once())->method('persist');
+        $this->em->expects($this->once())->method('flush');
+
+        $this->service->createFolder($owner, 'mon-dossier', null, FolderMediaType::General);
+    }
+
+    public function testCreateFolderThrowsIfDuplicate(): void
+    {
+        $owner  = new User('owner@example.com', 'Owner');
+        $parent = new Folder('parent', $owner);
+        $this->folderRepository->method('findOneBy')->willReturn(new Folder('mon-dossier', $owner, $parent));
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->service->createFolder($owner, 'mon-dossier', $parent, FolderMediaType::General);
+    }
+
+    public function testCreateFolderPersistsAndReturnsFolder(): void
+    {
+        $owner = new User('owner@example.com', 'Owner');
+        $this->folderRepository->method('findOneBy')->willReturn(null);
+        $this->em->expects($this->once())->method('persist')->with($this->isInstanceOf(Folder::class));
+        $this->em->expects($this->once())->method('flush');
+
+        $folder = $this->service->createFolder($owner, 'test', null, FolderMediaType::General);
+        $this->assertInstanceOf(Folder::class, $folder);
+        $this->assertSame('test', $folder->getName());
+    }
+
+    // ─── updateFolder ────────────────────────────────────────────────────────
+
+    public function testUpdateFolderChecksOwnership(): void
+    {
+        $owner  = new User('owner@example.com', 'Owner');
+        $folder = new Folder('old-name', $owner);
+        $this->ownershipChecker->expects($this->once())->method('denyUnlessOwner')->with($folder);
+        $this->em->method('flush');
+
+        $this->service->updateFolder($folder, '', null, false, null);
+    }
+
+    public function testUpdateFolderRenamesWhenNameProvided(): void
+    {
+        $owner  = new User('owner@example.com', 'Owner');
+        $folder = new Folder('old-name', $owner);
+        $this->filenameValidator->expects($this->once())->method('validate')->with('new-name');
+        $this->folderRepository->method('findOneBy')->willReturn(null);
+        $this->em->method('flush');
+
+        $this->service->updateFolder($folder, 'new-name', null, false, null);
+        $this->assertSame('new-name', $folder->getName());
+    }
+
+    public function testUpdateFolderSkipsRenameWhenEmptyName(): void
+    {
+        $owner  = new User('owner@example.com', 'Owner');
+        $folder = new Folder('old-name', $owner);
+        $this->filenameValidator->expects($this->never())->method('validate');
+        $this->em->method('flush');
+
+        $this->service->updateFolder($folder, '', null, false, null);
+        $this->assertSame('old-name', $folder->getName());
+    }
+
+    public function testUpdateFolderChangesMediaType(): void
+    {
+        $owner  = new User('owner@example.com', 'Owner');
+        $folder = new Folder('folder', $owner);
+        $this->em->method('flush');
+
+        $this->service->updateFolder($folder, '', FolderMediaType::Photo, false, null);
+        $this->assertSame(FolderMediaType::Photo, $folder->getMediaType());
+    }
+
+    public function testUpdateFolderThrowsIfSelfParent(): void
+    {
+        $owner  = new User('owner@example.com', 'Owner');
+        $folder = new Folder('my-folder', $owner);
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->service->updateFolder($folder, '', null, true, $folder);
+    }
+
+    public function testUpdateFolderThrowsOnCycleDetected(): void
+    {
+        $owner  = new User('owner@example.com', 'Owner');
+        $folder = new Folder('A', $owner);
+        $child  = new Folder('B', $owner, $folder);
+        $this->ownershipChecker->method('isOwner')->willReturn(true);
+        // Simulate: folder appears in child's ancestor chain → cycle
+        $this->folderRepository->method('findAncestorIds')
+            ->willReturn([$folder->getId()->toRfc4122()]);
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->service->updateFolder($folder, '', null, true, $child);
+    }
+
+    public function testUpdateFolderMovesToRoot(): void
+    {
+        $owner  = new User('owner@example.com', 'Owner');
+        $parent = new Folder('parent', $owner);
+        $folder = new Folder('child', $owner, $parent);
+        $this->em->expects($this->once())->method('flush');
+
+        $this->service->updateFolder($folder, '', null, true, null);
+        $this->assertNull($folder->getParent());
+    }
+
+    public function testUpdateFolderFlushesOnSuccess(): void
+    {
+        $owner  = new User('owner@example.com', 'Owner');
+        $folder = new Folder('folder', $owner);
+        $this->em->expects($this->once())->method('flush');
+
+        $this->service->updateFolder($folder, '', null, false, null);
+    }
+
+    // ─── deleteFolder ────────────────────────────────────────────────────────
+
+    public function testDeleteFolderChecksOwnership(): void
+    {
+        $owner  = new User('owner@example.com', 'Owner');
+        $folder = new Folder('to-delete', $owner);
+        $this->ownershipChecker->expects($this->once())->method('denyUnlessOwner')->with($folder);
+        $this->em->method('remove');
+        $this->em->method('flush');
+
+        $this->service->deleteFolder($folder, true);
+    }
+
+    public function testDeleteFolderWithContentsRemovesDirectly(): void
+    {
+        $owner  = new User('owner@example.com', 'Owner');
+        $folder = new Folder('to-delete', $owner);
+        $this->em->expects($this->once())->method('remove')->with($folder);
+        $this->em->expects($this->atLeast(1))->method('flush');
+
+        $this->service->deleteFolder($folder, true);
+    }
+
+    public function testDeleteFolderWithoutContentsMovesFilesFirst(): void
+    {
+        $owner   = new User('owner@example.com', 'Owner');
+        $folder  = new Folder('to-delete', $owner);
+        $uploads = new Folder('Uploads', $owner);
+        $file    = new File('doc.txt', 'text/plain', 100, 'path/doc.txt', $folder, $owner);
+        $folder->getFiles()->add($file);
+
+        $this->authResolver->method('getAuthenticatedUser')->willReturn($owner);
+        $this->defaultFolderService->expects($this->once())->method('resolve')->willReturn($uploads);
+        $this->folderRepository->method('findDescendantIds')->willReturn([]);
+        $this->folderRepository->method('find')->willReturn(null);
+        $this->em->expects($this->atLeast(2))->method('flush');
+
+        $this->service->deleteFolder($folder, false);
+
+        $this->assertSame($uploads, $file->getFolder());
+    }
+}


### PR DESCRIPTION
## Contexte

Vague 3 du plan SOLID/KISS/DRY : `FolderProcessor` violait le SRP en mélangeant dispatch HTTP, validation, ownership, persistance et logging (~260 lignes).

## Changements

### Nouvelles interfaces DIP
- `FilenameValidatorInterface`
- `OwnershipCheckerInterface`
- `AuthenticationResolverInterface`

Les 3 services implémentent leurs interfaces — testabilité complète par mock.

### FolderService (nouveau)
Contient toute la logique métier extraite de `FolderProcessor` :
- `createFolder` : validation nom, unicité, persist
- `updateFolder` : ownership, rename, mediaType, déplacement + détection de cycle
- `deleteFolder` : ownership, suppression avec/sans migration des fichiers

### FolderProcessor (simplifié)
Réduit à un pur dispatcher HTTP → domaine :
- Résout les entités (owner, parent) depuis IDs/IRIs
- Parse le body JSON (deleteContents, parentId)
- Délègue à `FolderService`
- Retourne le DTO
- 6 dépendances supprimées (EntityManager, AuthResolver, Logger, DefaultFolderService, FilenameValidator, OwnershipChecker)

## Tests
- ✅ 14 nouveaux tests unitaires `FolderServiceTest` (TDD RED→GREEN)
- ✅ 301/301 tests passent (dont tous les tests fonctionnels API FolderTest)

## Commits
- `✅ test(FolderServiceTest): RED → tests unitaires FolderService + interfaces DIP`
- `✨ feat(FolderService): extraction logique métier depuis FolderProcessor (SRP)`
- `♻️ refactor(FolderProcessor): simplification — pur dispatcher HTTP→FolderService`