### PR TITLE
✨ feat: design tokens CSS --hc-*, glassmorphism, font Geist (PR 1/4)

### DIFF
--- a/.github/avancement.md
+++ b/.github/avancement.md
@@ -1,8 +1,8 @@
 # 📋 Avancement — HomeCloud API
 
-> Dernière mise à jour : 2026-04-17
+> Dernière mise à jour : 2026-05-06
 
-> **Status git :** `main` — PR #166, #167, #168 mergées — 327 tests ✅
+> **Status git :** `main` — PR #169 mergée — 334 tests ✅
 
 ---
 
@@ -111,6 +111,13 @@ Score global : **9/10** — 4/5 axes de remédiation implémentés.
 |----|---------|---------|
 | #167 | `feat/assert-dto-constraints` | `#[Assert\Email]`, `#[Assert\Length]` sur `UserOutput` ; `#[Assert\NotBlank(groups:create)]` + `#[Assert\Length]` sur `FolderOutput::name` ; injection `ValidatorInterface` dans processors ; 422 retourne désormais `violations` |
 
+## ✅ API + Frontend — Validation unicité & fix drag & drop (2026-05-06)
+
+| PR | Branche | Contenu |
+|----|---------|---------|
+| #169 | `feat/uniqueness-validation` | `findOneByNameInFolder` dans `FileRepository` ; unicité vérifiée sur rename + move dans `FileActionService` et `FolderService` (parent effectif) ; `FileUniquenessTest` (4 tests) + `FolderUniquenessTest` (3 tests) |
+| #169 | `feat/uniqueness-validation` | Fix drag & drop : écoute sur `document` entier avec compteur anti-flickering ; `folderId` du fil d'ariane propagé jusqu'à la destination d'upload (`hc-folder-list`, `upload-modal`) |
+
 ## ✅ Chore — Cleanup code mort (2026-04-16)
 
 | Fichier supprimé | Raison |
@@ -126,19 +133,11 @@ Score global : **9/10** — 4/5 axes de remédiation implémentés.
 
 ---
 
-## ⚠️ Bugs connus
-
-| Priorité | Bug | Détail |
-|----------|-----|--------|
-| 🟡 Moyen | **Drag & drop upload non fonctionnel** | Quand on glisse un fichier sur la zone, le navigateur l'ouvre au lieu de déclencher l'upload. L'upload via le bouton "parcourir" fonctionne. À investiguer. |
-
----
-
 ## 📊 État des tests
 
-- **327 tests**, 679 assertions
+- **334 tests**, ~686 assertions
 - 0 skipped, 0 failures, 0 errors
-- +18 tests depuis PR #167 (violations Assert) et PR #168 (filtres)
+- +7 tests depuis PR #169 (unicité fichier/dossier)
 
 ---
 
@@ -159,7 +158,6 @@ Score global : **9/10** — 4/5 axes de remédiation implémentés.
 ## 🗺️ Prochaines pistes
 
 ### Reste à faire
-1. **Validation unicité** nom dossier/fichier dans un même parent → `.github/todo-api-features.md`
-2. **Documentation OpenAPI** à jour
-3. **Bug drag & drop upload** → voir section bugs connus
+1. **Redesign UI** — intégration du design system `demo/` (tokens CSS, Geist, glassmorphism, mode clair/sombre, responsive)
+2. **Documentation OpenAPI** à jour (filtres, codes 400 unicité, PATCH User)
 

--- a/assets/styles/button.css
+++ b/assets/styles/button.css
@@ -9,37 +9,76 @@
 	font-weight: 700;
 	font-size: 1.18rem;
 	padding: 1.1rem 0;
-	box-shadow: 0 4px 24px 0 var(--clr-shadow);
+	box-shadow: var(--hc-shadow);
 	transition: all 0.2s;
 	cursor: pointer;
-	font-family: 'Inter', Arial, sans-serif;
 	outline: none;
 	margin-top: 0.5rem;
 }
 .lg-btn:hover {
 	transform: translateY(-2px);
-	box-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.18);
+	box-shadow: var(--hc-shadow-lg);
 	filter: brightness(1.05);
 }
-.lg-btn:active { transform: translateY(0); }
-.lg-btn:focus { box-shadow: 0 0 0 3px var(--clr-focus-ring), 0 4px 24px 0 var(--clr-shadow); }
+.lg-btn:active  { transform: translateY(0); }
+.lg-btn:focus   { box-shadow: 0 0 0 3px var(--hc-accent-soft), var(--hc-shadow); }
 
+/* Bouton standard */
 .btn {
-    border: none;
-    border-radius: 0.75rem;
-    font-size: 0.875rem;
-    font-weight: 600;
-    padding: 0.625rem 1.25rem;
-    cursor: pointer;
-    transition: all 0.18s;
-    outline: none;
+	border: none;
+	border-radius: 0.75rem;
+	font-size: 0.875rem;
+	font-weight: 600;
+	padding: 0.625rem 1.25rem;
+	cursor: pointer;
+	transition: all 0.18s;
+	outline: none;
 }
 .btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
+/* Variantes design system */
 .btn-primary {
-    background: #2563eb;
-    color: #fff;
+	background: var(--hc-accent);
+	color: #fff;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
 }
-.btn-primary:hover:not(:disabled) { background: #3b82f6; }
-.btn-primary:active:not(:disabled) { background: #1d4ed8; }
+.btn-primary:hover:not(:disabled) {
+	background: var(--hc-accent-2);
+	transform: translateY(-1px);
+	box-shadow: 0 8px 20px -4px var(--hc-accent);
+}
+.btn-primary:active:not(:disabled) { transform: translateY(0); }
+
+.btn-soft {
+	background: var(--hc-surface-2);
+	color: var(--hc-text);
+	border: 1px solid var(--hc-border);
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+}
+.btn-soft:hover:not(:disabled) {
+	background: var(--hc-surface);
+	border-color: var(--hc-border-strong);
+}
+
+.btn-ghost {
+	background: transparent;
+	color: var(--hc-text);
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+}
+.btn-ghost:hover:not(:disabled) { background: var(--hc-surface-2); }
+
+.btn-icon {
+	width: 2rem;
+	height: 2rem;
+	padding: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
 

--- a/assets/styles/form.css
+++ b/assets/styles/form.css
@@ -1,13 +1,12 @@
 /* === Formulaires === */
 .lg-label {
 	display: block;
-	font-size: 0.82rem;
+	font-size: 0.75rem;
 	font-weight: 600;
-	color: rgba(255,255,255,0.70);
+	color: var(--hc-text-2);
 	text-transform: uppercase;
-	letter-spacing: 0.07em;
+	letter-spacing: 0.06em;
 	margin-bottom: 0.45rem;
-	font-family: 'Inter', Arial, sans-serif;
 	text-align: left;
 }
 
@@ -15,35 +14,55 @@
 	display: block;
 	width: 100%;
 	box-sizing: border-box;
-	border: 1px solid rgba(255,255,255,0.22);
-	border-radius: 1.5rem;
-	background: rgba(255,255,255,0.12);
-	color: #fff;
-	padding: 1.1rem 1.5rem;
-	margin-bottom: 1.2rem;
-	font-size: 1.15rem;
-	font-family: 'Inter', Arial, sans-serif;
-	box-shadow: 0 2px 8px 0 var(--clr-shadow);
+	border: 1px solid var(--hc-border);
+	border-radius: 0.75rem;
+	background: var(--hc-surface-2);
+	color: var(--hc-text);
+	padding: 0.65rem 1rem;
+	margin-bottom: 1rem;
+	font-size: 0.9rem;
+	box-shadow: none;
 	outline: none;
-	transition: background 0.2s, box-shadow 0.2s;
+	transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
 }
-.lg-input::placeholder { color: rgba(255,255,255,0.40); }
+.lg-input::placeholder { color: var(--hc-text-3); }
 .lg-input:focus {
-	background: rgba(255,255,255,0.18);
-	box-shadow: 0 0 0 2px var(--clr-focus-ring), 0 2px 8px 0 var(--clr-shadow);
+	background: var(--hc-surface);
+	border-color: var(--hc-accent);
+	box-shadow: 0 0 0 4px var(--hc-accent-soft);
 	outline: none;
 }
 
+/* Classe générique .input (design system) */
+.input {
+	display: block;
+	width: 100%;
+	box-sizing: border-box;
+	border: 1px solid var(--hc-border);
+	border-radius: 0.75rem;
+	background: var(--hc-surface-2);
+	color: var(--hc-text);
+	padding: 0.6rem 0.9rem;
+	font-size: 0.875rem;
+	outline: none;
+	transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
+}
+.input::placeholder { color: var(--hc-text-3); }
+.input:focus {
+	background: var(--hc-surface);
+	border-color: var(--hc-accent);
+	box-shadow: 0 0 0 4px var(--hc-accent-soft);
+}
+
 .lg-error {
-	margin-bottom: 1.2rem;
-	padding: 0.75rem 1.2rem;
-	border-radius: 1rem;
-	background: var(--clr-error-bg);
-	border: 1px solid var(--clr-error-border);
-	color: var(--clr-error-text);
-	font-size: 1rem;
+	margin-bottom: 1rem;
+	padding: 0.65rem 1rem;
+	border-radius: 0.75rem;
+	background: rgba(239, 68, 68, 0.08);
+	border: 1px solid rgba(239, 68, 68, 0.2);
+	color: var(--hc-err);
+	font-size: 0.875rem;
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;
-	font-family: 'Inter', Arial, sans-serif;
 }

--- a/assets/styles/layout.css
+++ b/assets/styles/layout.css
@@ -133,34 +133,88 @@ details[open] > .sidebar-folder-summary .sidebar-toggle-icon::before { content: 
 		border-left-color: #475569;
 	}
 }
-/* === Variables de thème (light / dark automatique via OS) === */
+/* === Variables de thème — design system HomeCloud === */
 :root {
-	--clr-bg:            #f7f8fa;
-	--clr-text:          #222;
-	--clr-text-muted:    #6b7280;
-	--clr-surface:       #fff;
-	--clr-surface-hover: #f0f4fa;
-	--clr-border:        #e0e7ef;
-	--clr-focus-ring:    #a5b4fc;
-	--clr-error-bg:      #fee2e2;
-	--clr-error-border:  #fecaca;
+	/* Accent */
+	--hc-accent:       #2b5fff;
+	--hc-accent-2:     #6e8bff;
+	--hc-accent-soft:  rgba(43, 95, 255, 0.12);
+
+	/* Surfaces & texte (light) */
+	--hc-bg:           #f4f5f8;
+	--hc-bg-2:         #eceef3;
+	--hc-surface:      rgba(255, 255, 255, 0.72);
+	--hc-surface-2:    rgba(255, 255, 255, 0.55);
+	--hc-surface-strong: rgba(255, 255, 255, 0.92);
+	--hc-border:       rgba(15, 23, 42, 0.08);
+	--hc-border-strong: rgba(15, 23, 42, 0.14);
+	--hc-text:         #0b1220;
+	--hc-text-2:       #475569;
+	--hc-text-3:       #94a3b8;
+	--hc-shadow:       0 1px 2px rgba(15, 23, 42, 0.04), 0 8px 24px -8px rgba(15, 23, 42, 0.12);
+	--hc-shadow-lg:    0 1px 2px rgba(15, 23, 42, 0.06), 0 24px 64px -16px rgba(15, 23, 42, 0.18);
+
+	/* Gradients ambient */
+	--hc-grad-1:  #d6e4ff;
+	--hc-grad-2:  #ffd8e8;
+	--hc-grad-3:  #d6f5e9;
+
+	/* Statuts */
+	--hc-ok:   #10b981;
+	--hc-warn: #f59e0b;
+	--hc-err:  #ef4444;
+
+	/* Aliases backward-compat --clr-* */
+	--clr-bg:            var(--hc-bg);
+	--clr-text:          var(--hc-text);
+	--clr-text-muted:    var(--hc-text-2);
+	--clr-surface:       var(--hc-surface);
+	--clr-surface-hover: var(--hc-surface-2);
+	--clr-border:        var(--hc-border);
+	--clr-focus-ring:    var(--hc-accent);
+	--clr-error-bg:      rgba(239, 68, 68, 0.10);
+	--clr-error-border:  rgba(239, 68, 68, 0.25);
 	--clr-error-text:    #b91c1c;
-	--clr-shadow:        rgba(31, 38, 135, 0.07);
+	--clr-shadow:        var(--hc-shadow);
 }
 
+/* Dark mode explicite (toggle JS via data-theme) */
+[data-theme="dark"] {
+	--hc-bg:           #07090f;
+	--hc-bg-2:         #0a0d16;
+	--hc-surface:      rgba(20, 25, 38, 0.55);
+	--hc-surface-2:    rgba(20, 25, 38, 0.35);
+	--hc-surface-strong: rgba(28, 33, 48, 0.85);
+	--hc-border:       rgba(255, 255, 255, 0.08);
+	--hc-border-strong: rgba(255, 255, 255, 0.16);
+	--hc-text:         #e6ebf5;
+	--hc-text-2:       #9aa4b8;
+	--hc-text-3:       #5b6478;
+	--hc-shadow:       0 1px 2px rgba(0,0,0,0.4), 0 8px 24px -8px rgba(0,0,0,0.6);
+	--hc-shadow-lg:    0 1px 2px rgba(0,0,0,0.5), 0 24px 64px -16px rgba(0,0,0,0.8);
+	--hc-grad-1:  #1e3a8a;
+	--hc-grad-2:  #6b21a8;
+	--hc-grad-3:  #134e4a;
+}
+
+/* Dark mode automatique via OS (fallback si pas de toggle JS) */
 @media (prefers-color-scheme: dark) {
-	:root {
-		--clr-bg:            #0f172a;
-		--clr-text:          #f1f5f9;
-		--clr-text-muted:    #94a3b8;
-		--clr-surface:       rgba(255, 255, 255, 0.08);
-		--clr-surface-hover: rgba(255, 255, 255, 0.13);
-		--clr-border:        rgba(255, 255, 255, 0.15);
-		--clr-focus-ring:    #818cf8;
-		--clr-error-bg:      rgba(239, 68, 68, 0.15);
-		--clr-error-border:  rgba(239, 68, 68, 0.30);
-		--clr-error-text:    #fca5a5;
-		--clr-shadow:        rgba(0, 0, 0, 0.30);
+	:root:not([data-theme="light"]) {
+		--hc-bg:           #07090f;
+		--hc-bg-2:         #0a0d16;
+		--hc-surface:      rgba(20, 25, 38, 0.55);
+		--hc-surface-2:    rgba(20, 25, 38, 0.35);
+		--hc-surface-strong: rgba(28, 33, 48, 0.85);
+		--hc-border:       rgba(255, 255, 255, 0.08);
+		--hc-border-strong: rgba(255, 255, 255, 0.16);
+		--hc-text:         #e6ebf5;
+		--hc-text-2:       #9aa4b8;
+		--hc-text-3:       #5b6478;
+		--hc-shadow:       0 1px 2px rgba(0,0,0,0.4), 0 8px 24px -8px rgba(0,0,0,0.6);
+		--hc-shadow-lg:    0 1px 2px rgba(0,0,0,0.5), 0 24px 64px -16px rgba(0,0,0,0.8);
+		--hc-grad-1:  #1e3a8a;
+		--hc-grad-2:  #6b21a8;
+		--hc-grad-3:  #134e4a;
 	}
 }
 
@@ -169,10 +223,10 @@ body {
 	box-sizing: border-box;
 	min-height: 100vh;
 	margin: 0;
-	background: var(--clr-bg);
-	font-family: 'Inter', Arial, sans-serif;
-	font-size: 1.15rem;
-	color: var(--clr-text);
+	background: var(--hc-bg);
+	font-family: 'Geist', 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+	font-size: 1rem;
+	color: var(--hc-text);
 }
 
 /* === Navbar === */

--- a/assets/styles/liquid-glass.css
+++ b/assets/styles/liquid-glass.css
@@ -111,3 +111,69 @@
 		border-radius: 1.6rem;
 	}
 }
+
+/* === Glassmorphism — design system HomeCloud === */
+.glass {
+	background: var(--hc-surface);
+	border: 1px solid var(--hc-border);
+	border-radius: 1rem;
+	box-shadow: var(--hc-shadow);
+	backdrop-filter: blur(24px) saturate(180%);
+}
+
+.glass-strong {
+	background: var(--hc-surface-strong);
+	border: 1px solid var(--hc-border);
+	border-radius: 1.25rem;
+	box-shadow: var(--hc-shadow-lg);
+	backdrop-filter: blur(32px) saturate(200%);
+}
+
+/* === Ambient background (orbs + grain) === */
+.hc-ambient {
+	position: fixed;
+	inset: 0;
+	pointer-events: none;
+	overflow: hidden;
+	z-index: 0;
+	background: var(--hc-bg);
+}
+.hc-ambient::before {
+	content: '';
+	position: absolute;
+	width: 720px; height: 720px;
+	border-radius: 50%;
+	background: var(--hc-grad-1);
+	filter: blur(80px);
+	opacity: 0.7;
+	top: -200px; left: -120px;
+}
+.hc-ambient::after {
+	content: '';
+	position: absolute;
+	width: 600px; height: 600px;
+	border-radius: 50%;
+	background: var(--hc-grad-2);
+	filter: blur(80px);
+	opacity: 0.6;
+	bottom: -160px; right: -120px;
+}
+.hc-ambient .orb {
+	position: absolute;
+	width: 520px; height: 520px;
+	border-radius: 50%;
+	background: var(--hc-grad-3);
+	filter: blur(80px);
+	opacity: 0.45;
+	top: 40%; left: 50%;
+	transform: translate(-50%, -50%);
+}
+.hc-ambient .grain {
+	position: absolute;
+	inset: 0;
+	opacity: 0.35;
+	mix-blend-mode: overlay;
+	pointer-events: none;
+	background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='240'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.6 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+}
+[data-theme="dark"] .hc-ambient .grain { opacity: 0.2; }

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -46,7 +46,7 @@
    Chaque section de design (liquid glass, layout, forms, etc.) est dans un fichier dédié.
 */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap');
 @import "liquid-glass.css";
 @import "layout.css";
 @import "form.css";


### PR DESCRIPTION
## Résumé

Première PR du redesign UI — pose les fondations CSS sans toucher à la structure HTML.

- Remplacement des tokens `--clr-*` par `--hc-*` (design system HomeCloud)
- Dark mode explicite via `[data-theme="dark"]` + fallback `prefers-color-scheme`
- Font Geist (Google Fonts) à la place d'Inter
- Nouvelles classes glassmorphism : `.glass`, `.glass-strong`
- Background ambient : `.hc-ambient`, `.orb`, `.grain`
- Nouveaux boutons : `.btn-soft`, `.btn-ghost`, `.btn-icon`
- Nouvelle classe input générique : `.input`
- Aliases `--clr-*` → `--hc-*` pour la backward-compat

## Test plan

- [ ] `npm test` → 10 tests JS verts ✅
- [ ] `npm run build` → compilation sans erreur
- [ ] Vérification visuelle : les variables CSS sont bien appliquées

🤖 Generated with [Claude Code](https://claude.com/claude-code)