### PR TITLE
🔧 fix(login): supprimer le lien manuel vers main.css

### DIFF
--- a/templates/web/login.html.twig
+++ b/templates/web/login.html.twig
@@ -2,9 +2,7 @@
 
 {% block title %}Connexion — HomeCloud{% endblock %}
 
-{% block stylesheets %}
-<link rel="stylesheet" href="{{ asset('styles/main.css') }}">
-{% endblock %}
+{% block stylesheets %}{% endblock %}
 
 {% block body %}
 <div class="login-wrapper">


### PR DESCRIPTION
## Résumé

- Suppression du `<link>` vers `main.css` dans `login.html.twig`
- Le CSS est déjà injecté via `{{ importmap('app') }}` dans `base.html.twig`
- Ce doublon causait le chargement d'un CSS sans Tailwind qui cassait les styles de la page de connexion

## Test plan

- [ ] Vérifier que la page de login s'affiche correctement sur https://ronan.lenouvel.me/login