### PR TITLE
🔧 fix(layout): scroll naturel du body sur mobile

### DIFF
--- a/assets/styles/layout.css
+++ b/assets/styles/layout.css
@@ -486,9 +486,30 @@ nav:hover .navbar-logo-cloud {
 
 /* ── Mobile (< 768px) ── */
 @media (max-width: 767px) {
+	html, body {
+		height: auto;
+		min-height: 100%;
+		overflow-x: hidden;
+	}
+
 	.hc-app-grid {
-		grid-template-columns: 1fr;
-		height: calc(100% - 64px);
+		display: flex;
+		flex-direction: column;
+		height: auto;
+		min-height: 100vh;
+	}
+
+	.hc-layout-main {
+		flex: 1;
+		height: auto;
+		overflow: visible;
+	}
+
+	.hc-content {
+		flex: none;
+		min-height: 0;
+		overflow: visible;
+		padding: 20px 16px 88px;
 	}
 
 	.hc-sidebar {
@@ -510,8 +531,6 @@ nav:hover .navbar-logo-cloud {
 
 	.hc-sidebar-close { display: inline-flex; }
 	.hc-topbar-burger { display: inline-flex; }
-
-	.hc-content { padding: 20px 16px 24px; }
 	.hc-topbar { padding: 10px 16px; }
 }
 


### PR DESCRIPTION
## Résumé

Les approches précédentes (`height: calc(100% - 64px)`, `min-height: 0`, `::after`) échouaient toutes car `100vh`/`100%` ne correspondent pas à la hauteur visible réelle sur iOS Safari et Chrome Android (barre d'URL dynamique, barre de navigation).

**Nouvelle approche** : le body scrolle naturellement sur mobile.
- `html, body { height: auto }` — plus de hauteur contrainte
- `.hc-layout-main { overflow: visible }` — plus de clip
- `.hc-content { padding-bottom: 88px }` — espace libre sous la tab-bar fixe (64px + marge)

## Test plan

- [ ] Page Paramètres sur mobile (iOS Safari + Chrome Android) : scroll jusqu'aux boutons, rien masqué par la tab-bar
- [ ] Pages longues : scroll correct
- [ ] Desktop inchangé