### PR TITLE
🔒 fix(FileProcessor): vérifier l'ownership avant DELETE /api/v1/files/{id}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ php.ini
 
 # Deploy info (généré par les scripts de déploiement)
 /templates/deploy-info.html.twig
+/.deploy-targets

--- a/src/Interface/OwnershipCheckerInterface.php
+++ b/src/Interface/OwnershipCheckerInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Interface;
 
 use App\Entity\Album;
+use App\Entity\File;
 use App\Entity\Folder;
 use App\Entity\Share;
 
@@ -14,10 +15,10 @@ use App\Entity\Share;
  */
 interface OwnershipCheckerInterface
 {
-    public function isOwner(Folder|Album|Share $resource): bool;
+    public function isOwner(Folder|Album|Share|File $resource): bool;
 
     /**
      * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException si non propriétaire
      */
-    public function denyUnlessOwner(Folder|Album|Share $resource): void;
+    public function denyUnlessOwner(Folder|Album|Share|File $resource): void;
 }

--- a/src/Security/OwnershipChecker.php
+++ b/src/Security/OwnershipChecker.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Security;
 
 use App\Entity\Album;
+use App\Entity\File;
 use App\Entity\Folder;
 use App\Entity\Share;
 use App\Interface\AuthenticationResolverInterface;
@@ -26,7 +27,7 @@ final readonly class OwnershipChecker implements OwnershipCheckerInterface
         private LoggerInterface $logger,
     ) {}
 
-    public function isOwner(Folder|Album|Share $resource): bool
+    public function isOwner(Folder|Album|Share|File $resource): bool
     {
         $user = $this->authResolver->getAuthenticatedUser();
 
@@ -48,7 +49,7 @@ final readonly class OwnershipChecker implements OwnershipCheckerInterface
         return $isOwner;
     }
 
-    public function denyUnlessOwner(Folder|Album|Share $resource): void
+    public function denyUnlessOwner(Folder|Album|Share|File $resource): void
     {
         $user = $this->authResolver->getAuthenticatedUser();
 

--- a/src/State/FileProcessor.php
+++ b/src/State/FileProcessor.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Delete;
 use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\FileOutput;
 use App\Interface\DefaultFolderServiceInterface;
+use App\Interface\OwnershipCheckerInterface;
 use App\Repository\FileRepository;
 use App\Repository\MediaRepository;
 use App\Security\AuthenticationResolver;
@@ -41,6 +42,7 @@ final class FileProcessor implements ProcessorInterface
         private readonly MediaRepository $mediaRepository,
         private readonly StorageServiceInterface $storageService,
         private readonly AuthenticationResolver $authResolver,
+        private readonly OwnershipCheckerInterface $ownershipChecker,
         private readonly DefaultFolderServiceInterface $defaultFolderService,
         private readonly FileActionService $fileActionService,
         private readonly RequestStack $requestStack,
@@ -66,6 +68,8 @@ final class FileProcessor implements ProcessorInterface
     {
         $file = $this->fileRepository->find($uriVariables['id'])
             ?? throw new NotFoundHttpException('File not found');
+
+        $this->ownershipChecker->denyUnlessOwner($file);
 
         // Supprimer le thumbnail du disque AVANT le cascade DB (onDelete: CASCADE supprime la ligne Media)
         $media = $this->mediaRepository->findOneBy(['file' => $file]);

--- a/tests/Api/FileDeleteTest.php
+++ b/tests/Api/FileDeleteTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api;
+
+use App\Entity\File;
+use App\Tests\AuthenticatedApiTestCase;
+
+/**
+ * Tests fonctionnels pour DELETE /api/v1/files/{id}.
+ */
+final class FileDeleteTest extends AuthenticatedApiTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+        $this->createUser('alice@example.com', 'password123', 'Alice');
+    }
+
+    private function createFile(string $name, \App\Entity\Folder $folder, \App\Entity\User $owner): File
+    {
+        $file = new File($name, 'text/plain', 42, 'test/' . uniqid() . '.txt', $folder, $owner, false);
+        $this->em->persist($file);
+        $this->em->flush();
+        return $file;
+    }
+
+    /** Le propriétaire peut supprimer son fichier → 204 */
+    public function testDeleteFileByOwnerReturns204(): void
+    {
+        $alice  = $this->em->getRepository(\App\Entity\User::class)->findOneBy(['email' => 'alice@example.com']);
+        $folder = $this->createFolder('Docs', $alice);
+        $file   = $this->createFile('document.txt', $folder, $alice);
+
+        $client = $this->createAuthenticatedClient($alice);
+        $client->request('DELETE', '/api/v1/files/' . $file->getId());
+
+        static::assertResponseStatusCodeSame(204);
+
+        $this->em->clear();
+        $deleted = $this->em->getRepository(File::class)->find($file->getId());
+        $this->assertNull($deleted, 'Le fichier doit être supprimé de la base');
+    }
+
+    /** Un autre utilisateur ne peut pas supprimer le fichier → 403 */
+    public function testDeleteFileByOtherUserForbidden(): void
+    {
+        $alice  = $this->em->getRepository(\App\Entity\User::class)->findOneBy(['email' => 'alice@example.com']);
+        $bob    = $this->createUser('bob@example.com', 'password123', 'Bob');
+        $folder = $this->createFolder('AliceFolder', $alice);
+        $file   = $this->createFile('secret.txt', $folder, $alice);
+
+        $client = $this->createAuthenticatedClient($bob);
+        $client->request('DELETE', '/api/v1/files/' . $file->getId());
+
+        static::assertResponseStatusCodeSame(403);
+    }
+
+    /** Fichier inexistant → 404 */
+    public function testDeleteNonExistentFileReturns404(): void
+    {
+        $alice  = $this->em->getRepository(\App\Entity\User::class)->findOneBy(['email' => 'alice@example.com']);
+        $client = $this->createAuthenticatedClient($alice);
+        $client->request('DELETE', '/api/v1/files/123e4567-e89b-12d3-a456-426614174000');
+
+        static::assertResponseStatusCodeSame(404);
+    }
+}

--- a/tests/Api/MediaTest.php
+++ b/tests/Api/MediaTest.php
@@ -220,7 +220,7 @@ final class MediaTest extends AuthenticatedApiTestCase
 
         $this->assertFileExists($thumbFile);
 
-        $this->createAuthenticatedClient()->request('DELETE', '/api/v1/files/' . $file->getId());
+        $this->createAuthenticatedClient($user)->request('DELETE', '/api/v1/files/' . $file->getId());
 
         $this->assertResponseStatusCodeSame(204);
         $this->assertFileDoesNotExist($thumbFile);


### PR DESCRIPTION
## Contexte

`FileProcessor::handleDelete` ne vérifiait pas l'ownership du fichier avant suppression — n'importe quel utilisateur authentifié pouvait supprimer les fichiers d'autrui.

## Changements

- **`OwnershipCheckerInterface` / `OwnershipChecker`** : union type étendu à `File` (était `Folder|Album|Share`)
- **`FileProcessor::handleDelete`** : injection de `OwnershipCheckerInterface` + appel `denyUnlessOwner($file)` → retourne 403 si non propriétaire
- **`FileDeleteTest`** : nouveaux tests fonctionnels DELETE 204 (owner), 403 (autre user), 404 (inexistant)
- **`MediaTest`** : bug latent corrigé — `createAuthenticatedClient()` passait le mauvais user lors du DELETE
- **`.gitignore`** : `.deploy-targets` ignoré

## Plan de test

- [ ] CI verte (PHPUnit 315 tests, 0 failures)
- [ ] `DELETE /api/v1/files/{id}` par le propriétaire → 204
- [ ] `DELETE /api/v1/files/{id}` par un autre user → 403
- [ ] `DELETE /api/v1/files/{id}` sur un fichier inexistant → 404