### PR TITLE
fix(dashboard): palette, layout et redirection post-login

### DIFF
--- a/assets/styles/button.css
+++ b/assets/styles/button.css
@@ -20,13 +20,13 @@
 	display: inline-flex;
 	align-items: center;
 	gap: 0.4rem;
+	box-shadow: var(--hc-shadow-crisp);
+	transition: box-shadow 0.15s ease, background 0.15s ease;
 }
 .btn-primary:hover:not(:disabled) {
 	background: var(--hc-accent-2);
-	transform: translateY(-1px);
-	box-shadow: 0 8px 20px -4px var(--hc-accent);
+	box-shadow: none;
 }
-.btn-primary:active:not(:disabled) { transform: translateY(0); }
 
 .btn-soft {
 	background: var(--hc-surface-2);

--- a/assets/styles/dashboard.css
+++ b/assets/styles/dashboard.css
@@ -125,6 +125,13 @@
 }
 .hc-btn-primary:hover { box-shadow: none; }
 
+/* ── Bouton "tinted" — fond accent-soft, ombre crisp qui disparaît au survol ── */
+.hc-btn-soft {
+  box-shadow: var(--hc-shadow-crisp);
+  transition: box-shadow .15s ease;
+}
+.hc-btn-soft:hover { box-shadow: none; }
+
 /* ── Nav sidebar : ombre légère au survol des items non sélectionnés ── */
 .hc-nav-item:hover {
   box-shadow: var(--hc-shadow-crisp);

--- a/assets/styles/layout.css
+++ b/assets/styles/layout.css
@@ -150,12 +150,14 @@ details[open] > .sidebar-folder-summary .sidebar-toggle-icon::before { content: 
 	--hc-shadow-crisp: 2px 3px 8px -1px rgba(35, 35, 35, 0.20);
 
 	/* Surfaces & texte (light) */
-	--hc-bg:           #f4f5f8;
+	--hc-bg:           #FAFAFA;
 	--hc-bg-2:         #eceef3;
-	--hc-surface:      rgba(255, 255, 255, 0.72);
-	--hc-surface-2:    rgba(255, 255, 255, 0.55);
-	--hc-surface-strong: rgba(255, 255, 255, 0.92);
+	--hc-surface:      #FFFFFF;
+	--hc-surface-2:    #F7F8FA;
+	--hc-surface-strong: #FFFFFF;
+	--hc-input:        #F4F5F8;
 	--hc-border:       rgba(15, 23, 42, 0.08);
+	--hc-border-row:   rgba(15, 23, 42, 0.06);
 	--hc-border-strong: rgba(15, 23, 42, 0.14);
 	--hc-text:         #0b1220;
 	--hc-text-2:       #475569;
@@ -195,12 +197,14 @@ details[open] > .sidebar-folder-summary .sidebar-toggle-icon::before { content: 
 
 	--hc-shadow-crisp: 2px 3px 8px -1px rgba(0, 0, 0, 0.35);
 
-	--hc-bg:           #07090f;
+	--hc-bg:           #0A0C12;
 	--hc-bg-2:         #0a0d16;
-	--hc-surface:      rgba(20, 25, 38, 0.55);
-	--hc-surface-2:    rgba(20, 25, 38, 0.35);
-	--hc-surface-strong: rgba(28, 33, 48, 0.85);
-	--hc-border:       rgba(255, 255, 255, 0.08);
+	--hc-surface:      #12141C;
+	--hc-surface-2:    #161822;
+	--hc-surface-strong: #12141C;
+	--hc-input:        #181B26;
+	--hc-border:       rgba(255, 255, 255, 0.09);
+	--hc-border-row:   rgba(255, 255, 255, 0.06);
 	--hc-border-strong: rgba(255, 255, 255, 0.16);
 	--hc-text:         #e6ebf5;
 	--hc-text-2:       #9aa4b8;
@@ -223,12 +227,14 @@ details[open] > .sidebar-folder-summary .sidebar-toggle-icon::before { content: 
 
 		--hc-shadow-crisp: 2px 3px 8px -1px rgba(0, 0, 0, 0.35);
 
-		--hc-bg:           #07090f;
+		--hc-bg:           #0A0C12;
 		--hc-bg-2:         #0a0d16;
-		--hc-surface:      rgba(20, 25, 38, 0.55);
-		--hc-surface-2:    rgba(20, 25, 38, 0.35);
-		--hc-surface-strong: rgba(28, 33, 48, 0.85);
-		--hc-border:       rgba(255, 255, 255, 0.08);
+		--hc-surface:      #12141C;
+		--hc-surface-2:    #161822;
+		--hc-surface-strong: #12141C;
+		--hc-input:        #181B26;
+		--hc-border:       rgba(255, 255, 255, 0.09);
+		--hc-border-row:   rgba(255, 255, 255, 0.06);
 		--hc-border-strong: rgba(255, 255, 255, 0.16);
 		--hc-text:         #e6ebf5;
 		--hc-text-2:       #9aa4b8;

--- a/assets/styles/layout.css
+++ b/assets/styles/layout.css
@@ -319,9 +319,7 @@ nav:hover .navbar-logo-cloud {
 	padding: 16px;
 	height: 100%;
 	border-right: 1px solid var(--hc-border);
-	background: linear-gradient(180deg, var(--hc-surface-2), transparent);
-	backdrop-filter: blur(20px) saturate(180%);
-	-webkit-backdrop-filter: blur(20px) saturate(180%);
+	background: var(--hc-surface);
 	overflow-y: auto;
 	transition: transform 0.25s ease;
 }

--- a/assets/styles/layout.css
+++ b/assets/styles/layout.css
@@ -249,6 +249,7 @@ html, body {
 	height: 100%;
 	margin: 0;
 	padding: 0;
+	overflow: hidden;
 }
 body {
 	box-sizing: border-box;
@@ -597,6 +598,10 @@ nav:hover .navbar-logo-cloud {
 	width: 100%;
 	max-width: 420px;
 	padding: 2rem;
+	background: var(--hc-surface);
+	border: 1px solid var(--hc-border);
+	border-radius: 6px;
+	box-shadow: var(--hc-shadow-crisp);
 }
 
 .login-header {
@@ -608,8 +613,8 @@ nav:hover .navbar-logo-cloud {
 	width: 3.5rem;
 	height: 3.5rem;
 	margin: 0 auto 1rem;
-	border-radius: 0.75rem;
-	background: linear-gradient(135deg, var(--hc-accent), var(--hc-accent-2));
+	border-radius: 6px;
+	background: var(--hc-accent);
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -39,7 +39,7 @@ security:
                 username_parameter: email
                 password_parameter: password
                 enable_csrf: true
-                default_target_path: app_explorer
+                default_target_path: app_home
             logout:
                 path: app_logout
                 target: app_login

--- a/config/packages/test/security.yaml
+++ b/config/packages/test/security.yaml
@@ -34,7 +34,7 @@ security:
                 username_parameter: email
                 password_parameter: password
                 enable_csrf: true
-                default_target_path: app_explorer
+                default_target_path: app_home
             logout:
                 path: app_logout
                 target: app_login

--- a/src/Controller/Web/LoginController.php
+++ b/src/Controller/Web/LoginController.php
@@ -19,7 +19,7 @@ final class LoginController extends AbstractController
     public function login(AuthenticationUtils $authenticationUtils): Response
     {
         if ($this->getUser()) {
-            return $this->redirectToRoute('app_explorer');
+            return $this->redirectToRoute('app_home');
         }
 
         return $this->render('web/login.html.twig', [

--- a/templates/components/FolderCard.html.twig
+++ b/templates/components/FolderCard.html.twig
@@ -1,9 +1,9 @@
 {# Composant FolderCard — Carte dossier #}
 {% import 'macros/icon.html.twig' as icons %}
-<div class="folder-card">
+<div class="folder-card p-4 rounded-md border border-gray-200 dark:border-gray-700 shadow-[var(--hc-shadow-crisp)]">
 	<a href="{{ path('app_explorer', { folder: item.id }) }}" class="block">
-		<div class="folder-icon">{{ icons.icon('folder', 24) }}</div>
-		<div class="folder-name">{{ item.name }}</div>
+		<div class="folder-icon text-gray-600 dark:text-gray-400 mb-2">{{ icons.icon('folder', 24) }}</div>
+		<div class="folder-name font-semibold text-sm text-gray-800 dark:text-gray-100 truncate">{{ item.name }}</div>
 	</a>
 	<div class="folder-actions flex justify-end items-center mt-2 gap-2">
 		<button type="button"

--- a/templates/components/FoldersGrid.html.twig
+++ b/templates/components/FoldersGrid.html.twig
@@ -1,5 +1,5 @@
 {# Composant FoldersGrid — Grille de dossiers et fichiers #}
-<div class="folders-grid">
+<div class="folders-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
   {% if folders is empty and files is empty %}
     <twig:EmptyState
       title="Aucun fichier ni dossier"

--- a/templates/components/NewMenu.html.twig
+++ b/templates/components/NewMenu.html.twig
@@ -3,7 +3,7 @@
     <button id="new-menu-btn"
             data-testid="new-btn"
             type="button"
-            class="hc-btn-primary"
+            class="hc-btn-soft"
             style="width:100%; display:flex; align-items:center; gap:0.5rem; padding:0.6rem 1rem;
                    border-radius:6px; background:var(--hc-accent-soft); border:none;
                    cursor:pointer;

--- a/templates/components/NewMenu.html.twig
+++ b/templates/components/NewMenu.html.twig
@@ -3,12 +3,11 @@
     <button id="new-menu-btn"
             data-testid="new-btn"
             type="button"
+            class="hc-btn-primary"
             style="width:100%; display:flex; align-items:center; gap:0.5rem; padding:0.6rem 1rem;
-                   border-radius:2rem; background:#fff; border:1px solid #e5e7eb;
-                   box-shadow:0 1px 4px rgba(0,0,0,0.08); cursor:pointer;
-                   font-size:0.875rem; font-weight:600; color:#374151; transition:box-shadow 0.15s;"
-            onmouseover="this.style.boxShadow='0 3px 10px rgba(0,0,0,0.13)'"
-            onmouseout="this.style.boxShadow='0 1px 4px rgba(0,0,0,0.08)'">
+                   border-radius:6px; background:var(--hc-accent-soft); border:none;
+                   cursor:pointer;
+                   font-size:0.875rem; font-weight:600; color:var(--hc-accent);">
         <span style="font-size:1.1rem; font-weight:300;">＋</span> Nouveau
     </button>
 

--- a/templates/web/dashboard.html.twig
+++ b/templates/web/dashboard.html.twig
@@ -4,7 +4,7 @@
 
 {% block content %}
 
-<div class="flex flex-col gap-7 max-w-[1100px] mx-auto min-h-full">
+<div class="flex flex-col gap-7 max-w-[1100px] mx-auto h-full">
 
   <!-- En-tête avec salutation et bouton Importer -->
   <div class="flex items-center justify-between">

--- a/templates/web/dashboard.html.twig
+++ b/templates/web/dashboard.html.twig
@@ -9,11 +9,11 @@
   <!-- En-tête avec salutation et bouton Importer -->
   <div class="flex items-center justify-between">
     <div>
-      <h1 class="text-2xl font-black tracking-tight mb-1">Bonjour, {{ app.user.displayName }}</h1>
+      <h1 class="text-2xl font-black tracking-tight mb-1">Bonjour {{ app.user.displayName }}</h1>
       <p class="text-sm font-medium text-slate-500">{{ 'now'|date('d F Y', false, 'fr_FR') }}</p>
     </div>
     <button onclick="document.getElementById('upload-modal')?.showModal && document.getElementById('upload-modal').showModal()"
-            class="hc-btn-primary flex items-center gap-2 px-4 py-2 rounded-md font-semibold text-sm cursor-pointer"
+            class="hc-btn-soft flex items-center gap-2 px-4 py-2 rounded-md font-semibold text-sm cursor-pointer"
             style="background: var(--hc-accent-soft); color: var(--hc-accent);">
       <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>

--- a/templates/web/dashboard.html.twig
+++ b/templates/web/dashboard.html.twig
@@ -4,7 +4,7 @@
 
 {% block content %}
 
-<div class="flex flex-col gap-7 max-w-3xl">
+<div class="flex flex-col gap-7 max-w-[1100px] mx-auto min-h-full">
 
   <!-- En-tête avec salutation et bouton Importer -->
   <div class="flex items-center justify-between">
@@ -77,7 +77,7 @@
   </div>
 
   <!-- Section Fichiers récents -->
-  <div>
+  <div class="flex-1 flex flex-col">
     <div class="flex items-center justify-between mb-3">
       <h2 class="font-bold text-base">Fichiers récents</h2>
       <a href="{{ path('app_explorer') }}" class="font-semibold text-sm text-red-600 hover:text-red-700 transition-colors">Tout voir</a>

--- a/templates/web/dashboard.html.twig
+++ b/templates/web/dashboard.html.twig
@@ -13,7 +13,8 @@
       <p class="text-sm font-medium text-slate-500">{{ 'now'|date('d F Y', false, 'fr_FR') }}</p>
     </div>
     <button onclick="document.getElementById('upload-modal')?.showModal && document.getElementById('upload-modal').showModal()"
-            class="hc-btn-primary flex items-center gap-2 px-4 py-2 rounded-lg bg-red-600 text-white font-semibold text-sm cursor-pointer hover:bg-red-700 transition-colors">
+            class="hc-btn-primary flex items-center gap-2 px-4 py-2 rounded-md font-semibold text-sm cursor-pointer"
+            style="background: var(--hc-accent-soft); color: var(--hc-accent);">
       <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
         <path d="M17 8l-5-5-5 5"></path>

--- a/templates/web/layout.html.twig
+++ b/templates/web/layout.html.twig
@@ -21,7 +21,7 @@
 
         {# En-tête : logo + bouton fermeture (mobile) #}
         <div class="hc-sidebar-header">
-            <a href="{{ path('app_explorer') }}" class="hc-brand">
+            <a href="{{ path('app_home') }}" class="hc-brand">
                 <div class="hc-brand-icon">
                     {{ icons.icon('cloud', 16) }}
                 </div>

--- a/templates/web/login.html.twig
+++ b/templates/web/login.html.twig
@@ -6,7 +6,7 @@
 
 {% block body %}
 <div class="login-wrapper">
-  <div class="glass-strong login-card">
+  <div class="login-card">
 
     <div class="login-header">
       <div class="login-logo">

--- a/tests/Integration/DashboardCssTest.php
+++ b/tests/Integration/DashboardCssTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+final class DashboardCssTest extends TestCase
+{
+    public function testDashboardCssFileExists(): void
+    {
+        $cssPath = __DIR__ . '/../../assets/styles/dashboard.css';
+        self::assertFileExists($cssPath, 'dashboard.css should exist');
+    }
+
+    public function testDashboardCssContainsStatGridClass(): void
+    {
+        $cssPath = __DIR__ . '/../../assets/styles/dashboard.css';
+        $cssContent = file_get_contents($cssPath);
+        self::assertStringContainsString('.hc-stat-grid', $cssContent);
+    }
+
+    public function testDashboardCssContainsStatCardClass(): void
+    {
+        $cssPath = __DIR__ . '/../../assets/styles/dashboard.css';
+        $cssContent = file_get_contents($cssPath);
+        self::assertStringContainsString('.hc-stat-card', $cssContent);
+    }
+
+    public function testDashboardCssContainsFileListClass(): void
+    {
+        $cssPath = __DIR__ . '/../../assets/styles/dashboard.css';
+        $cssContent = file_get_contents($cssPath);
+        self::assertStringContainsString('.hc-file-list', $cssContent);
+    }
+
+    public function testDashboardCssContainsFileRowClass(): void
+    {
+        $cssPath = __DIR__ . '/../../assets/styles/dashboard.css';
+        $cssContent = file_get_contents($cssPath);
+        self::assertStringContainsString('.hc-file-row', $cssContent);
+    }
+
+    public function testDashboardCssIsImportedInAppCss(): void
+    {
+        $appCssPath = __DIR__ . '/../../assets/styles/app.css';
+        $appCssContent = file_get_contents($appCssPath);
+        self::assertStringContainsString('dashboard.css', $appCssContent);
+    }
+}

--- a/tests/Web/WebAuthTest.php
+++ b/tests/Web/WebAuthTest.php
@@ -61,7 +61,7 @@ final class WebAuthTest extends WebTestCase
         $this->createUser();
         $this->login();
 
-        $this->assertResponseRedirects('/explorer');
+        $this->assertResponseRedirects('/');
     }
 
     public function testAfterLoginDashboardIsAccessible(): void


### PR DESCRIPTION
## Summary
- Aligne la palette de couleurs et les boutons ("Nouveau", "Importer", "Se connecter") sur le design system flat officiel (accent-soft, ombre crisp qui disparaît au survol, radius 6px) — remplace les résidus de glassmorphism (blur, gradients, ombres floues amplifiées au hover)
- Répare le rendu de la grille de dossiers/fichiers de `/explorer` (classes CSS manquantes)
- Corrige la largeur/hauteur du container dashboard pour occuper tout l'espace disponible (`max-width: 1100px` centré, hauteur bornée strictement)
- Corrige la redirection post-authentification : pointait encore vers `/explorer` (reliquat du déplacement de l'explorateur), redirige maintenant vers `/` (dashboard)
- Ajoute `overflow: hidden` sur html/body pour empêcher la page de scroller au-delà du viewport

## Test plan
- [x] Suite PHPUnit complète : 365 tests passants (`WebAuthTest` incluant le test de redirection post-login mis à jour)
- [x] Build Tailwind recompilé à chaque étape (`composer build-assets`)
- [ ] Vérification visuelle manuelle : dashboard, explorateur, page de login (light/dark mode)