### PR TITLE
✨ feat(RenameModal): remplacer prompt() par une modale glassmorphism

### DIFF
--- a/assets/js/rename.js
+++ b/assets/js/rename.js
@@ -1,4 +1,7 @@
 import { apiFetch } from './api.js';
+import { Modal } from './modal.js';
+
+const INVALID_CHARS = /[\\/:*?"<>|]/u;
 
 class RenameManager {
 	constructor() {
@@ -11,90 +14,110 @@ class RenameManager {
 
 	async handleClick(e) {
 		const clicked = e.target;
-		const el = (clicked && clicked.closest) ? (clicked.closest('.rename-btn') || clicked.closest('[data-rename-action]') || clicked) : clicked;
+		const el = (clicked && clicked.closest)
+			? (clicked.closest('.rename-btn') || clicked.closest('[data-rename-action]') || clicked)
+			: clicked;
 
-		// folder / file rename buttons (class-based or inline)
 		if (el && el.classList && (el.classList.contains('rename-btn') || el.classList.contains('inline-rename-btn'))) {
 			e.preventDefault(); e.stopPropagation();
-			const id = el.dataset.folderId || el.dataset.fileId || el.dataset.id || el.getAttribute('data-folder-id') || el.getAttribute('data-file-id') || el.getAttribute('data-id');
+			const id = el.dataset.folderId || el.dataset.fileId || el.dataset.id
+				|| el.getAttribute('data-folder-id') || el.getAttribute('data-file-id') || el.getAttribute('data-id');
 			if (!id) return;
 			const current = this._findNameForElement(el) || '';
-			if (el.dataset.fileId || el.getAttribute('data-file-id')) {
-				this.renameFilePrompt(id, current);
-			} else {
-				this.renameFolderPrompt(id, current);
-			}
+			const type = (el.dataset.fileId || el.getAttribute('data-file-id')) ? 'file' : 'folder';
+			openRenameModal(type, id, current);
 			return;
 		}
 
-		// inline rename buttons (data-rename-action)
 		if (el && el.dataset && el.dataset.renameAction) {
 			e.preventDefault(); e.stopPropagation();
-			const type = el.dataset.renameAction; // 'folder' or 'file'
-			const id = el.dataset.id;
+			const type = el.dataset.renameAction;
+			const id   = el.dataset.id;
 			const current = this._findNameForElement(el) || '';
-			if (type === 'folder') this.renameFolderPrompt(id, current);
-			if (type === 'file') this.renameFilePrompt(id, current);
+			openRenameModal(type, id, current);
 		}
 	}
 
 	_findNameForElement(el) {
-		// try to find nearby element with class folder-name or file-name
 		const nameEl = el.closest('.folder-card')?.querySelector('.folder-name, .file-name')
 			|| el.closest('.file-card')?.querySelector('.file-name')
 			|| el.closest('a')?.querySelector('.folder-name')
 			|| null;
 		return nameEl ? nameEl.textContent.trim() : '';
 	}
-
-	async renameFolderPrompt(id, currentName) {
-		const newName = prompt('Renommer le dossier', currentName);
-		if (newName === null) return;
-		const trimmed = newName.trim();
-		if (!trimmed) { alert('Le nom ne peut pas être vide'); return; }
-		if (trimmed.length > 255) { alert('Le nom est trop long (255 caractères max)'); return; }
-		if (!/^[^\\/:*?"<>|]+$/u.test(trimmed)) { alert('Caractères invalides dans le nom'); return; }
-		try {
-			const res = await apiFetch(`/api/v1/folders/${encodeURIComponent(id)}`, {
-				method: 'PATCH',
-				headers: { 'Content-Type': 'application/merge-patch+json' },
-				body: JSON.stringify({ name: trimmed }),
-			});
-			if (!res.ok) {
-				const txt = await res.text();
-				throw new Error(`${res.status}: ${txt}`);
-			}
-			// simple reload for now; UI will be improved later
-			window.location.reload();
-		} catch (err) {
-			console.error('Rename error', err);
-			alert('Erreur lors du renommage: ' + err.message);
-		}
-	}
-
-	async renameFilePrompt(id, currentName) {
-		const newName = prompt('Renommer le fichier', currentName);
-		if (newName === null) return;
-		const trimmed = newName.trim();
-		if (!trimmed) { alert('Le nom ne peut pas être vide'); return; }
-		if (trimmed.length > 255) { alert('Le nom est trop long (255 caractères max)'); return; }
-		try {
-			const res = await apiFetch(`/api/v1/files/${encodeURIComponent(id)}`, {
-				method: 'PATCH',
-				headers: { 'Content-Type': 'application/merge-patch+json' },
-				body: JSON.stringify({ originalName: trimmed }),
-			});
-			if (!res.ok) {
-				const txt = await res.text();
-				throw new Error(`${res.status}: ${txt}`);
-			}
-			window.location.reload();
-		} catch (err) {
-			console.error('Rename file error', err);
-			alert('Erreur lors du renommage du fichier: ' + err.message);
-		}
-	}
 }
+
+window.openRenameModal = function(type, id, currentName) {
+	document.getElementById('rename-entity-type').value = type;
+	document.getElementById('rename-entity-id').value   = id;
+	document.getElementById('rename-modal-title').textContent =
+		(type === 'file' ? 'Renommer le fichier' : 'Renommer le dossier');
+	const input = document.getElementById('rename-input');
+	input.value = currentName;
+	document.getElementById('rename-error').classList.add('hidden');
+	Modal.open('rename-modal');
+	setTimeout(() => { input.focus(); input.select(); }, 50);
+
+	// Soumettre avec Entrée
+	input.onkeydown = function(e) {
+		if (e.key === 'Enter') submitRename();
+		if (e.key === 'Escape') Modal.close('rename-modal');
+	};
+};
+
+window.submitRename = async function() {
+	const type = document.getElementById('rename-entity-type').value;
+	const id   = document.getElementById('rename-entity-id').value;
+	const name = document.getElementById('rename-input').value.trim();
+	const errorEl = document.getElementById('rename-error');
+
+	errorEl.classList.add('hidden');
+
+	if (!name) {
+		errorEl.textContent = 'Le nom ne peut pas être vide.';
+		errorEl.classList.remove('hidden');
+		return;
+	}
+	if (name.length > 255) {
+		errorEl.textContent = 'Le nom est trop long (255 caractères max).';
+		errorEl.classList.remove('hidden');
+		return;
+	}
+	if (INVALID_CHARS.test(name)) {
+		errorEl.textContent = 'Caractères invalides : \\ / : * ? " < > |';
+		errorEl.classList.remove('hidden');
+		return;
+	}
+
+	const btn = document.getElementById('rename-submit-btn');
+	btn.disabled = true;
+
+	const isFile = type === 'file';
+	const url    = isFile ? `/api/v1/files/${encodeURIComponent(id)}` : `/api/v1/folders/${encodeURIComponent(id)}`;
+	const body   = JSON.stringify(isFile ? { originalName: name } : { name });
+
+	try {
+		const res = await apiFetch(url, {
+			method:  'PATCH',
+			headers: { 'Content-Type': 'application/merge-patch+json' },
+			body,
+		});
+		Modal.close('rename-modal');
+		if (res.ok) {
+			showToast('Renommé ✅', 'success');
+			setTimeout(() => window.location.reload(), 800);
+		} else {
+			const err = await res.json().catch(() => ({}));
+			showToast('Erreur : ' + (err.detail || err.message || res.status), 'error');
+		}
+	} catch (err) {
+		Modal.close('rename-modal');
+		showToast('Erreur réseau', 'error');
+		console.error(err);
+	} finally {
+		btn.disabled = false;
+	}
+};
 
 const manager = new RenameManager();
 manager.init();

--- a/templates/components/RenameModal.html.twig
+++ b/templates/components/RenameModal.html.twig
@@ -1,0 +1,44 @@
+{# Modale de renommage — partagée par tous les boutons ✏️ #}
+<div id="rename-modal"
+     class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+     tabindex="-1"
+     aria-modal="true"
+     role="dialog">
+  <div class="bg-white/10 backdrop-blur-2xl border border-white/20 rounded-3xl
+              shadow-2xl p-6 w-full max-w-md mx-4">
+
+    <h2 id="rename-modal-title"
+        class="text-white text-xl font-semibold mb-4">
+      Renommer...
+    </h2>
+
+    <input type="text"
+           id="rename-input"
+           class="w-full px-4 py-2 rounded-xl bg-white/10 border border-white/20
+                  text-white placeholder-white/40 focus:outline-none focus:ring-2
+                  focus:ring-green-400/60 mb-2"
+           maxlength="255"
+           autocomplete="off">
+
+    <p id="rename-error" class="hidden text-red-400 text-sm mb-3"></p>
+
+    <input type="hidden" id="rename-entity-type" value="">
+    <input type="hidden" id="rename-entity-id" value="">
+
+    <div class="flex justify-end gap-3 mt-4">
+      <button type="button"
+              onclick="closeModal('rename-modal')"
+              class="px-4 py-2 rounded-xl text-white/70 hover:text-white hover:bg-white/10 transition-colors">
+        Annuler
+      </button>
+      <button type="button"
+              id="rename-submit-btn"
+              onclick="submitRename()"
+              class="px-4 py-2 rounded-xl bg-green-500 hover:bg-green-400 text-white
+                     font-medium transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+        Renommer
+      </button>
+    </div>
+
+  </div>
+</div>

--- a/templates/web/layout.html.twig
+++ b/templates/web/layout.html.twig
@@ -3,6 +3,7 @@
 {# Modales globales #}
 <twig:MoveModal />
 <twig:DeleteFolderModal />
+<twig:RenameModal />
 
 {% endblock %}
 {% extends 'base.html.twig' %}
@@ -238,30 +239,10 @@
 <script>
 // Global rename helper: adds rename buttons next to folder names in lists and sidebar
 (function () {
-    async function renameFolder(id, currentName) {
-        var newName = prompt('Renommer le dossier', currentName);
-        if (newName === null) return; // cancelled
-        newName = newName.trim();
-        if (!newName) { alert('Le nom ne peut pas être vide'); return; }
-        if (newName.length > 255) { alert('Le nom est trop long (255 caractères max)'); return; }
-        if (!/^[^\\/:*?"<>|]+$/u.test(newName)) { alert('Caractères invalides dans le nom'); return; }
-        try {
-            var token = await HC.getToken();
-            var res = await fetch('/api/v1/folders/' + encodeURIComponent(id), {
-                method: 'PATCH',
-                headers: {
-                    'Authorization': 'Bearer ' + token,
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({ name: newName })
-            });
-            if (res.ok) {
-                window.location.reload();
-            } else {
-                var txt = await res.text();
-                alert('Erreur: ' + res.status + '\n' + txt);
-            }
-        } catch (e) { alert('Erreur réseau: ' + e.message); }
+    function renameFolder(id, currentName) {
+        if (typeof window.openRenameModal === 'function') {
+            window.openRenameModal('folder', id, currentName);
+        }
     }
 
     function attachRenameButtons() {


### PR DESCRIPTION
## Contexte

Le renommage fichiers/dossiers utilisait `prompt()` — dialogue natif du navigateur, incohérent avec les modales glassmorphism existantes (MoveModal, DeleteFolderModal).

## Changements

- **`RenameModal.html.twig`** : nouveau composant Twig, même style que `MoveModal` — input pré-rempli, validation inline, boutons Annuler/Renommer
- **`rename.js`** : `prompt()` et `alert()` remplacés par `openRenameModal()` / `submitRename()` — validation sans dialog natif, toast succès/erreur, soumission via Entrée
- **`layout.html.twig`** : inclusion de `<twig:RenameModal />` + `renameFolder()` du script inline délégué à `openRenameModal()`

## Plan de test

- [ ] CI verte
- [ ] Clic ✏️ sur un fichier → modale s'ouvre avec le nom courant pré-rempli
- [ ] Clic ✏️ sur un dossier → même comportement
- [ ] Valider → toast "Renommé ✅" + page rechargée
- [ ] Annuler → fermeture sans action
- [ ] Nom vide → message d'erreur inline (pas d'alert)
- [ ] Touche Entrée → soumet, Échap → ferme