### PR TITLE
🔧 fix(layout): ajouter min-height:0 sur .hc-content pour activer le scroll

### DIFF
--- a/assets/styles/layout.css
+++ b/assets/styles/layout.css
@@ -435,6 +435,7 @@ nav:hover .navbar-logo-cloud {
 /* ── Contenu scrollable ── */
 .hc-content {
 	flex: 1;
+	min-height: 0;
 	overflow: auto;
 	padding: 28px 32px;
 	color: var(--hc-text);


### PR DESCRIPTION
## Résumé

Bug classique flex + overflow : sans `min-height: 0`, un flex child conserve `min-height: auto` et s'étend au-delà de la hauteur de son parent. `overflow: auto` ne se déclenche jamais — `.hc-layout-main { overflow: hidden }` clippe silencieusement le bas du contenu, rendant les boutons en bas de page inaccessibles sur mobile.

## Test plan

- [ ] Page Paramètres sur mobile : scroller jusqu'aux boutons, aucun élément masqué par la tab-bar
- [ ] Pages longues (fichiers, dossiers imbriqués) : scroll correct sur desktop et mobile