### PR TITLE
🔧 fix(layout): corriger le scroll mobile/laptop

### DIFF
--- a/assets/styles/layout.css
+++ b/assets/styles/layout.css
@@ -486,30 +486,26 @@ nav:hover .navbar-logo-cloud {
 
 /* ── Mobile (< 768px) ── */
 @media (max-width: 767px) {
-	html, body {
-		height: auto;
-		min-height: 100%;
-		overflow-x: hidden;
+	body {
+		padding-bottom: 64px;
 	}
 
 	.hc-app-grid {
-		display: flex;
-		flex-direction: column;
-		height: auto;
-		min-height: 100vh;
+		grid-template-columns: 1fr;
+		height: 100%;
 	}
 
 	.hc-layout-main {
-		flex: 1;
-		height: auto;
-		overflow: visible;
+		height: 100%;
+		overflow: hidden;
 	}
 
 	.hc-content {
-		flex: none;
+		flex: 1;
 		min-height: 0;
-		overflow: visible;
-		padding: 20px 16px 88px;
+		overflow: auto;
+		-webkit-overflow-scrolling: touch;
+		padding: 20px 16px 24px;
 	}
 
 	.hc-sidebar {


### PR DESCRIPTION
## Cause racine

La media query mobile overridait `overflow: visible` sur `.hc-content`, supprimant le scroll container. `.hc-layout-main { overflow: hidden }` clippait silencieusement le contenu sans scrollbar — affectait mobile ET toute fenêtre ≤ 767px (laptop).

## Solution

- `body { padding-bottom: 64px }` (border-box) → content area = `100vh - 64px`
- `.hc-app-grid { height: 100% }` → remplit exactement l'espace au-dessus de la tab-bar
- `.hc-content { flex: 1; min-height: 0; overflow: auto; -webkit-overflow-scrolling: touch }` → scroll container fiable sur iOS et Android

## Test plan

- [ ] Page Paramètres sur mobile : boutons visibles et accessibles
- [ ] Fenêtre laptop réduite à < 767px : scroll fonctionnel
- [ ] Desktop > 767px : rendu inchangé