### PR TITLE
🏭 ci(deploy.yml): déclenchement automatique après CI success sur main

### DIFF
--- a/.github/avancement.md
+++ b/.github/avancement.md
@@ -1,8 +1,8 @@
 # 📋 Avancement — HomeCloud API
 
-> Dernière mise à jour : 2026-03-24
+> Dernière mise à jour : 2026-03-26
 
-> **Status git :** `main` — tout mergé, 301 tests ✅
+> **Status git :** `main` — tout mergé, 312 tests ✅
 
 ---
 
@@ -43,9 +43,9 @@ src/
 
 ---
 
-## ✅ Audit Sécurité — TERMINÉ (2026-03-24)
+## ✅ Audit Sécurité — TERMINÉ (2026-03-26)
 
-Score global : **8/10** — aucun point critique détecté.
+Score global : **9/10** — 4/5 axes de remédiation implémentés.
 
 | Point audité | Résultat |
 |---|---|
@@ -56,13 +56,18 @@ Score global : **8/10** — aucun point critique détecté.
 | CORS (regex serrée en prod) | ✅ OK |
 | Security Headers (CSP, X-Frame-Options…) | ✅ OK |
 | SQL injection (QueryBuilder paramétrisé) | ✅ OK |
-| Rate limiting sur /api/v1/auth/login | ❌ À faire |
-| Auth failure logging | ⚠️ À améliorer |
-| HSTS header | ⚠️ À faire |
-| `composer audit` en CI | ⚠️ À faire |
-| Assert sur DTOs | ⚠️ Basse priorité |
+| Rate limiting sur /api/v1/auth/login | ✅ Fait (PR #146 — 5 req / 15 min, HTTP 429) |
+| Auth failure logging | ✅ Fait (PR #146 — email, IP, user-agent) |
+| HSTS header | ✅ Fait (PR #146 — prod uniquement, max-age=31536000) |
+| `composer audit` en CI | ✅ Fait (PR #147 — step avant les tests) |
+| Assert sur DTOs | ⚠️ Basse priorité — reste à faire |
 
-→ Plan de remédiation : `.github/todo-security.md`
+### CI/CD — Node.js 24
+
+- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` ajouté (PR #147)
+- `node-version` mis à jour vers `22` (LTS)
+
+→ Détail des tâches restantes : `.github/todo-security.md`
 
 ---
 
@@ -76,7 +81,7 @@ Score global : **8/10** — aucun point critique détecté.
 
 ## 📊 État des tests
 
-- **301 tests**, 633 assertions
+- **312 tests**, 659 assertions
 - 1 skipped (test d'intégration Stopwatch conditionnel)
 - 0 failures, 0 errors
 
@@ -85,4 +90,9 @@ Score global : **8/10** — aucun point critique détecté.
 ## 🗺️ Prochaines pistes
 
 Voir `.github/todo-api-features.md` et `.github/todo-user-settings.md` pour les fonctionnalités restantes.
+
+### Priorité suggérée
+1. **Assert sur DTOs** (clôture sécurité — priorité basse) → `.github/todo-security.md`
+2. **API Features** PATCH/DELETE Folder, File, User + pagination → `.github/todo-api-features.md`
+3. **Page paramètres utilisateur** (email, mot de passe) → `.github/todo-user-settings.md`
 

--- a/.github/avancement.md
+++ b/.github/avancement.md
@@ -87,6 +87,20 @@ Score global : **9/10** — 4/5 axes de remédiation implémentés.
 
 ---
 
+## ✅ CI/CD — Pipeline complet (2026-03-26)
+
+| Étape | Workflow | Déclencheur |
+|-------|----------|-------------|
+| Tests PHP (PHPUnit + MariaDB) | `CI/php` | push / PR sur `main` |
+| Tests JS (Jest) | `CI/js` | push / PR sur `main` |
+| Audit dépendances | `CI` → `composer audit` | push / PR sur `main` |
+| Déploiement auto | `Deploy` | CI ✅ sur `main` |
+| Déploiement manuel | `Deploy` | `workflow_dispatch` |
+
+→ Tout merge dans `main` avec CI verte déclenche automatiquement le déploiement sur `ronan.lenouvel.me`.
+
+---
+
 ## 🗺️ Prochaines pistes
 
 Voir `.github/todo-api-features.md` et `.github/todo-user-settings.md` pour les fonctionnalités restantes.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,10 @@
 name: Deploy
 
 on:
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main]
+    types: [completed]
   workflow_dispatch:
     inputs:
       environment:
@@ -19,7 +23,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: production
-
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: 📥 Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## 🚀 CD automatique

Déclenche le workflow `Deploy` automatiquement dès que `CI` passe sur `main`.

### Changements
- Ajout du trigger `workflow_run` sur `CI` (branche `main`, type `completed`)
- Condition `if` sur le job : deploy uniquement si CI a réussi **ou** si c'est un déclenchement manuel (`workflow_dispatch`)

### Comportement
| Événement | Résultat |
|-----------|---------|
| Push sur `main` → CI ✅ | Deploy automatique |
| Push sur `main` → CI ❌ | Pas de deploy |
| Déclenchement manuel | Deploy (comme avant) |