### PR TITLE
🏭 ci(deploy): script multi-instances et guide déploiement o2switch

### DIFF
--- a/.claude/deploiement.md
+++ b/.claude/deploiement.md
@@ -1,0 +1,166 @@
+# Déploiement HomeCloud — Guide opérationnel
+
+Cible : hébergement mutualisé **o2switch**, un sous-domaine par instance (`<prenom>.lenouvel.me`).
+
+---
+
+## Méthode de déploiement
+
+SSH depuis la machine locale via les scripts `bin/`.
+
+> Le déploiement automatique GitHub Actions (webhook) ne fonctionne **pas** sur o2switch — les IPs Microsoft Azure (GitHub Actions) sont bloquées par le firewall. Les scripts SSH sont la seule méthode fiable.
+
+---
+
+## Déploiement multi-instances — `bin/deploy-all.sh`
+
+Script principal de production. Déploie sur toutes les instances listées dans `.deploy-targets`.
+
+### Prérequis
+
+**`.deploy-targets`** — à la racine, non versionné, un prénom par ligne :
+
+```text
+ronan
+alice
+# bob    ← commenté = ignoré
+```
+
+**`.secrets`** — variables globales SSH :
+
+```bash
+SSH_KEY_PATH=/home/ronan/.ssh/o2switch
+```
+
+**`.secrets.<prenom>`** — par instance, uniquement pour `--init` :
+
+```bash
+DB_PASSWORD_PRESET=<mot de passe MySQL de l'instance>
+```
+
+### Mise à jour de toutes les instances
+
+Après chaque merge sur `main` :
+
+```bash
+bash bin/deploy-all.sh
+```
+
+Chaîne exécutée sur chaque serveur :
+`git pull` → `composer install --no-dev` → `cache:clear` → `migrations` → `asset-map:compile`
+
+### Premier déploiement de toutes les instances
+
+```bash
+bash bin/deploy-all.sh --init
+```
+
+Pour chaque prénom dans `.deploy-targets` :
+
+1. Charge `.secrets.<prenom>` (DB_PASSWORD_PRESET requis)
+2. Génère `APP_SECRET` et `JWT_PASSPHRASE` localement
+3. Clone le repo sur le serveur
+4. Crée `.env.local` avec toutes les variables
+5. Lance `composer install`, `cache:clear`, `migrations`, `lexik:jwt:generate-keypair`, `asset-map:compile`
+
+> Après `--init`, créer le premier utilisateur manuellement en SSH (voir section ci-dessous).
+
+---
+
+## Déploiement ciblé — `bin/deploy.sh`
+
+Pour une instance spécifique (beta, test, ou nouvelle instance en solo) :
+
+```bash
+bash bin/deploy.sh           # premier déploiement interactif
+bash bin/deploy.sh --update  # mise à jour d'une seule instance
+```
+
+---
+
+## Prérequis cPanel — nouvelle instance
+
+À faire une seule fois par sous-domaine dans cPanel avant tout déploiement.
+
+### a) Créer le sous-domaine
+
+- cPanel → Domaines → Sous-domaines
+- Sous-domaine : `<prenom>`, domaine : `lenouvel.me`
+- Chemin racine : `/<prenom>.lenouvel.me`
+
+### b) Créer la base de données MySQL
+
+- cPanel → Bases de données MySQL
+- Base : `ron2cuba_<prenom>` (préfixe imposé par o2switch)
+- Utilisateur : `ron2cuba_<prenom>`
+- Mot de passe : à noter dans `.secrets.<prenom>`
+- Affecter l'utilisateur à la base avec tous les droits
+
+### c) Autoriser l'IP SSH
+
+- cPanel → Sécurité → Accès SSH → Autorisation SSH
+- Ajouter ton IP (entrante + sortante, port 22)
+- Vérifier ton IP : `curl ifconfig.me`
+
+### d) Clé SSH autorisée
+
+- cPanel → Sécurité → Accès SSH → Gérer les clés
+- La clé `o2switch-homecloud` doit être présente et `authorized`
+- Clé privée locale : `~/.ssh/o2switch`
+
+---
+
+## Étapes manuelles post-déploiement initial
+
+Après `--init` ou `bin/deploy.sh`, **en SSH** :
+
+```bash
+ssh -i ~/.ssh/o2switch ron2cuba@lenouvel.me
+cd /home9/ron2cuba/<prenom>.lenouvel.me
+
+# Créer le premier utilisateur admin
+php bin/console app:create-user '<email>' '<password>' <prenom> --env=prod
+```
+
+> `lexik:jwt:generate-keypair` et `asset-map:compile` sont déjà gérés par les scripts.
+
+---
+
+## Chemins importants sur o2switch
+
+| Ressource   | Chemin                                                      |
+|-------------|-------------------------------------------------------------|
+| Composer    | `/usr/local/bin/composer`                                   |
+| PHP         | `/usr/local/bin/php`                                        |
+| Projet      | `/home9/ron2cuba/<prenom>.lenouvel.me/`                     |
+| Logs deploy | `/home9/ron2cuba/<prenom>.lenouvel.me/var/log/deploy.log`   |
+| SSH user    | `ron2cuba@lenouvel.me`                                      |
+
+---
+
+## Variables `.env.local` sur le serveur
+
+À créer manuellement sur chaque instance (jamais dans git) :
+
+```bash
+APP_ENV=prod
+APP_SECRET=<généré par le script>
+DATABASE_URL=mysql://ron2cuba_<prenom>:<password>@127.0.0.1:3306/ron2cuba_<prenom>?serverVersion=mariadb-10.6.0&charset=utf8mb4
+JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
+JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
+JWT_PASSPHRASE=
+```
+
+> Généré automatiquement par `bin/deploy-all.sh --init`. Pour `bin/deploy.sh`, le script le crée aussi.
+
+---
+
+## Diagnostic — erreurs fréquentes
+
+| Symptôme                  | Cause                              | Solution                                       |
+|---------------------------|------------------------------------|------------------------------------------------|
+| 500 sur le site           | Assets non compilés                | `php bin/console asset-map:compile`            |
+| 500 sur le site           | `SecRuleEngine` dans `.htaccess`   | Supprimer ce bloc du `.htaccess` serveur       |
+| `git pull` bloqué         | Fichier untracked sur le serveur   | `rm -f <fichier>` puis `git pull`              |
+| DB access denied          | `.env.local` incorrect             | Vérifier `DATABASE_URL` et mot de passe cPanel |
+| SSH refusé                | IP non whitelistée                 | cPanel → Accès SSH → Autorisation SSH          |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Sommaire de référence. Lire avant toute intervention — suivre les liens pour
 | Méthodologie TDD             | [.claude/tdd.md](.claude/tdd.md)                         |
 | Design frontend              | [.claude/frontend.md](.claude/frontend.md)               |
 | CI/CD, déploiement, suivi    | [.claude/cicd.md](.claude/cicd.md)                       |
+| Guide déploiement o2switch   | [.claude/deploiement.md](.claude/deploiement.md)         |
 
 ---
 

--- a/bin/deploy-all.sh
+++ b/bin/deploy-all.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# =============================================================================
+# HomeCloud — Déploiement multi-instances sur o2switch
+# Usage :
+#   bash bin/deploy-all.sh           → Mise à jour de tous les targets (.deploy-targets)
+#   bash bin/deploy-all.sh --init    → Premier déploiement de tous les targets
+# =============================================================================
+
+set -euo pipefail
+
+# ── Chargement des secrets globaux ────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${SCRIPT_DIR}/.."
+SECRETS_FILE="${ROOT_DIR}/.secrets"
+if [[ -f "$SECRETS_FILE" ]]; then
+    # shellcheck source=../.secrets
+    source "$SECRETS_FILE"
+fi
+
+# ── Mode ──────────────────────────────────────────────────────────────────────
+INIT_MODE=false
+if [[ "${1:-}" == "--init" ]]; then
+    INIT_MODE=true
+fi
+
+# ── Couleurs ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()    { echo -e "${BLUE}ℹ${NC}  $*"; }
+success() { echo -e "${GREEN}✔${NC}  $*"; }
+warn()    { echo -e "${YELLOW}⚠${NC}  $*"; }
+error()   { echo -e "${RED}✖${NC}  $*" >&2; }
+title()   { echo -e "\n${BOLD}$*${NC}"; }
+
+# ── Configuration fixe ────────────────────────────────────────────────────────
+SSH_USER="ron2cuba"
+SSH_HOST="lenouvel.me"
+SSH_PORT=22
+GIT_REPO="https://github.com/ronan-develop/home-cloud"
+GIT_BRANCH="main"
+PHP_BIN="/usr/local/bin/php"
+COMPOSER_BIN="composer"
+
+SSH_KEY_OPTS=""
+if [[ -n "${SSH_KEY_PATH:-}" && -f "${SSH_KEY_PATH}" ]]; then
+    SSH_KEY_OPTS="-i ${SSH_KEY_PATH}"
+fi
+
+# ── Lecture de .deploy-targets ────────────────────────────────────────────────
+TARGETS_FILE="${ROOT_DIR}/.deploy-targets"
+if [[ ! -f "$TARGETS_FILE" ]]; then
+    error "Fichier .deploy-targets introuvable (${TARGETS_FILE})"
+    error "Crée-le avec un prénom par ligne. Exemple :"
+    error "  ronan"
+    error "  alice"
+    exit 1
+fi
+
+mapfile -t TARGETS < <(grep -v '^\s*#' "$TARGETS_FILE" | grep -v '^\s*$' | tr -d '[:space:]')
+
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+    error "Aucune cible trouvée dans .deploy-targets"
+    exit 1
+fi
+
+# ── Récapitulatif ─────────────────────────────────────────────────────────────
+title "═══════════════════════════════════════════════"
+if [[ "$INIT_MODE" == true ]]; then
+    title "  HomeCloud — Déploiement initial (${#TARGETS[@]} instance(s))"
+else
+    title "  HomeCloud — Mise à jour (${#TARGETS[@]} instance(s))"
+fi
+title "═══════════════════════════════════════════════"
+echo ""
+info "Cibles :"
+for t in "${TARGETS[@]}"; do
+    echo "    • ${t}.lenouvel.me"
+done
+echo ""
+
+# ── Vérification SSH globale ──────────────────────────────────────────────────
+info "Test de connexion SSH vers ${SSH_USER}@${SSH_HOST}…"
+if ! ssh ${SSH_KEY_OPTS} -p "${SSH_PORT}" -o ConnectTimeout=10 "${SSH_USER}@${SSH_HOST}" "echo OK" &>/dev/null; then
+    error "Connexion SSH impossible."
+    error "Vérifiez que votre IP est whitelistée : cPanel → Sécurité → Accès SSH → Autorisation SSH"
+    exit 1
+fi
+success "Connexion SSH OK"
+
+REMOTE_HOME=$(ssh ${SSH_KEY_OPTS} -p "${SSH_PORT}" "${SSH_USER}@${SSH_HOST}" 'echo $HOME')
+
+# ── Suivi des résultats ───────────────────────────────────────────────────────
+declare -a RESULTS_OK=()
+declare -a RESULTS_FAIL=()
+
+# ── Boucle sur les cibles ─────────────────────────────────────────────────────
+for PRENOM in "${TARGETS[@]}"; do
+    SUBDOMAIN="${PRENOM}.lenouvel.me"
+    DEPLOY_PATH="${REMOTE_HOME}/${SUBDOMAIN}"
+
+    title "── ${SUBDOMAIN} ──────────────────────────────────"
+
+    if [[ "$INIT_MODE" == true ]]; then
+        # ── Chargement des secrets par instance ───────────────────────────────
+        INSTANCE_SECRETS="${ROOT_DIR}/.secrets.${PRENOM}"
+        if [[ ! -f "$INSTANCE_SECRETS" ]]; then
+            error "Fichier .secrets.${PRENOM} introuvable — instance ignorée"
+            error "Crée ${INSTANCE_SECRETS} avec DB_PASSWORD_PRESET=<motdepasse>"
+            RESULTS_FAIL+=("$SUBDOMAIN (secrets manquants)")
+            continue
+        fi
+        # shellcheck source=../.secrets.ronan
+        source "$INSTANCE_SECRETS"
+
+        if [[ -z "${DB_PASSWORD_PRESET:-}" ]]; then
+            error "DB_PASSWORD_PRESET absent dans .secrets.${PRENOM} — instance ignorée"
+            RESULTS_FAIL+=("$SUBDOMAIN (DB_PASSWORD_PRESET manquant)")
+            continue
+        fi
+
+        DB_NAME="${SSH_USER}_${PRENOM}"
+        DB_USER="${SSH_USER}_${PRENOM}"
+        DB_PASSWORD="$DB_PASSWORD_PRESET"
+        APP_SECRET=$(php -r "echo bin2hex(random_bytes(16));")
+        JWT_PASSPHRASE=$(php -r "echo bin2hex(random_bytes(24));")
+        DATABASE_URL="mysql://${DB_USER}:${DB_PASSWORD}@127.0.0.1:3306/${DB_NAME}?serverVersion=mariadb-10.6.0&charset=utf8mb4"
+
+        info "Clonage et setup initial…"
+        if ssh ${SSH_KEY_OPTS} -p "${SSH_PORT}" "${SSH_USER}@${SSH_HOST}" "
+            set -e
+            mkdir -p ${DEPLOY_PATH}
+            cd ${DEPLOY_PATH}
+            git clone ${GIT_REPO} .
+            ${COMPOSER_BIN} install --no-interaction --prefer-dist --no-progress --no-dev
+            cat > .env.local <<'ENVEOF'
+APP_ENV=prod
+APP_SECRET=${APP_SECRET}
+DATABASE_URL=${DATABASE_URL}
+JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
+JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
+JWT_PASSPHRASE=${JWT_PASSPHRASE}
+ENVEOF
+            ${PHP_BIN} bin/console cache:clear --env=prod
+            ${PHP_BIN} bin/console doctrine:migrations:migrate --no-interaction --env=prod
+            ${PHP_BIN} bin/console lexik:jwt:generate-keypair --skip-if-exists --env=prod
+            ${PHP_BIN} bin/console asset-map:compile
+        "; then
+            success "${SUBDOMAIN} — déploiement initial OK"
+            RESULTS_OK+=("$SUBDOMAIN")
+        else
+            error "${SUBDOMAIN} — échec"
+            RESULTS_FAIL+=("$SUBDOMAIN")
+        fi
+
+        # Reset pour ne pas polluer l'instance suivante
+        unset DB_PASSWORD_PRESET DB_PASSWORD APP_SECRET JWT_PASSPHRASE DATABASE_URL
+
+    else
+        # ── Mise à jour ───────────────────────────────────────────────────────
+        info "git pull + composer + cache + migrations + assets…"
+        if ssh ${SSH_KEY_OPTS} -p "${SSH_PORT}" "${SSH_USER}@${SSH_HOST}" "
+            set -e
+            cd ${DEPLOY_PATH}
+            git pull origin ${GIT_BRANCH}
+            ${COMPOSER_BIN} install --no-interaction --prefer-dist --no-progress --no-dev
+            ${PHP_BIN} bin/console cache:clear --env=prod
+            ${PHP_BIN} bin/console doctrine:migrations:migrate --no-interaction --env=prod
+            ${PHP_BIN} bin/console asset-map:compile
+        "; then
+            success "${SUBDOMAIN} — mise à jour OK"
+            RESULTS_OK+=("$SUBDOMAIN")
+        else
+            error "${SUBDOMAIN} — échec"
+            RESULTS_FAIL+=("$SUBDOMAIN")
+        fi
+    fi
+done
+
+# ── Récapitulatif final ───────────────────────────────────────────────────────
+title "═══════════════════════════════════════════════"
+title "  Résultat"
+title "═══════════════════════════════════════════════"
+for d in "${RESULTS_OK[@]:-}"; do
+    [[ -n "$d" ]] && echo -e "  ${GREEN}✅${NC}  ${d}"
+done
+for d in "${RESULTS_FAIL[@]:-}"; do
+    [[ -n "$d" ]] && echo -e "  ${RED}❌${NC}  ${d}"
+done
+echo ""
+
+if [[ ${#RESULTS_FAIL[@]} -gt 0 ]]; then
+    exit 1
+fi

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -57,7 +57,7 @@ if [[ -n "${SSH_KEY_PATH:-}" && -f "$SSH_KEY_PATH" ]]; then
 fi
 GIT_BRANCH="main"
 PHP_BIN="/usr/local/bin/php"
-COMPOSER_BIN="/opt/cpanel/composer/bin/composer"
+COMPOSER_BIN="composer"
 
 # ── Questionnaire ─────────────────────────────────────────────────────────────
 title "═══════════════════════════════════════"
@@ -170,8 +170,14 @@ info "Chemin de déploiement : ${DEPLOY_PATH}"
 title "── Déploiement en cours ────────────────────"
 
 if [[ "$UPDATE_MODE" == true ]]; then
-    info "Mode mise à jour : git pull + composer install"
-    ssh ${SSH_KEY_OPTS} -p "${SSH_PORT}" "${SSH_USER}@${SSH_HOST}" "cd ${DEPLOY_PATH} && git pull origin main && composer install --no-interaction --prefer-dist --no-progress" && \
+    info "Mode mise à jour : git pull + composer + cache + migrations + assets"
+    ssh ${SSH_KEY_OPTS} -p "${SSH_PORT}" "${SSH_USER}@${SSH_HOST}" \
+        "cd ${DEPLOY_PATH} && \
+         git pull origin main && \
+         ${COMPOSER_BIN} install --no-interaction --prefer-dist --no-progress --no-dev && \
+         ${PHP_BIN} bin/console cache:clear --env=prod && \
+         ${PHP_BIN} bin/console doctrine:migrations:migrate --no-interaction --env=prod && \
+         ${PHP_BIN} bin/console asset-map:compile" && \
     success "✅ Déploiement réussi !" || \
     { error "❌ Erreur lors du déploiement."; exit 1; }
 else


### PR DESCRIPTION
## Résumé

- Ajout de `bin/deploy-all.sh` — déploiement SSH sur toutes les instances listées dans `.deploy-targets` (`--update` et `--init`)
- Ajout de `.claude/deploiement.md` — guide opérationnel complet (prérequis cPanel, secrets, diagnostic)
- Correction de `bin/deploy.sh` — chemin composer corrigé + chaîne `--update` complétée (`cache:clear`, `migrations`, `asset-map:compile`)
- Référence au guide ajoutée dans `CLAUDE.md`

## Test plan

- [ ] Vérifier que `bin/deploy-all.sh` lit correctement `.deploy-targets`
- [ ] Tester `bin/deploy-all.sh` en mode `--update` sur une instance existante
- [ ] Vérifier que `bin/deploy.sh --update` exécute bien la chaîne complète