### PR TITLE
🔧 fix(deploy): ignorer les pushs hors branche main

### DIFF
--- a/public/deploy.php
+++ b/public/deploy.php
@@ -42,6 +42,13 @@ if (!hash_equals($expected, $signature)) {
     exit('Invalid signature');
 }
 
+// ── Vérification de la branche ───────────────────────────────────────────────
+$data = json_decode($payload, true);
+if (($data['ref'] ?? '') !== 'refs/heads/main') {
+    http_response_code(200);
+    exit('Skipped: not main branch');
+}
+
 // ── Déploiement ───────────────────────────────────────────────────────────────
 $projectDir = dirname(__DIR__);
 $logFile    = $projectDir . '/var/log/deploy.log';


### PR DESCRIPTION
## Résumé

- Ajout d'une vérification du champ `ref` dans le payload JSON
- Si le push n'est pas sur `main`, retourne HTTP 200 avec `Skipped: not main branch`
- Compatible avec le webhook natif GitHub (même format de payload)

## Contexte

Le déploiement passe désormais par le **webhook natif GitHub** (Settings → Webhooks) plutôt que GitHub Actions, pour contourner le blocage des IPs Azure par o2switch.

## Plan de test

- [ ] CI verte
- [ ] Configurer le webhook GitHub : payload URL = `https://ronan.lenouvel.me/deploy.php`, secret = `DEPLOY_WEBHOOK_SECRET`
- [ ] Vérifier qu'un push sur `main` déclenche le déploiement
- [ ] Vérifier qu'un push sur une autre branche retourne 200 Skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)