### PR TITLE
✨ feat(UserOutput, FolderOutput): contraintes Assert + validation via ValidatorInterface

### DIFF
--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -9,5 +9,6 @@ api_platform:
         json: ['application/json']
     defaults:
         stateless: true
+        validate: true
         cache_headers:
             vary: ['Content-Type', 'Authorization', 'Origin']

--- a/src/ApiResource/FolderOutput.php
+++ b/src/ApiResource/FolderOutput.php
@@ -14,6 +14,7 @@ use ApiPlatform\OpenApi\Model;
 use App\State\FolderProcessor;
 use App\State\FolderProvider;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     shortName: 'Folder',
@@ -34,6 +35,7 @@ use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
         ),
         new Post(
             uriTemplate: '/v1/folders',
+            validationContext: ['groups' => ['Default', 'create']],
             openapi: new Model\Operation(
                 summary: 'Crée un nouveau dossier.',
                 description: 'Crée un dossier. `parentId` est optionnel ; si absent, le dossier est à la racine.',
@@ -75,6 +77,9 @@ use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 final class FolderOutput
 {
     public string $id = '';
+
+    #[Assert\NotBlank(groups: ['create'])]
+    #[Assert\Length(max: 255)]
     public string $name = '';
     public ?string $parentId = null;
     public ?string $ownerId = null;

--- a/src/ApiResource/UserOutput.php
+++ b/src/ApiResource/UserOutput.php
@@ -11,6 +11,7 @@ use ApiPlatform\Metadata\Patch;
 use ApiPlatform\OpenApi\Model;
 use App\State\UserProcessor;
 use App\State\UserProvider;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     shortName: 'User',
@@ -48,9 +49,15 @@ use App\State\UserProvider;
 final class UserOutput
 {
     public string $id = '';
+
+    #[Assert\Email]
     public string $email = '';
+
+    #[Assert\Length(max: 255)]
     public string $displayName = '';
+
     public string $createdAt = '';
-    /** Champ write-only : accepté en entrée PATCH, jamais exposé en réponse. */
+
+    #[Assert\Length(min: 8)]
     public ?string $password = null;
 }

--- a/src/State/FolderProcessor.php
+++ b/src/State/FolderProcessor.php
@@ -9,6 +9,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\State\ProcessorInterface;
+use ApiPlatform\Validator\ValidatorInterface;
 use App\ApiResource\FolderOutput;
 use App\Enum\FolderMediaType;
 use App\Interface\FolderRepositoryInterface;
@@ -40,10 +41,15 @@ final class FolderProcessor implements ProcessorInterface
         private readonly FolderProvider $provider,
         private readonly RequestStack $requestStack,
         private readonly IriExtractor $iriExtractor,
+        private readonly ValidatorInterface $validator,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
     {
+        if (!$operation instanceof Delete) {
+            $this->validator->validate($data, $operation->getValidationContext() ?? []);
+        }
+
         return match (true) {
             $operation instanceof Post   => $this->handlePost($data),
             $operation instanceof Patch  => $this->handlePatch($data, $uriVariables),
@@ -57,9 +63,6 @@ final class FolderProcessor implements ProcessorInterface
      */
     private function handlePost(FolderOutput $data): FolderOutput
     {
-        if (empty($data->name)) {
-            throw new BadRequestHttpException('name is required');
-        }
         if (empty($data->ownerId)) {
             throw new BadRequestHttpException('ownerId is required');
         }

--- a/src/State/UserProcessor.php
+++ b/src/State/UserProcessor.php
@@ -7,6 +7,7 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\State\ProcessorInterface;
+use ApiPlatform\Validator\ValidatorInterface;
 use App\ApiResource\UserOutput;
 use App\Interface\AuthenticationResolverInterface;
 use App\Interface\UserRepositoryInterface;
@@ -36,10 +37,13 @@ final class UserProcessor implements ProcessorInterface
         private readonly UserProvider $provider,
         private readonly AuthenticationResolverInterface $authResolver,
         private readonly UserPasswordHasherInterface $passwordHasher,
+        private readonly ValidatorInterface $validator,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
     {
+        $this->validator->validate($data, $operation->getValidationContext() ?? []);
+
         return match (true) {
             $operation instanceof Patch => $this->handlePatch($data, $uriVariables),
             default => $data,
@@ -57,9 +61,6 @@ final class UserProcessor implements ProcessorInterface
         }
 
         if (!empty($data->email)) {
-            if (!filter_var($data->email, FILTER_VALIDATE_EMAIL)) {
-                throw new UnprocessableEntityHttpException('Email invalide.');
-            }
             $existing = $this->userRepository->findOneBy(['email' => $data->email]);
             if ($existing !== null && !$existing->getId()->equals($user->getId())) {
                 throw new UnprocessableEntityHttpException('Cet email est déjà utilisé.');
@@ -68,16 +69,10 @@ final class UserProcessor implements ProcessorInterface
         }
 
         if (!empty($data->displayName)) {
-            if (strlen($data->displayName) > 255) {
-                throw new UnprocessableEntityHttpException('displayName trop long (max 255 caractères).');
-            }
             $user->setDisplayName($data->displayName);
         }
 
         if ($data->password !== null) {
-            if (strlen($data->password) < 8) {
-                throw new UnprocessableEntityHttpException('Le mot de passe doit contenir au moins 8 caractères.');
-            }
             $user->setPassword($this->passwordHasher->hashPassword($user, $data->password));
         }
 

--- a/tests/Api/FolderCrudTest.php
+++ b/tests/Api/FolderCrudTest.php
@@ -155,7 +155,7 @@ final class FolderCrudTest extends AuthenticatedApiTestCase
         );
     }
 
-    public function testCreateFolderMissingNameReturns400(): void
+    public function testCreateFolderMissingNameReturns422(): void
     {
         $em = static::getContainer()->get(\Doctrine\ORM\EntityManagerInterface::class);
         $user = $em->getRepository(\App\Entity\User::class)->findOneBy(['email' => 'alice@example.com']);
@@ -165,7 +165,26 @@ final class FolderCrudTest extends AuthenticatedApiTestCase
                 'ownerId' => (string) $user->getId(),
             ],
         ]);
-        static::assertResponseStatusCodeSame(400);
+        static::assertResponseStatusCodeSame(422);
+        $data = $client->getResponse()->toArray(false);
+        $this->assertArrayHasKey('violations', $data);
+    }
+
+    /** name > 255 caractères → 422 avec violations */
+    public function testCreateFolderWithTooLongNameReturns422(): void
+    {
+        $em = static::getContainer()->get(\Doctrine\ORM\EntityManagerInterface::class);
+        $user = $em->getRepository(\App\Entity\User::class)->findOneBy(['email' => 'alice@example.com']);
+        $client = $this->createAuthenticatedClient($user);
+        $client->request('POST', '/api/v1/folders', [
+            'json' => [
+                'name'    => str_repeat('a', 256),
+                'ownerId' => (string) $user->getId(),
+            ],
+        ]);
+        static::assertResponseStatusCodeSame(422);
+        $data = $client->getResponse()->toArray(false);
+        $this->assertArrayHasKey('violations', $data);
     }
 
     public function testCreateFolderDuplicateNameInParentReturns400(): void

--- a/tests/Api/FolderTest.php
+++ b/tests/Api/FolderTest.php
@@ -112,13 +112,13 @@ final class FolderTest extends AuthenticatedApiTestCase
         $this->assertSame((string) $parent->getId(), $data['parentId']);
     }
 
-    public function testPostFolderReturns400WhenNameIsMissing(): void
+    public function testPostFolderReturns422WhenNameIsMissing(): void
     {
         $owner = $this->createUser();
         $this->createAuthenticatedClient()->request('POST', '/api/v1/folders', [
             'json' => ['ownerId' => (string) $owner->getId()],
         ]);
-        $this->assertResponseStatusCodeSame(400);
+        $this->assertResponseStatusCodeSame(422);
     }
 
     // --- PATCH /api/v1/folders/{id} ---

--- a/tests/Api/UserPatchTest.php
+++ b/tests/Api/UserPatchTest.php
@@ -113,4 +113,52 @@ final class UserPatchTest extends AuthenticatedApiTestCase
 
         $this->assertResponseStatusCodeSame(422);
     }
+
+    /** Email invalide → 422 avec clé violations (format standard API Platform) */
+    public function testPatchWithInvalidEmailReturnsViolations(): void
+    {
+        $alice = $this->em->getRepository(\App\Entity\User::class)->findOneBy(['email' => 'alice@example.com']);
+
+        $client = $this->createAuthenticatedClient($alice);
+        $client->request('PATCH', '/api/v1/users/' . $alice->getId(), [
+            'json' => ['email' => 'not-an-email'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+        $data = $client->getResponse()->toArray(false);
+        $this->assertArrayHasKey('violations', $data);
+    }
+
+    /** displayName trop long (> 255) → 422 avec violations */
+    public function testPatchWithTooLongDisplayNameReturns422(): void
+    {
+        $alice = $this->em->getRepository(\App\Entity\User::class)->findOneBy(['email' => 'alice@example.com']);
+
+        $client = $this->createAuthenticatedClient($alice);
+        $client->request('PATCH', '/api/v1/users/' . $alice->getId(), [
+            'json' => ['displayName' => str_repeat('a', 256)],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+        $data = $client->getResponse()->toArray(false);
+        $this->assertArrayHasKey('violations', $data);
+    }
+
+    /** Mot de passe trop court → 422 avec violations */
+    public function testPatchWithShortPasswordReturnsViolations(): void
+    {
+        $alice = $this->em->getRepository(\App\Entity\User::class)->findOneBy(['email' => 'alice@example.com']);
+
+        $client = $this->createAuthenticatedClient($alice);
+        $client->request('PATCH', '/api/v1/users/' . $alice->getId(), [
+            'json' => ['password' => '123'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+        $data = $client->getResponse()->toArray(false);
+        $this->assertArrayHasKey('violations', $data);
+    }
 }


### PR DESCRIPTION
## Résumé

- Ajout de `#[Assert\Email]`, `#[Assert\Length]` sur `UserOutput` (email, displayName, password)
- Ajout de `#[Assert\NotBlank(groups:create)]` + `#[Assert\Length(max:255)]` sur `FolderOutput::name`
- Injection de `ApiPlatform\Validator\ValidatorInterface` dans `UserProcessor` et `FolderProcessor`
- Suppression des validations manuelles redondantes dans les processors
- Activation de `validate: true` dans `api_platform.yaml`
- Les 422 retournent désormais la clé `violations` (format standard API Platform)

## Test plan

- [ ] CI verte (319 tests)
- [ ] PATCH /api/v1/users/{id} avec email invalide → 422 + `violations`
- [ ] PATCH /api/v1/users/{id} avec password < 8 chars → 422 + `violations`
- [ ] PATCH /api/v1/users/{id} avec displayName > 255 chars → 422 + `violations`
- [ ] POST /api/v1/folders sans name → 422 + `violations`
- [ ] POST /api/v1/folders avec name > 255 chars → 422 + `violations`
- [ ] PATCH /api/v1/folders/{id} sans name → 200 (NotBlank ne s'applique pas sur PATCH)