### PR TITLE
🔧 fix(AssetMapper): corriger le chargement des styles CSS

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -5,6 +5,7 @@
 @import "./liquid-glass.css";
 @import "./upload.css";
 @import "./settings.css";
+@import "./main.css";
 
 nav .navbar-logo .navbar-logo-cloud {
   text-shadow: -3px 6px 4px rgba(60,70,110,0.38);

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -41,18 +41,6 @@
 .main-breadcrumbs-current {
    color: #fff;
 }
-/* === main.css ===
-   Ce fichier centralise les imports CSS pour HomeCloud.
-   Chaque section de design (liquid glass, layout, forms, etc.) est dans un fichier dédié.
-*/
-
-@import url('https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap');
-@import "liquid-glass.css";
-@import "layout.css";
-@import "form.css";
-@import "button.css";
-@import "animation.css";
-
 /* Import-card : zone de drop en évidence */
 .import-card {
   border: 2.5px dashed #a5b4fc;

--- a/templates/web/layout.html.twig
+++ b/templates/web/layout.html.twig
@@ -1,5 +1,4 @@
 {% block stylesheets %}
-<link rel="stylesheet" href="{{ asset('styles/main.css') }}">
 {# Modales globales #}
 <twig:MoveModal />
 <twig:DeleteFolderModal />


### PR DESCRIPTION
## Résumé

- Suppression du `<link>` manuel vers `main.css` dans `layout.html.twig` (doublon avec `importmap('app')`)
- Ajout de `@import "./main.css"` dans `app.css` pour que les classes `.search-glass`, `.breadcrumbs` et `.import-card` passent par le pipeline AssetMapper + Tailwind
- Nettoyage de `main.css` : suppression des imports dupliqués qui cassaient les styles en production

## Test plan

- [ ] Vérifier que les styles s'affichent correctement sur https://ronan.lenouvel.me après déploiement
- [ ] Vérifier la console navigateur (aucune 404 sur les assets CSS)
- [ ] Vérifier que les classes `.search-glass`, `.import-card` et `.main-breadcrumbs` sont bien appliquées