### PR TITLE
🎨 style(settings): adapter les couleurs aux variables du thème light/dark

### DIFF
--- a/assets/styles/settings.css
+++ b/assets/styles/settings.css
@@ -1,9 +1,9 @@
 /* === Page Paramètres === */
 
 .settings-card {
-    background: rgba(255, 255, 255, 0.10);
+    background: var(--hc-surface);
     backdrop-filter: blur(24px) saturate(180%);
-    border: 1px solid rgba(255, 255, 255, 0.20);
+    border: 1px solid var(--hc-border);
     border-radius: 1rem;
     padding: 1.5rem;
     display: flex;
@@ -14,7 +14,7 @@
 .settings-card-title {
     font-size: 0.875rem;
     font-weight: 600;
-    color: rgba(255, 255, 255, 0.80);
+    color: var(--hc-text);
 }
 
 .settings-field {
@@ -26,29 +26,29 @@
 .settings-label {
     font-size: 0.75rem;
     font-weight: 500;
-    color: rgba(255, 255, 255, 0.60);
+    color: var(--hc-text-2);
     text-transform: uppercase;
     letter-spacing: 0.05em;
 }
 
 .settings-input {
-    background: rgba(255, 255, 255, 0.10);
-    border: 1px solid rgba(255, 255, 255, 0.20);
+    background: var(--hc-surface-2);
+    border: 1px solid var(--hc-border);
     border-radius: 0.75rem;
     padding: 0.625rem 1rem;
-    color: #fff;
+    color: var(--hc-text);
     font-size: 0.875rem;
     transition: border-color 0.18s, box-shadow 0.18s;
     outline: none;
 }
 
 .settings-input::placeholder {
-    color: rgba(255, 255, 255, 0.30);
+    color: var(--hc-text-3);
 }
 
 .settings-input:focus {
-    border-color: rgba(96, 165, 250, 0.60);
-    box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.20);
+    border-color: var(--hc-accent);
+    box-shadow: 0 0 0 2px var(--hc-accent-soft);
 }
 
 .settings-actions {

--- a/templates/web/settings.html.twig
+++ b/templates/web/settings.html.twig
@@ -6,7 +6,7 @@
 
 <div class="max-w-xl mx-auto flex flex-col gap-6">
 
-    <h1 class="text-2xl font-bold text-white">Paramètres du compte</h1>
+    <h1 class="text-2xl font-bold" style="color: var(--hc-text)">Paramètres du compte</h1>
 
     {# ── Card profil ── #}
     <div class="settings-card">


### PR DESCRIPTION
## Résumé

- Remplacement de toutes les couleurs hardcodées en blanc dans `settings.css` par les variables `--hc-*` (text, surface, border, accent)
- Correction du `text-white` sur le `<h1>` dans `settings.html.twig`

Les champs, labels et titres sont maintenant lisibles en mode clair comme en mode sombre.

## Test plan

- [ ] Vérifier la page Paramètres en mode clair : textes, labels, inputs lisibles
- [ ] Vérifier la page Paramètres en mode sombre : rendu intact