### PR TITLE
♻️ refactor(ExceptionStyle): uniformisation des exceptions HTTP

### DIFF
--- a/src/Controller/Web/AlbumWebController.php
+++ b/src/Controller/Web/AlbumWebController.php
@@ -11,7 +11,6 @@ use App\Service\AlbumService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Uid\Uuid;
@@ -44,13 +43,9 @@ final class AlbumWebController extends AbstractController
     {
         $name = (string) $request->request->get('name', '');
 
-        try {
-            /** @var User $user */
-            $user = $this->getUser();
-            $album = $this->albumService->create($name, $user);
-        } catch (\InvalidArgumentException $e) {
-            throw new BadRequestHttpException($e->getMessage(), $e);
-        }
+        /** @var User $user */
+        $user  = $this->getUser();
+        $album = $this->albumService->create($name, $user);
 
         return $this->redirectToRoute('app_album_detail', ['id' => $album->getId()->toRfc4122()]);
     }

--- a/src/Interface/DefaultFolderServiceInterface.php
+++ b/src/Interface/DefaultFolderServiceInterface.php
@@ -21,7 +21,7 @@ interface DefaultFolderServiceInterface
      *   2. $newFolderName fourni → crée un nouveau dossier
      *   3. Aucun → retourne/crée le dossier système "Uploads"
      *
-     * @throws \InvalidArgumentException si le folderId n'existe pas ou n'appartient pas à $owner
+     * @throws \Symfony\Component\HttpKernel\Exception\BadRequestHttpException si le folderId n'existe pas ou n'appartient pas à $owner
      */
     public function resolve(?string $folderId, ?string $newFolderName, User $owner): Folder;
 }

--- a/src/Service/AlbumService.php
+++ b/src/Service/AlbumService.php
@@ -7,6 +7,7 @@ namespace App\Service;
 use App\Entity\Album;
 use App\Entity\User;
 use App\Interface\AlbumRepositoryInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * Service métier pour la gestion des albums (SRP).
@@ -24,13 +25,13 @@ final class AlbumService
     /**
      * Crée un nouvel album pour l'utilisateur donné.
      *
-     * @throws \InvalidArgumentException si le nom est vide ou uniquement des espaces
+     * @throws BadRequestHttpException si le nom est vide ou uniquement des espaces
      */
     public function create(string $name, User $owner): Album
     {
         $name = trim($name);
         if ($name === '') {
-            throw new \InvalidArgumentException('Le nom de l\'album est obligatoire.');
+            throw new BadRequestHttpException('Le nom de l\'album est obligatoire.');
         }
 
         $album = new Album($name, $owner);

--- a/src/Service/DefaultFolderService.php
+++ b/src/Service/DefaultFolderService.php
@@ -9,6 +9,7 @@ use App\Entity\User;
 use App\Interface\DefaultFolderServiceInterface;
 use App\Repository\FolderRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * Résout le dossier de destination d'un fichier uploadé.
@@ -37,18 +38,18 @@ final class DefaultFolderService implements DefaultFolderServiceInterface
      *   newFolderName fourni → crée un nouveau Folder
      *   aucun → retourne (ou crée) le folder "Uploads"
      *
-     * @throws \InvalidArgumentException si folderId est fourni mais introuvable
+     * @throws BadRequestHttpException si folderId est fourni mais introuvable
      */
     public function resolve(?string $folderId, ?string $newFolderName, User $owner): Folder
     {
         if ($folderId !== null && $folderId !== '') {
             $folder = $this->folderRepository->find($folderId);
             if ($folder === null) {
-                throw new \InvalidArgumentException(sprintf('Folder "%s" not found', $folderId));
+                throw new BadRequestHttpException(sprintf('Folder "%s" not found', $folderId));
             }
             // Vérifier que le folder appartient bien à l'owner — empêche l'accès cross-user
             if ((string) $folder->getOwner()->getId() !== (string) $owner->getId()) {
-                throw new \InvalidArgumentException(sprintf('Folder "%s" not found', $folderId));
+                throw new BadRequestHttpException(sprintf('Folder "%s" not found', $folderId));
             }
 
             return $folder;
@@ -57,10 +58,10 @@ final class DefaultFolderService implements DefaultFolderServiceInterface
         if ($newFolderName !== null && $newFolderName !== '') {
             $trimmed = trim($newFolderName);
             if ($trimmed === '') {
-                throw new \InvalidArgumentException('newFolderName cannot be blank');
+                throw new BadRequestHttpException('newFolderName cannot be blank');
             }
             if (mb_strlen($trimmed) > 255) {
-                throw new \InvalidArgumentException('newFolderName must not exceed 255 characters');
+                throw new BadRequestHttpException('newFolderName must not exceed 255 characters');
             }
             $folder = new Folder($trimmed, $owner);
             $this->em->persist($folder);
@@ -152,11 +153,11 @@ final class DefaultFolderService implements DefaultFolderServiceInterface
                 continue;
             }
             if (mb_strlen($seg) > 255) {
-                throw new \InvalidArgumentException('Folder name segment too long');
+                throw new BadRequestHttpException('Folder name segment too long');
             }
             // Basic sanitization: disallow NUL bytes
             if (strpos($seg, "\0") !== false) {
-                throw new \InvalidArgumentException('Invalid characters in folder name');
+                throw new BadRequestHttpException('Invalid characters in folder name');
             }
             $segments[] = $seg;
         }

--- a/tests/Service/AlbumServiceTest.php
+++ b/tests/Service/AlbumServiceTest.php
@@ -10,6 +10,7 @@ use App\Interface\AlbumRepositoryInterface;
 use App\Service\AlbumService;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * Tests unitaires AlbumService — SRP : création et suppression d'albums.
@@ -72,7 +73,7 @@ final class AlbumServiceTest extends TestCase
         $user = $this->makeUser();
         $this->repository->expects($this->never())->method('save');
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(BadRequestHttpException::class);
         $this->expectExceptionMessage('nom');
 
         $this->service->create('', $user);
@@ -83,7 +84,7 @@ final class AlbumServiceTest extends TestCase
         $user = $this->makeUser();
         $this->repository->expects($this->never())->method('save');
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(BadRequestHttpException::class);
 
         $this->service->create('   ', $user);
     }

--- a/tests/Unit/Service/DefaultFolderServiceTest.php
+++ b/tests/Unit/Service/DefaultFolderServiceTest.php
@@ -10,6 +10,7 @@ use App\Repository\FolderRepository;
 use App\Service\DefaultFolderService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 final class DefaultFolderServiceTest extends TestCase
 {
@@ -90,7 +91,7 @@ final class DefaultFolderServiceTest extends TestCase
 
     public function testResolveWithFolderIdBelongingToAnotherOwnerThrows(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(BadRequestHttpException::class);
 
         $owner = new User('owner-a@example.com', 'A');
         $other = new User('owner-b@example.com', 'B');


### PR DESCRIPTION
## Contexte

`mn-exception-style` du plan SOLID : uniformisation de la convention d'exception.
Les services lançaient `\InvalidArgumentException` (PHP domain), alors que le projet utilise `BadRequestHttpException` (Symfony HTTP) partout ailleurs.

## Changements

### Services mis à jour
- `DefaultFolderService` — 5 throws remplacés
- `AlbumService` — 1 throw remplacé

### Interface mise à jour
- `DefaultFolderServiceInterface` — @throws mis à jour

### Controller simplifié
- `AlbumWebController::create()` — suppression du try/catch bridge (inutile : `BadRequestHttpException` se propage automatiquement via Symfony)

### Tests mis à jour
- `AlbumServiceTest` — 2 `expectException`
- `DefaultFolderServiceTest` — 1 `expectException`

> Note : `FileProvider.php` conserve son `catch (\InvalidArgumentException)` car il capture une exception de `Uuid::fromString()` (bibliothèque tierce, hors scope).

## Tests
✅ 301/301 passent