### PR TITLE
🛠️ chore(Interface): centralisation de toutes les interfaces dans src/Interface/

### DIFF
--- a/src/Controller/ResetPasswordController.php
+++ b/src/Controller/ResetPasswordController.php
@@ -24,7 +24,7 @@ class ResetPasswordController extends AbstractController
     public function __construct(
         private ResetPasswordHelperInterface $resetPasswordHelper,
         private EntityManagerInterface $entityManager,
-        private \App\Service\PasswordResetServiceInterface $passwordResetService,
+        private \App\Interface\PasswordResetServiceInterface $passwordResetService,
     ) {}
 
     #[Route('/reset-password', name: 'web_reset_password', methods: ['GET'])]

--- a/src/Controller/Web/FolderWebController.php
+++ b/src/Controller/Web/FolderWebController.php
@@ -6,7 +6,7 @@ namespace App\Controller\Web;
 
 use App\Entity\Folder;
 use App\Interface\DefaultFolderServiceInterface;
-use App\Service\FolderMoverInterface;
+use App\Interface\FolderMoverInterface;
 use App\Repository\FolderRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -30,7 +30,7 @@ final class FolderWebController extends AbstractController
         private readonly FolderRepository $folderRepository,
         private readonly DefaultFolderServiceInterface $defaultFolderService,
         private readonly EntityManagerInterface $em,
-        private readonly \App\Service\FolderMoverInterface $folderMover,
+        private readonly \App\Interface\FolderMoverInterface $folderMover,
     ) {}
 
     #[Route('/folders/{id}/delete', name: 'app_folder_delete', methods: ['POST'])]

--- a/src/Interface/FolderMoverInterface.php
+++ b/src/Interface/FolderMoverInterface.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace App\Service;
+declare(strict_types=1);
+
+namespace App\Interface;
 
 use App\Entity\Folder;
 use App\Entity\User;

--- a/src/Interface/PasswordResetServiceInterface.php
+++ b/src/Interface/PasswordResetServiceInterface.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace App\Service;
+declare(strict_types=1);
+
+namespace App\Interface;
 
 interface PasswordResetServiceInterface
 {

--- a/src/Service/FolderMover.php
+++ b/src/Service/FolderMover.php
@@ -10,7 +10,7 @@ use App\Interface\DefaultFolderServiceInterface;
 use App\Repository\FolderRepository;
 use Doctrine\ORM\EntityManagerInterface;
 
-final class FolderMover implements \App\Service\FolderMoverInterface
+final class FolderMover implements \App\Interface\FolderMoverInterface
 {
     public function __construct(
         private readonly FolderRepository $folderRepository,

--- a/src/Service/PasswordResetService.php
+++ b/src/Service/PasswordResetService.php
@@ -7,6 +7,8 @@ use Doctrine\ORM\EntityManagerInterface;
 use SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordExceptionInterface;
 use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
 
+use App\Interface\PasswordResetServiceInterface;
+
 class PasswordResetService implements PasswordResetServiceInterface
 {
     public function __construct(

--- a/tests/Integration/FolderMoverIntegrationTest.php
+++ b/tests/Integration/FolderMoverIntegrationTest.php
@@ -8,7 +8,7 @@ use App\Entity\File;
 use App\Entity\Folder;
 use App\Entity\User;
 use App\Interface\DefaultFolderServiceInterface;
-use App\Service\FolderMoverInterface;
+use App\Interface\FolderMoverInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class FolderMoverIntegrationTest extends KernelTestCase

--- a/tests/Unit/Service/FolderMoverTest.php
+++ b/tests/Unit/Service/FolderMoverTest.php
@@ -9,7 +9,7 @@ use App\Entity\Folder;
 use App\Entity\User;
 use App\Interface\DefaultFolderServiceInterface;
 use App\Repository\FolderRepository;
-use App\Service\FolderMoverInterface;
+use App\Interface\FolderMoverInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
## Contexte

Les interfaces `FolderMoverInterface` et `PasswordResetServiceInterface` étaient orphelines dans `src/Service/` au lieu du dossier dédié `src/Interface/`.

## Changements
- `src/Service/FolderMoverInterface.php` → `src/Interface/FolderMoverInterface.php`
- `src/Service/PasswordResetServiceInterface.php` → `src/Interface/PasswordResetServiceInterface.php`
- Namespace mis à jour : `App\Service` → `App\Interface`
- 5 usages mis à jour : `FolderMover`, `PasswordResetService`, `FolderWebController`, `ResetPasswordController`, tests

## Tests
✅ 301/301 passent