### PR TITLE
🔧 fix(deploy.yml): forcer HTTP/1.1 pour le webhook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
           PAYLOAD='{"ref":"refs/heads/main"}'
           SIGNATURE="sha256=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | awk '{print $2}')"
 
-          RESPONSE=$(curl -s -o /tmp/deploy_response.txt -w "%{http_code}" \
+          RESPONSE=$(curl -s --http1.1 -o /tmp/deploy_response.txt -w "%{http_code}" \
             -X POST "$WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             -H "X-Hub-Signature-256: $SIGNATURE" \


### PR DESCRIPTION
## Résumé

- Ajout de `--http1.1` au curl du webhook de déploiement
- Corrige l'exit code 92 (`CURLE_HTTP2_STREAM`) qui faisait échouer le job `deploy`

## Plan de test

- [ ] CI verte
- [ ] Job `deploy` passe sans erreur curl
- [ ] `ronan.lenouvel.me` mis à jour après merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)