### PR TITLE
🎨 style(settings): extraire les styles inline en classes CSS dédiées

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -4,6 +4,7 @@
 @import "./layout.css";
 @import "./liquid-glass.css";
 @import "./upload.css";
+@import "./settings.css";
 
 nav .navbar-logo .navbar-logo-cloud {
   text-shadow: -3px 6px 4px rgba(60,70,110,0.38);

--- a/assets/styles/button.css
+++ b/assets/styles/button.css
@@ -24,3 +24,22 @@
 .lg-btn:active { transform: translateY(0); }
 .lg-btn:focus { box-shadow: 0 0 0 3px var(--clr-focus-ring), 0 4px 24px 0 var(--clr-shadow); }
 
+.btn {
+    border: none;
+    border-radius: 0.75rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    padding: 0.625rem 1.25rem;
+    cursor: pointer;
+    transition: all 0.18s;
+    outline: none;
+}
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.btn-primary {
+    background: #2563eb;
+    color: #fff;
+}
+.btn-primary:hover:not(:disabled) { background: #3b82f6; }
+.btn-primary:active:not(:disabled) { background: #1d4ed8; }
+

--- a/assets/styles/settings.css
+++ b/assets/styles/settings.css
@@ -1,0 +1,83 @@
+/* === Page Paramètres === */
+
+.settings-card {
+    background: rgba(255, 255, 255, 0.10);
+    backdrop-filter: blur(24px) saturate(180%);
+    border: 1px solid rgba(255, 255, 255, 0.20);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.settings-card-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.80);
+}
+
+.settings-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.settings-label {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.60);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.settings-input {
+    background: rgba(255, 255, 255, 0.10);
+    border: 1px solid rgba(255, 255, 255, 0.20);
+    border-radius: 0.75rem;
+    padding: 0.625rem 1rem;
+    color: #fff;
+    font-size: 0.875rem;
+    transition: border-color 0.18s, box-shadow 0.18s;
+    outline: none;
+}
+
+.settings-input::placeholder {
+    color: rgba(255, 255, 255, 0.30);
+}
+
+.settings-input:focus {
+    border-color: rgba(96, 165, 250, 0.60);
+    box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.20);
+}
+
+.settings-actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.settings-toast {
+    display: none;
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    z-index: 50;
+    padding: 0.75rem 1.25rem;
+    border-radius: 1rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    transition: opacity 0.2s;
+}
+
+.settings-toast.toast-success {
+    background: rgba(22, 163, 74, 0.85);
+    color: #fff;
+}
+
+.settings-toast.toast-error {
+    background: rgba(220, 38, 38, 0.85);
+    color: #fff;
+}

--- a/templates/web/settings.html.twig
+++ b/templates/web/settings.html.twig
@@ -9,35 +9,29 @@
     <h1 class="text-2xl font-bold text-white">Paramètres du compte</h1>
 
     {# ── Card profil ── #}
-    <div class="rounded-2xl bg-white/10 backdrop-blur-2xl border border-white/20 p-6 flex flex-col gap-5"
-         style="filter: url(#glass-distort);">
+    <div class="settings-card">
 
-        <h2 class="text-base font-semibold text-white/80">Informations personnelles</h2>
+        <h2 class="settings-card-title">Informations personnelles</h2>
 
         <div class="flex flex-col gap-4">
 
-            <div class="flex flex-col gap-1">
-                <label for="settings-displayName" class="text-xs font-medium text-white/60 uppercase tracking-wider">Nom affiché</label>
+            <div class="settings-field">
+                <label for="settings-displayName" class="settings-label">Nom affiché</label>
                 <input id="settings-displayName" type="text" value="{{ user.displayName }}"
-                       class="bg-white/10 border border-white/20 rounded-xl px-4 py-2.5 text-white text-sm
-                              placeholder-white/30 focus:outline-none focus:ring-2 focus:ring-blue-400/60
-                              transition-all">
+                       class="settings-input">
             </div>
 
-            <div class="flex flex-col gap-1">
-                <label for="settings-email" class="text-xs font-medium text-white/60 uppercase tracking-wider">Adresse e-mail</label>
+            <div class="settings-field">
+                <label for="settings-email" class="settings-label">Adresse e-mail</label>
                 <input id="settings-email" type="email" value="{{ user.email }}"
-                       class="bg-white/10 border border-white/20 rounded-xl px-4 py-2.5 text-white text-sm
-                              placeholder-white/30 focus:outline-none focus:ring-2 focus:ring-blue-400/60
-                              transition-all">
+                       class="settings-input">
             </div>
 
         </div>
 
-        <div class="flex justify-end">
+        <div class="settings-actions">
             <button id="btn-save-profile" onclick="saveProfile()"
-                    class="px-5 py-2.5 bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white text-sm
-                           font-semibold rounded-xl transition-all disabled:opacity-50">
+                    class="btn btn-primary">
                 Enregistrer
             </button>
         </div>
@@ -45,35 +39,29 @@
     </div>
 
     {# ── Card mot de passe ── #}
-    <div class="rounded-2xl bg-white/10 backdrop-blur-2xl border border-white/20 p-6 flex flex-col gap-5"
-         style="filter: url(#glass-distort);">
+    <div class="settings-card">
 
-        <h2 class="text-base font-semibold text-white/80">Changer le mot de passe</h2>
+        <h2 class="settings-card-title">Changer le mot de passe</h2>
 
         <div class="flex flex-col gap-4">
 
-            <div class="flex flex-col gap-1">
-                <label for="settings-password" class="text-xs font-medium text-white/60 uppercase tracking-wider">Nouveau mot de passe</label>
+            <div class="settings-field">
+                <label for="settings-password" class="settings-label">Nouveau mot de passe</label>
                 <input id="settings-password" type="password" placeholder="8 caractères minimum"
-                       class="bg-white/10 border border-white/20 rounded-xl px-4 py-2.5 text-white text-sm
-                              placeholder-white/30 focus:outline-none focus:ring-2 focus:ring-blue-400/60
-                              transition-all">
+                       class="settings-input">
             </div>
 
-            <div class="flex flex-col gap-1">
-                <label for="settings-password-confirm" class="text-xs font-medium text-white/60 uppercase tracking-wider">Confirmer</label>
+            <div class="settings-field">
+                <label for="settings-password-confirm" class="settings-label">Confirmer</label>
                 <input id="settings-password-confirm" type="password" placeholder="Répéter le mot de passe"
-                       class="bg-white/10 border border-white/20 rounded-xl px-4 py-2.5 text-white text-sm
-                              placeholder-white/30 focus:outline-none focus:ring-2 focus:ring-blue-400/60
-                              transition-all">
+                       class="settings-input">
             </div>
 
         </div>
 
-        <div class="flex justify-end">
+        <div class="settings-actions">
             <button id="btn-save-password" onclick="savePassword()"
-                    class="px-5 py-2.5 bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white text-sm
-                           font-semibold rounded-xl transition-all disabled:opacity-50">
+                    class="btn btn-primary">
                 Changer le mot de passe
             </button>
         </div>
@@ -83,20 +71,7 @@
 </div>
 
 {# ── Toast ── #}
-<div id="settings-toast"
-     class="hidden fixed bottom-6 right-6 z-50 px-5 py-3 rounded-2xl text-sm font-semibold shadow-xl
-            transition-all backdrop-blur-xl border">
-</div>
-
-{# ── SVG filter (glass distortion) ── #}
-<svg class="hidden" xmlns="http://www.w3.org/2000/svg">
-    <defs>
-        <filter id="glass-distort" x="-5%" y="-5%" width="110%" height="110%">
-            <feTurbulence type="fractalNoise" baseFrequency="0.65 0.65" numOctaves="3" seed="2" result="noise"/>
-            <feDisplacementMap in="SourceGraphic" in2="noise" scale="3" xChannelSelector="R" yChannelSelector="G"/>
-        </filter>
-    </defs>
-</svg>
+<div id="settings-toast" class="settings-toast"></div>
 
 <script>
 (function () {
@@ -105,16 +80,10 @@
     function showToast(message, isError) {
         var toast = document.getElementById('settings-toast');
         toast.textContent = message;
-        if (isError) {
-            toast.className = toast.className.replace(/hidden/, '').trim();
-            toast.style.cssText = 'background:rgba(220,38,38,0.85); color:#fff; border-color:rgba(255,255,255,0.15);';
-        } else {
-            toast.className = toast.className.replace(/hidden/, '').trim();
-            toast.style.cssText = 'background:rgba(22,163,74,0.85); color:#fff; border-color:rgba(255,255,255,0.15);';
-        }
-        toast.classList.remove('hidden');
+        toast.className = 'settings-toast ' + (isError ? 'toast-error' : 'toast-success');
+        toast.style.display = 'block';
         clearTimeout(toast._timer);
-        toast._timer = setTimeout(function () { toast.classList.add('hidden'); }, 3500);
+        toast._timer = setTimeout(function () { toast.style.display = 'none'; }, 3500);
     }
 
     async function patch(payload) {


### PR DESCRIPTION
## Résumé

- Création de `assets/styles/settings.css` : classes `.settings-card`, `.settings-input`, `.settings-label`, `.settings-field`, `.settings-actions`, `.settings-toast`
- Ajout de `.btn` / `.btn-primary` dans `button.css` (classe réutilisable)
- Import de `settings.css` dans `app.css`
- Nettoyage de `settings.html.twig` : zéro style inline, zéro classe Tailwind utilitaire en dur
- Suppression du SVG filter `glass-distort` (distorsion trop forte, nuisait à la lisibilité)

## Test plan

- [ ] Vérifier visuellement `/settings` : cards lisibles, inputs focusables, boutons bleus, toast fonctionnel
- [ ] Vérifier que les classes `.btn-primary` n'impactent pas les autres pages