### PR TITLE
🔧 fix(layout): corriger le scroll masqué par la tab-bar sur mobile

### DIFF
--- a/assets/styles/layout.css
+++ b/assets/styles/layout.css
@@ -510,7 +510,14 @@ nav:hover .navbar-logo-cloud {
 	.hc-sidebar-close { display: inline-flex; }
 	.hc-topbar-burger { display: inline-flex; }
 
-	.hc-content { padding: 20px 16px 80px; }
+	.hc-content {
+		padding: 20px 16px 0;
+	}
+	.hc-content::after {
+		content: '';
+		display: block;
+		height: 88px;
+	}
 	.hc-topbar { padding: 10px 16px; }
 }
 


### PR DESCRIPTION
## Résumé

Sur mobile, `padding-bottom` dans un conteneur `overflow: auto` est ignoré par Safari et Chrome mobile — le contenu en bas de page était coupé par la tab-bar fixe (64px).

Remplacement du `padding-bottom: 80px` par un pseudo-élément `::after { height: 88px }` sur `.hc-content`, qui force la zone scrollable à inclure l'espace nécessaire sous le dernier élément.

## Test plan

- [ ] Sur mobile (ou DevTools responsive), vérifier que la page Paramètres scrolle jusqu'aux boutons sans qu'ils soient cachés par la tab-bar
- [ ] Vérifier sur iOS Safari et Chrome Android