### PR TITLE
⏪ revert(base): retirer le fond rouge de test

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -8,7 +8,7 @@
         {{ importmap('app') }}
         {% block stylesheets %}{% endblock %}
     </head>
-    <body class="bg-red-500 text-gray-900 dark:text-slate-100 min-h-screen transition-colors">
+    <body class="bg-gray-50 dark:bg-slate-900 text-gray-900 dark:text-slate-100 min-h-screen transition-colors">
         {# SVG filters (Liquid Glass) #}
         <svg class="hidden" xmlns="http://www.w3.org/2000/svg">
             <defs>


### PR DESCRIPTION
Revert du fond rouge utilisé pour valider le pipeline de déploiement SSH.