### PR TITLE
🔧 fix(deploy.yml): retirer --http1.1, le serveur impose HTTP/2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
           SIGNATURE="sha256=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | awk '{print $2}')"
 
           CURL_EXIT=0
-          RESPONSE=$(curl -s --http1.1 -o /tmp/deploy_response.txt -w "%{http_code}" \
+          RESPONSE=$(curl -s -o /tmp/deploy_response.txt -w "%{http_code}" \
             -X POST "$WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             -H "X-Hub-Signature-256: $SIGNATURE" \


### PR DESCRIPTION
## Résumé

- Suppression du flag `--http1.1` qui causait l'exit 56
- Le serveur o2switch négocie HTTP/2 via ALPN (`h2`) — forcer HTTP/1.1 provoquait un conflit de protocole
- La vraie cause du code 92 initial était l'absence de `public/deploy.php` sur le serveur (maintenant uploadé)

## Plan de test

- [ ] CI verte
- [ ] Job deploy passe avec HTTP 200
- [ ] `ronan.lenouvel.me` mis à jour

🤖 Generated with [Claude Code](https://claude.com/claude-code)