### PR TITLE
🔧 fix(layout): réduire la grille de 64px sur mobile pour libérer la tab-bar

### DIFF
--- a/assets/styles/layout.css
+++ b/assets/styles/layout.css
@@ -487,7 +487,7 @@ nav:hover .navbar-logo-cloud {
 @media (max-width: 767px) {
 	.hc-app-grid {
 		grid-template-columns: 1fr;
-		height: 100%;
+		height: calc(100% - 64px);
 	}
 
 	.hc-sidebar {
@@ -510,14 +510,7 @@ nav:hover .navbar-logo-cloud {
 	.hc-sidebar-close { display: inline-flex; }
 	.hc-topbar-burger { display: inline-flex; }
 
-	.hc-content {
-		padding: 20px 16px 0;
-	}
-	.hc-content::after {
-		content: '';
-		display: block;
-		height: 88px;
-	}
+	.hc-content { padding: 20px 16px 24px; }
 	.hc-topbar { padding: 10px 16px; }
 }
 


### PR DESCRIPTION
## Résumé

Le `::after` précédent ne suffisait pas — `.hc-layout-main { overflow: hidden }` clippait le contenu jusqu'au bas du viewport, exactement là où la tab-bar fixe (64px) se posait par-dessus.

Correction : `height: calc(100% - 64px)` sur `.hc-app-grid` en mobile — le grid s'arrête juste au-dessus de la tab-bar, le contenu est entièrement scrollable sans être masqué.

## Test plan

- [ ] Sur mobile, vérifier que la page Paramètres scrolle jusqu'aux boutons
- [ ] Vérifier que toutes les pages (Fichiers, Galerie, Albums) scrollent correctement
- [ ] Vérifier que la tab-bar reste bien visible en bas