### PR TITLE
🔧 fix(FolderTreeFactory): suppression code de dev (toto/tata)

### DIFF
--- a/src/Controller/FolderBrowserController.php
+++ b/src/Controller/FolderBrowserController.php
@@ -31,8 +31,8 @@ class FolderBrowserController extends AbstractController
     #[Route('/web/folders', name: 'web_folders')]
     public function index(FolderRepository $folderRepository, UserRepository $userRepository, FolderTreeService $treeService, \App\Factory\FolderTreeFactory $treeFactory): Response
     {
-        // Utilisation du service factory pour garantir la racine et les enfants par défaut
-        $root = $treeFactory->ensureDefaultTree();
+        // Crée le dossier racine si absent (premier accès)
+        $treeFactory->ensureDefaultTree();
 
         // On récupère uniquement les dossiers racines (parent null)
         $rootFolders = $folderRepository->findBy(['parent' => null]);

--- a/src/Factory/FolderTreeFactory.php
+++ b/src/Factory/FolderTreeFactory.php
@@ -21,8 +21,8 @@ class FolderTreeFactory
     ) {}
 
     /**
-     * Crée la racine et les enfants par défaut si besoin.
-     * Retourne le dossier racine.
+     * Crée le dossier racine "Dossiers" s'il n'existe pas encore pour le premier utilisateur.
+     * Utilisé uniquement au premier affichage du navigateur de dossiers.
      */
     public function ensureDefaultTree(): ?Folder
     {
@@ -32,21 +32,6 @@ class FolderTreeFactory
             if ($user) {
                 $root = new Folder('Dossiers', $user, null);
                 $this->em->persist($root);
-                $this->em->flush();
-            }
-        }
-
-        if ($root && $root->getChildren()->count() === 0) {
-            $toto = $this->folderRepository->findOneBy(['name' => 'toto', 'parent' => $root]);
-            if (!$toto) {
-                $toto = new Folder('toto', $root->getOwner(), $root);
-                $this->em->persist($toto);
-                $this->em->flush();
-            }
-            $tata = $this->folderRepository->findOneBy(['name' => 'tata', 'parent' => $toto]);
-            if (!$tata) {
-                $tata = new Folder('tata', $toto->getOwner(), $toto);
-                $this->em->persist($tata);
                 $this->em->flush();
             }
         }


### PR DESCRIPTION
La méthode `ensureDefaultTree()` créait automatiquement des dossiers `toto` et `tata` si la racine était vide — du scaffolding de développement qui ne devait pas survivre en prod.\n\n**Changements :**\n- Suppression du bloc `if ($root->getChildren()->count() === 0)` et des créations `toto`/`tata`\n- Nettoyage de `$root` (variable non utilisée dans le controller)\n\n✅ 301/301 tests passent