### PR TITLE
✨ feat: validation unicité fichier/dossier + fix drag & drop upload

### DIFF
--- a/.github/avancement.md
+++ b/.github/avancement.md
@@ -1,8 +1,8 @@
 # 📋 Avancement — HomeCloud API
 
-> Dernière mise à jour : 2026-04-16
+> Dernière mise à jour : 2026-04-17
 
-> **Status git :** `main` — tout mergé, 309 tests ✅
+> **Status git :** `main` — PR #166, #167, #168 mergées — 327 tests ✅
 
 ---
 
@@ -60,7 +60,7 @@ Score global : **9/10** — 4/5 axes de remédiation implémentés.
 | Auth failure logging | ✅ Fait (PR #146 — email, IP, user-agent) |
 | HSTS header | ✅ Fait (PR #146 — prod uniquement, max-age=31536000) |
 | `composer audit` en CI | ✅ Fait (PR #147 — step avant les tests) |
-| Assert sur DTOs | ⚠️ Basse priorité — reste à faire |
+| Assert sur DTOs | ✅ Fait (PR #167 — `#[Assert\Email]`, `#[Assert\Length]`, `#[Assert\NotBlank]` sur UserOutput et FolderOutput, violations 422) |
 
 ### CI/CD — Node.js 24
 
@@ -92,6 +92,25 @@ Score global : **9/10** — 4/5 axes de remédiation implémentés.
 |----|---------|---------|
 | #162 | `feat/rename-modal` | Remplace `prompt()` par une modale glassmorphism — `openRenameModal()` / `submitRename()`, validation inline, toast, Entrée/Échap |
 
+## ✅ Frontend — Page paramètres utilisateur (2026-04-17)
+
+| PR | Branche | Contenu |
+|----|---------|---------|
+| #165 | `feat/user-settings-patch` | Route `/settings`, `UserSettingsController`, formulaires profil + mot de passe, PATCH `/api/v1/users/{id}`, `UserProcessor`, `UserPatchTest` (200/403/404/422) |
+| #166 | `style/settings-css-refactor` | Extraction des styles inline → `settings.css` (`.settings-card`, `.settings-input`…), `.btn`/`.btn-primary` dans `button.css`, suppression SVG filter glass-distort |
+
+## ✅ API — Pagination/tri/recherche Folders & Files (2026-04-17)
+
+| PR | Branche | Contenu |
+|----|---------|---------|
+| #168 | `feat/folder-file-filters` | `FolderRepository::findFiltered/countFiltered` + `FileRepository::findFiltered/countFiltered` ; `FolderProvider`/`FileProvider` lisent `?name=`, `?originalName=`, `?order[field]=asc\|desc` ; `FolderFilterTest` + `FileFilterTest` (8 tests) |
+
+## ✅ Sécurité — Assert sur DTOs (2026-04-17)
+
+| PR | Branche | Contenu |
+|----|---------|---------|
+| #167 | `feat/assert-dto-constraints` | `#[Assert\Email]`, `#[Assert\Length]` sur `UserOutput` ; `#[Assert\NotBlank(groups:create)]` + `#[Assert\Length]` sur `FolderOutput::name` ; injection `ValidatorInterface` dans processors ; 422 retourne désormais `violations` |
+
 ## ✅ Chore — Cleanup code mort (2026-04-16)
 
 | Fichier supprimé | Raison |
@@ -117,9 +136,9 @@ Score global : **9/10** — 4/5 axes de remédiation implémentés.
 
 ## 📊 État des tests
 
-- **309 tests**, 643 assertions
-- 0 skipped (test GET File corrigé — PR #163)
-- 0 failures, 0 errors
+- **327 tests**, 679 assertions
+- 0 skipped, 0 failures, 0 errors
+- +18 tests depuis PR #167 (violations Assert) et PR #168 (filtres)
 
 ---
 
@@ -139,10 +158,8 @@ Score global : **9/10** — 4/5 axes de remédiation implémentés.
 
 ## 🗺️ Prochaines pistes
 
-Voir `.github/todo-api-features.md` et `.github/todo-user-settings.md` pour les fonctionnalités restantes.
-
-### Priorité suggérée
-1. **Assert sur DTOs** (clôture sécurité — priorité basse) → `.github/todo-security.md`
-2. **API Features** PATCH/DELETE File, PATCH/DELETE Folder, User + pagination → `.github/todo-api-features.md`
-3. **Page paramètres utilisateur** (email, mot de passe) → `.github/todo-user-settings.md`
+### Reste à faire
+1. **Validation unicité** nom dossier/fichier dans un même parent → `.github/todo-api-features.md`
+2. **Documentation OpenAPI** à jour
+3. **Bug drag & drop upload** → voir section bugs connus
 

--- a/assets/components/hc-folder-list.js
+++ b/assets/components/hc-folder-list.js
@@ -39,9 +39,10 @@ class HCFolderList extends HTMLElement {
             return { id: null, isNew: true, newName: this._newName };
         }
         const folder = this._folders.find(f => f.id === this._selectedId);
-        return folder
-            ? { ...folder, isNew: false }
-            : { id: null, isNew: false };
+        if (folder) return { ...folder, isNew: false };
+        // Dossier connu (ex: sous-dossier non listé par l'API) — on retourne l'ID tel quel
+        if (this._selectedId) return { id: this._selectedId, isNew: false };
+        return { id: null, isNew: false };
     }
 
     _render() {

--- a/assets/js/upload-modal.js
+++ b/assets/js/upload-modal.js
@@ -466,7 +466,7 @@ function closeUploadModal() {
  */
 export function initUploadModal() {
     document.addEventListener('hc:files-selected', async (event) => {
-        const { files } = event.detail;
+        const { files, folderId } = event.detail;
         if (!files || !Array.isArray(files)) {
             console.warn('[UploadModal] Invalid files:', files);
             return;
@@ -495,7 +495,7 @@ export function initUploadModal() {
             console.warn('[UploadModal] Could not fetch folders:', err);
         }
 
-        openUploadModal(files, { folders }).catch(err => {
+        openUploadModal(files, { folders, folderId: folderId || '' }).catch(err => {
             console.error('[UploadModal] Error opening modal:', err);
         });
     });

--- a/src/Interface/FileRepositoryInterface.php
+++ b/src/Interface/FileRepositoryInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Interface;
 
 use App\Entity\File;
+use App\Entity\Folder;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -21,4 +22,6 @@ interface FileRepositoryInterface
      * @return File|null
      */
     public function findById(Uuid $id): ?File;
+
+    public function findOneByNameInFolder(string $name, Folder $folder): ?File;
 }

--- a/src/Repository/FileRepository.php
+++ b/src/Repository/FileRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\File;
+use App\Entity\Folder;
 use App\Entity\User;
 use App\Interface\FileRepositoryInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -92,13 +93,13 @@ class FileRepository extends ServiceEntityRepository implements FileRepositoryIn
             ->getResult();
     }
 
-    /**
-     * Find a file by ID (implements FileRepositoryInterface).
-     *
-     * @return File|null
-     */
     public function findById(Uuid $id): ?File
     {
         return $this->find($id);
+    }
+
+    public function findOneByNameInFolder(string $name, Folder $folder): ?File
+    {
+        return $this->findOneBy(['originalName' => $name, 'folder' => $folder]);
     }
 }

--- a/src/Service/FileActionService.php
+++ b/src/Service/FileActionService.php
@@ -43,6 +43,12 @@ final class FileActionService
     public function rename(File $file, string $newName): void
     {
         $this->filenameValidator->validate($newName);
+
+        $existing = $this->fileRepository->findOneByNameInFolder($newName, $file->getFolder());
+        if ($existing !== null && !$existing->getId()->equals($file->getId())) {
+            throw new BadRequestHttpException('A file with this name already exists in this folder');
+        }
+
         $file->setOriginalName($newName);
         $this->em->flush();
     }
@@ -54,18 +60,18 @@ final class FileActionService
      */
     public function move(File $file, Folder $targetFolder, User $requester): void
     {
-        // 1. Auth: file owner
         $this->authChecker->assertOwns($file, $requester);
-
-        // 2. Auth: target folder owner
         $this->authChecker->assertOwns($targetFolder, $requester);
 
-        // 3. Validation: cycle check (prevent B > A > C, move B under C)
         if ($this->authChecker->wouldCreateCycle($file->getFolder(), $targetFolder)) {
             throw new BadRequestHttpException('Moving would create a folder cycle');
         }
 
-        // 4. Persist
+        $existing = $this->fileRepository->findOneByNameInFolder($file->getOriginalName(), $targetFolder);
+        if ($existing !== null && !$existing->getId()->equals($file->getId())) {
+            throw new BadRequestHttpException('A file with this name already exists in the target folder');
+        }
+
         $file->setFolder($targetFolder);
         $this->em->flush();
     }

--- a/src/Service/FolderService.php
+++ b/src/Service/FolderService.php
@@ -98,11 +98,24 @@ final class FolderService
 
         if ($newName !== '') {
             $this->filenameValidator->validate($newName);
-            $criteria = ['name' => $newName, 'owner' => $folder->getOwner(), 'parent' => $folder->getParent()];
-            $existing = $this->folderRepository->findOneBy($criteria);
+        }
+
+        // Unicité vérifiée contre le parent effectif (nouveau si déplacement, sinon actuel)
+        $effectiveName   = $newName !== '' ? $newName : $folder->getName();
+        $effectiveParent = $parentChanged ? $newParent : $folder->getParent();
+
+        if ($newName !== '' || $parentChanged) {
+            $existing = $this->folderRepository->findOneBy([
+                'name'   => $effectiveName,
+                'owner'  => $folder->getOwner(),
+                'parent' => $effectiveParent,
+            ]);
             if ($existing !== null && !$existing->getId()->equals($folder->getId())) {
                 throw new BadRequestHttpException('A folder with this name already exists in the parent');
             }
+        }
+
+        if ($newName !== '') {
             $folder->setName($newName);
         }
 

--- a/templates/web/home.html.twig
+++ b/templates/web/home.html.twig
@@ -49,13 +49,42 @@
 </div>
 
 <script>
-// Ajoute la classe drop-active sur dragenter/leave pour feedback visuel
-const importCard = document.getElementById('main-import-card');
-if(importCard) {
-  importCard.addEventListener('dragenter', () => importCard.classList.add('drop-active'));
-  importCard.addEventListener('dragleave', () => importCard.classList.remove('drop-active'));
-  importCard.addEventListener('drop',      () => importCard.classList.remove('drop-active'));
-}
+(function () {
+  const importCard = document.getElementById('main-import-card');
+  if (!importCard) return;
+
+  // Compteur pour ignorer les dragleave sur les éléments enfants
+  let dragCounter = 0;
+
+  // Activation sur tout le document — la zone réagit dès que le fichier entre dans la page
+  document.addEventListener('dragenter', (e) => {
+    e.preventDefault();
+    dragCounter++;
+    importCard.classList.add('drop-active');
+  });
+
+  document.addEventListener('dragover', (e) => { e.preventDefault(); });
+
+  document.addEventListener('dragleave', (e) => {
+    dragCounter--;
+    // relatedTarget null = le curseur a quitté la fenêtre du navigateur
+    if (dragCounter <= 0 || e.relatedTarget === null) {
+      dragCounter = 0;
+      importCard.classList.remove('drop-active');
+    }
+  });
+
+  document.addEventListener('drop', (e) => {
+    e.preventDefault();
+    dragCounter = 0;
+    importCard.classList.remove('drop-active');
+    const files = Array.from(e.dataTransfer.files).filter(f => f.size > 0);
+    if (files.length === 0) return;
+    const folderIdInput = importCard.querySelector('input[name="folder_id"]');
+    const folderId = folderIdInput ? folderIdInput.value : '';
+    document.dispatchEvent(new CustomEvent('hc:files-selected', { detail: { files, folderId } }));
+  });
+}());
 </script>
 
 {% endblock %}

--- a/tests/Api/FileUniquenessTest.php
+++ b/tests/Api/FileUniquenessTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api;
+
+use App\Entity\File;
+use App\Tests\AuthenticatedApiTestCase;
+
+/**
+ * Validation d'unicité du nom de fichier lors d'un renommage ou d'un déplacement.
+ */
+final class FileUniquenessTest extends AuthenticatedApiTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->createUser('alice@example.com', 'password123', 'Alice');
+    }
+
+    private function createFile(string $name, \App\Entity\Folder $folder, \App\Entity\User $owner): File
+    {
+        $file = new File($name, 'text/plain', 42, 'test/' . uniqid() . '.txt', $folder, $owner, false);
+        $this->em->persist($file);
+        $this->em->flush();
+        return $file;
+    }
+
+    /** PATCH rename — nom déjà utilisé dans le même dossier → 400 */
+    public function testRenameFileToExistingNameInSameFolderReturns400(): void
+    {
+        $alice  = $this->em->getRepository(\App\Entity\User::class)->findOneBy(['email' => 'alice@example.com']);
+        $folder = $this->createFolder('Docs', $alice);
+        $this->createFile('existing.txt', $folder, $alice);
+        $file   = $this->createFile('other.txt', $folder, $alice);
+
+        $client = $this->createAuthenticatedClient($alice);
+        $response = $client->request('PATCH', '/api/v1/files/' . $file->getId(), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json'    => ['originalName' => 'existing.txt'],
+        ]);
+
+        static::assertResponseStatusCodeSame(400);
+    }
+
+    /** PATCH move — fichier de même nom déjà présent dans le dossier cible → 400 */
+    public function testMoveFileToFolderWithExistingNameReturns400(): void
+    {
+        $alice   = $this->em->getRepository(\App\Entity\User::class)->findOneBy(['email' => 'alice@example.com']);
+        $folderA = $this->createFolder('FolderA', $alice);
+        $folderB = $this->createFolder('FolderB', $alice);
+        $this->createFile('conflict.txt', $folderB, $alice);
+        $file    = $this->createFile('conflict.txt', $folderA, $alice);
+
+        $client = $this->createAuthenticatedClient($alice);
+        $response = $client->request('PATCH', '/api/v1/files/' . $file->getId(), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json'    => ['targetFolderId' => (string) $folderB->getId()],
+        ]);
+
+        static::assertResponseStatusCodeSame(400);
+    }
+
+    /** PATCH rename — nom unique dans le dossier → 200 */
+    public function testRenameFileToUniqueNameSucceeds(): void
+    {
+        $alice  = $this->em->getRepository(\App\Entity\User::class)->findOneBy(['email' => 'alice@example.com']);
+        $folder = $this->createFolder('Docs', $alice);
+        $file   = $this->createFile('document.txt', $folder, $alice);
+
+        $client = $this->createAuthenticatedClient($alice);
+        $response = $client->request('PATCH', '/api/v1/files/' . $file->getId(), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json'    => ['originalName' => 'renamed.txt'],
+        ]);
+
+        static::assertResponseStatusCodeSame(200);
+        $this->assertSame('renamed.txt', $response->toArray()['originalName']);
+    }
+
+    /** PATCH move — pas de collision dans le dossier cible → 200 */
+    public function testMoveFileNoCollisionSucceeds(): void
+    {
+        $alice   = $this->em->getRepository(\App\Entity\User::class)->findOneBy(['email' => 'alice@example.com']);
+        $folderA = $this->createFolder('FolderA', $alice);
+        $folderB = $this->createFolder('FolderB', $alice);
+        $file    = $this->createFile('unique.txt', $folderA, $alice);
+
+        $client = $this->createAuthenticatedClient($alice);
+        $response = $client->request('PATCH', '/api/v1/files/' . $file->getId(), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json'    => ['targetFolderId' => (string) $folderB->getId()],
+        ]);
+
+        static::assertResponseStatusCodeSame(200);
+        $this->assertSame((string) $folderB->getId(), $response->toArray()['folderId']);
+    }
+}

--- a/tests/Api/FolderUniquenessTest.php
+++ b/tests/Api/FolderUniquenessTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api;
+
+use App\Tests\AuthenticatedApiTestCase;
+
+/**
+ * Validation d'unicité du nom de dossier lors d'un déplacement (PATCH parentId).
+ *
+ * Cas non couverts par FolderCrudTest :
+ * - Move seul (nom inchangé) → collision dans le nouveau parent
+ * - Rename + Move simultanés → collision dans le nouveau parent
+ */
+final class FolderUniquenessTest extends AuthenticatedApiTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->createUser('alice@example.com', 'password123', 'Alice');
+    }
+
+    /** PATCH move uniquement — nom identique déjà présent dans le nouveau parent → 400 */
+    public function testMoveFolderCausesNameCollisionReturns400(): void
+    {
+        $alice  = $this->em->getRepository(\App\Entity\User::class)->findOneBy(['email' => 'alice@example.com']);
+        $target = $this->createFolder('Target', $alice);
+        $this->createFolder('SameName', $alice, $target);
+        $toMove = $this->createFolder('SameName', $alice);
+
+        $client = $this->createAuthenticatedClient($alice);
+        $response = $client->request('PATCH', '/api/v1/folders/' . $toMove->getId(), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json'    => ['parentId' => (string) $target->getId()],
+        ]);
+
+        static::assertResponseStatusCodeSame(400);
+    }
+
+    /** PATCH rename + move — nouveau nom déjà présent dans le nouveau parent → 400 */
+    public function testRenameAndMoveFolderCollisionInNewParentReturns400(): void
+    {
+        $alice  = $this->em->getRepository(\App\Entity\User::class)->findOneBy(['email' => 'alice@example.com']);
+        $target = $this->createFolder('Target', $alice);
+        $this->createFolder('Existing', $alice, $target);
+        $toMove = $this->createFolder('Original', $alice);
+
+        $client = $this->createAuthenticatedClient($alice);
+        $response = $client->request('PATCH', '/api/v1/folders/' . $toMove->getId(), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json'    => [
+                'name'     => 'Existing',
+                'parentId' => (string) $target->getId(),
+            ],
+        ]);
+
+        static::assertResponseStatusCodeSame(400);
+    }
+
+    /** PATCH move — pas de collision dans le nouveau parent → 200 */
+    public function testMoveFolderNoCollisionSucceeds(): void
+    {
+        $alice  = $this->em->getRepository(\App\Entity\User::class)->findOneBy(['email' => 'alice@example.com']);
+        $target = $this->createFolder('Target', $alice);
+        $toMove = $this->createFolder('UniqueInTarget', $alice);
+
+        $client = $this->createAuthenticatedClient($alice);
+        $response = $client->request('PATCH', '/api/v1/folders/' . $toMove->getId(), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json'    => ['parentId' => (string) $target->getId()],
+        ]);
+
+        static::assertResponseStatusCodeSame(200);
+        $this->assertSame((string) $target->getId(), $response->toArray()['parentId']);
+    }
+}


### PR DESCRIPTION
## Résumé

- Validation unicité du nom de fichier/dossier dans le même répertoire parent (rename + move)
- Fix drag & drop upload : détection sur tout le document, dispatch vers la bonne destination (dossier du fil d'ariane)

## Changements

### Backend
- `FileRepositoryInterface` + `FileRepository` : nouvelle méthode `findOneByNameInFolder`
- `FileActionService` : vérification unicité sur rename et move
- `FolderService` : vérification unicité sur rename et déplacement (parent effectif)

### Tests
- `FileUniquenessTest` : rename/move avec conflit de nom (409/400)
- `FolderUniquenessTest` : rename/move dossier avec conflit

### Frontend
- `hc-folder-list` : `getSelected()` retourne l'ID directement si le dossier n'est pas dans la liste API (sous-dossiers)
- `upload-modal` : `folderId` du fil d'ariane propagé jusqu'à la destination d'upload
- `home.html.twig` : drag & drop écouté sur `document` entier, compteur anti-flickering, dispatch `hc:files-selected` avec `folderId`

## Test plan

- [ ] Renommer un fichier/dossier avec un nom déjà pris dans le même répertoire → 400
- [ ] Déplacer un fichier/dossier vers un répertoire contenant déjà un élément du même nom → 400
- [ ] Glisser-déposer un fichier depuis n'importe où dans la page → modal s'ouvre
- [ ] Destination pré-sélectionnée = dossier courant du fil d'ariane
- [ ] Suite de tests complète : `php bin/phpunit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)