### PR TITLE
🎨 Aligner /explorer sur le design system du dashboard

### DIFF
--- a/.github/avancement.md
+++ b/.github/avancement.md
@@ -1,8 +1,20 @@
 # 📋 Avancement — HomeCloud API
 
-> Dernière mise à jour : 2026-05-06
+> Dernière mise à jour : 2026-07-12
 
-> **Status git :** `main` — PR #169 mergée — 334 tests ✅
+> **Status git :** branche `feat/explorer-design-alignment` — 368 tests ✅
+
+---
+
+## 🎨 Alignement design /explorer sur le dashboard (2026-07-12)
+
+Migration de la page `/explorer` (Mes fichiers) vers le design system `--hc-*` déjà en place sur le dashboard (PR #183/#185). Voir [plan.md](../plan.md) pour le détail.
+
+- `assets/styles/explorer.css` créé : cartes, pastilles icône, actions, dropzone, état vide — cohérents avec `dashboard.css`
+- Sidebar dossiers (`layout.css`) migrée vers les variables `--hc-*` ; suppression d'un bloc `@media (prefers-color-scheme: dark)` redondant qui ignorait le toggle `[data-theme]`
+- `ImportCard`, `FolderCard`, `FileCard`, `EmptyState`, `Breadcrumbs` restylés (fini les hex en dur type `#a5b4fc`, `text-white`, dégradés violets)
+- En-tête de page ajouté (`h1` + décompte dossiers/fichiers), `ExplorerController` passe désormais `folderCount`/`fileCount`
+- Corrigé au passage : `login()` dans `ExplorerPageTest` suivait la redirection post-login vers `/dashboard` (commit #185) au lieu de rester sur `/explorer` — 6 tests cassés remis au vert
 
 ---
 

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -3,6 +3,7 @@
 @import "./form.css";
 @import "./layout.css";
 @import "./dashboard.css";
+@import "./explorer.css";
 @import "./liquid-glass.css";
 @import "./upload.css";
 @import "./settings.css";

--- a/assets/styles/explorer.css
+++ b/assets/styles/explorer.css
@@ -45,6 +45,16 @@
 .hc-item-icon--image  { background: var(--hc-accent-soft); color: var(--hc-accent); }
 .hc-item-icon--doc    { background: var(--hc-green-soft);  color: var(--hc-green); }
 
+/* ── Pastille icône import (dropzone) — variante large ── */
+.hc-item-icon--lg {
+  width: 56px;
+  height: 56px;
+}
+.hc-item-icon--lg svg {
+  width: 28px;
+  height: 28px;
+}
+
 /* ── Typo carte ── */
 .hc-item-name {
   font: 600 13.5px 'Geist', sans-serif;

--- a/assets/styles/explorer.css
+++ b/assets/styles/explorer.css
@@ -1,0 +1,110 @@
+/*
+ * assets/styles/explorer.css
+ * Styles pour l'explorateur de fichiers (/explorer)
+ * Aligné sur le design system du dashboard (assets/styles/dashboard.css).
+ * Dépend des variables --hc-* définies dans layout.css.
+ */
+
+/* ── Layout explorateur (aside + contenu) ── */
+.hc-explorer-grid {
+  display: flex;
+  gap: 16px;
+}
+
+/* ── En-tête de page ── */
+.hc-page-sub {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--hc-text-3);
+}
+
+/* ── Carte unifiée dossier / fichier ── */
+.hc-item-card {
+  background: var(--hc-surface);
+  border: 1px solid var(--hc-border);
+  border-radius: 6px;
+  padding: 16px;
+  box-shadow: var(--hc-shadow-crisp);
+  transition: background .15s ease;
+}
+.hc-item-card:hover {
+  background: var(--hc-surface-2);
+}
+
+/* ── Pastille icône ── */
+.hc-item-icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.hc-item-icon--folder { background: var(--hc-indigo-soft); color: var(--hc-indigo); }
+.hc-item-icon--image  { background: var(--hc-accent-soft); color: var(--hc-accent); }
+.hc-item-icon--doc    { background: var(--hc-green-soft);  color: var(--hc-green); }
+
+/* ── Typo carte ── */
+.hc-item-name {
+  font: 600 13.5px 'Geist', sans-serif;
+  color: var(--hc-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hc-item-meta {
+  font: 500 12px 'Geist', sans-serif;
+  color: var(--hc-text-3);
+  margin-top: 2px;
+}
+
+/* ── Actions carte ── */
+.hc-item-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.hc-item-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px;
+  border-radius: 6px;
+  color: var(--hc-text-3);
+  transition: background .15s ease, color .15s ease;
+  cursor: pointer;
+}
+.hc-item-action--edit:hover { color: var(--hc-green);  background: var(--hc-green-soft); }
+.hc-item-action--move:hover { color: var(--hc-indigo); background: var(--hc-indigo-soft); }
+.hc-item-action--danger:hover { color: var(--hc-err); background: rgba(239, 68, 68, 0.10); }
+
+/* ── Dropzone d'import ── */
+.hc-dropzone {
+  border: 2px dashed var(--hc-border-strong);
+  border-radius: 6px;
+  transition: border-color .15s ease, background .15s ease;
+}
+.hc-dropzone.drop-active {
+  border-color: var(--hc-accent);
+  background: var(--hc-accent-soft);
+}
+
+/* ── État vide ── */
+.hc-empty-state h2 {
+  color: var(--hc-text);
+}
+.hc-empty-state p {
+  color: var(--hc-text-3);
+}
+
+/* ── Responsive ── */
+@media (max-width: 767px) {
+  .hc-explorer-grid {
+    flex-direction: column;
+  }
+}

--- a/assets/styles/layout.css
+++ b/assets/styles/layout.css
@@ -7,7 +7,7 @@
 .sidebar-folders-title {
 	font-size: 0.85rem;
 	font-weight: 600;
-	color: #94a3b8;
+	color: var(--hc-text-3);
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 	padding-left: 0.5rem;
@@ -25,9 +25,9 @@
 	align-items: center;
 	gap: 0.4rem;
 	padding: 0.35rem 0.5rem;
-	border-radius: 0.6rem;
+	border-radius: 6px;
 	font-size: 0.875rem;
-	color: #6b7280;
+	color: var(--hc-text-2);
 	text-decoration: none;
 	transition: background 0.15s, color 0.15s;
 	cursor: pointer;
@@ -36,13 +36,13 @@
 }
 .sidebar-folder-link:hover,
 .sidebar-folder-summary:hover {
-	background: #e5e7eb;
-	color: #111827;
+	background: var(--hc-surface-2);
+	color: var(--hc-text);
 }
 .sidebar-folder-link.active,
 .sidebar-folder-summary.active {
-	background: #e0e7ff;
-	color: #2563eb;
+	background: var(--hc-accent-soft);
+	color: var(--hc-accent);
 	font-weight: 600;
 }
 
@@ -110,28 +110,18 @@ details[open] > .sidebar-folder-summary .sidebar-toggle-icon::before { content: 
 	padding-left: 0.4rem;
 	margin-left: 0.35rem;
 	margin-right: 0.5rem;
-	border-left: 1.5px solid #d1d5db;
+	border-left: 1.5px solid var(--hc-border-strong);
 	display: flex;
 	flex-direction: column;
 	margin-top: 0.1rem;
 	margin-bottom: 0.1rem;
 }
 
-
-@media (prefers-color-scheme: dark) {
-	.sidebar-folder-link.active,
-	.sidebar-folder-summary.active {
-		background: #1e293b;
-		color: #a5b4fc;
-	}
-	.sidebar-folder-link:hover,
-	.sidebar-folder-summary:hover {
-		background: #334155;
-		color: #fff;
-	}
-	.sidebar-folder-children {
-		border-left-color: #475569;
-	}
+.sidebar-folder-empty {
+	font-size: 12.5px;
+	font-weight: 500;
+	color: var(--hc-text-3);
+	padding: 0.35rem 0.5rem;
 }
 /* === Variables de thème — design system HomeCloud === */
 :root {

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -46,13 +46,3 @@
    text-decoration: underline;
 }
 
-/* Import-card : zone de drop en évidence */
-.import-card {
-  border: 2.5px dashed #a5b4fc;
-  transition: border-color 0.18s;
-  padding: 2.5rem 2rem;
-}
-.import-card.drop-active {
-  border-color: #2563eb;
-  background: rgba(165,180,252,0.10);
-}

--- a/src/Controller/Web/ExplorerController.php
+++ b/src/Controller/Web/ExplorerController.php
@@ -76,6 +76,8 @@ final class ExplorerController extends AbstractController
             'breadcrumbSegments' => $breadcrumbSegments,
             'folders'            => $folders,
             'files'              => $files,
+            'folderCount'        => count($folders),
+            'fileCount'          => count($files),
             'sidebarTree'        => $this->folderRepository->findAllAsTree($user, $currentFolder),
         ]);
     }

--- a/src/Controller/Web/SearchController.php
+++ b/src/Controller/Web/SearchController.php
@@ -47,7 +47,7 @@ final class SearchController extends AbstractController
                 'id'       => $folder->getId()->toRfc4122(),
                 'name'     => $folder->getName(),
                 'isFolder' => true,
-                'url'      => '/?folder=' . $folder->getId()->toRfc4122(),
+                'url'      => '/explorer?folder=' . $folder->getId()->toRfc4122(),
             ];
         }
 
@@ -60,7 +60,7 @@ final class SearchController extends AbstractController
                 'size'       => $file->getSize(),
                 'folderId'   => $file->getFolder()->getId()->toRfc4122(),
                 'folderName' => $file->getFolder()->getName(),
-                'folderUrl'  => '/?folder=' . $file->getFolder()->getId()->toRfc4122(),
+                'folderUrl'  => '/explorer?folder=' . $file->getFolder()->getId()->toRfc4122(),
             ];
         }
 

--- a/src/Repository/FolderRepository.php
+++ b/src/Repository/FolderRepository.php
@@ -103,7 +103,7 @@ class FolderRepository extends ServiceEntityRepository implements FolderReposito
             $nodes[] = [
                 'id'       => $id,
                 'name'     => $folder->getName(),
-                'url'      => '/?folder=' . $id,
+                'url'      => '/explorer?folder=' . $id,
                 'isActive' => $currentFolder !== null && $folder->getId()->equals($currentFolder->getId()),
                 'isOpen'   => isset($openIds[$id]),
                 'children' => $this->buildTree($all, $folder, $openIds, $currentFolder),

--- a/templates/components/Breadcrumbs.html.twig
+++ b/templates/components/Breadcrumbs.html.twig
@@ -11,7 +11,7 @@
           {{- segment.label -}}
         {%- endif -%}
       </a>
-      {% if not loop.last %}&nbsp;&gt;&nbsp;{% endif %}
+      {% if not loop.last %}<svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-chevron-right" style="vertical-align: middle; margin: 0 2px; opacity:.6;"><polyline points="9 6 15 12 9 18"/></svg>{% endif %}
     {% else %}
       <span>{{ segment.label }}</span>
     {% endif %}

--- a/templates/components/EmptyState.html.twig
+++ b/templates/components/EmptyState.html.twig
@@ -1,14 +1,15 @@
 {# Composant EmptyState : affiche un état vide stylé avec icône, titre, sous-titre et action optionnelle #}
-<div class="flex flex-col items-center justify-center py-16 px-4 text-center">
+<div class="hc-empty-state flex flex-col items-center justify-center py-16 px-4 text-center">
   {% if icon %}
     <div class="mb-6 text-6xl opacity-40">{{ icon|raw }}</div>
   {% endif %}
-  <h2 class="text-2xl font-semibold text-white mb-2">{{ title }}</h2>
+  <h2 class="text-2xl font-semibold mb-2">{{ title }}</h2>
   {% if subtitle %}
-    <p class="text-white/60 mb-6">{{ subtitle }}</p>
+    <p class="mb-6">{{ subtitle }}</p>
   {% endif %}
   {% if actionLabel and actionUrl %}
-    <a href="{{ actionUrl }}" class="inline-block px-6 py-2 rounded-2xl bg-blue-500 text-white font-medium shadow-lg hover:bg-blue-600 transition-all focus:outline-none focus:ring-2 focus:ring-blue-400/50">
+    <a href="{{ actionUrl }}" class="hc-btn-soft inline-block px-6 py-2 rounded-md font-semibold text-sm transition-all focus:outline-none focus:ring-2"
+       style="background: var(--hc-accent-soft); color: var(--hc-accent);">
       {{ actionLabel }}
     </a>
   {% endif %}

--- a/templates/components/FileCard.html.twig
+++ b/templates/components/FileCard.html.twig
@@ -1,6 +1,10 @@
 {# Composant FileCard — Carte fichier #}
-<div class="folder-card">
-	<div class="file-icon">
+<div class="folder-card hc-item-card">
+	<div class="file-icon hc-item-icon
+		{%- if item.mimeType starts with 'image/' %} hc-item-icon--image
+		{%- elseif item.mimeType starts with 'video/' or item.mimeType starts with 'audio/' or item.mimeType == 'application/pdf' %} hc-item-icon--doc
+		{%- else %} hc-item-icon--doc
+		{%- endif %} mb-2">
 		{% if item.mimeType starts with 'image/' %}<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-images"><path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5z"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
 			{% elseif item.mimeType starts with 'video/' %}<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-video"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
 			{% elseif item.mimeType starts with 'audio/' %}<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-music"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
@@ -8,10 +12,16 @@
 			{% else %}<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-file"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>
 		{% endif %}
 	</div>
-	<div class="file-name">{{ item.originalName ?? item.name }}</div>
-	<div class="file-meta">
+	<div class="file-name hc-item-name">{{ item.originalName ?? item.name }}</div>
+	<div class="file-meta hc-item-meta">
 		{% if item.size is defined %}
-			{{ item.size | number_format(0, ',', ' ') }} o ·
+			{% if item.size < 1024 %}
+				{{ item.size }} o ·
+			{% elseif item.size < 1048576 %}
+				{{ (item.size / 1024) | number_format(0, ',', ' ') }} Ko ·
+			{% else %}
+				{{ (item.size / 1048576) | number_format(1, ',', ' ') }} Mo ·
+			{% endif %}
 		{% endif %}
 		{% if item.createdAt is defined %}
 			{{ item.createdAt | date('d/m/Y') }}
@@ -20,22 +30,21 @@
 			<svg width="16" height="16" fill="currentColor" stroke="none" viewBox="0 0 24 24" class="hc-icon hc-icon-alert text-amber-500 inline ml-1" title="Fichier neutralisé"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><circle cx="12" cy="17" r="1"/><line x1="12" y1="9" x2="12" y2="13"/></svg>
 		{% endif %}
 	</div>
-	<div class="file-actions" style="margin-top:0.7rem; display:flex; gap:0.5rem;">
+	<div class="file-actions hc-item-actions">
 		{% if item.id is defined %}
-			
 			<a href="#"
 			   role="button"
 			   data-testid="rename-file-btn-{{ item.id }}"
-			   class="rename-btn p-2 rounded-lg text-gray-400 hover:text-green-600 hover:bg-green-50 dark:hover:bg-green-950/40 transition-colors"
+			   class="rename-btn hc-item-action hc-item-action--edit"
 			   title="Renommer {{ item.originalName ?? item.name|e('html') }}"
 			   data-file-id="{{ item.id }}"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-pencil"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg></a>
 			<a href="{{ path('app_file_download', { id: item.id }) }}"
-			   class="p-2 rounded-lg text-gray-400 hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-950/40 transition-colors"
+			   class="hc-item-action hc-item-action--move"
 			   title="Télécharger {{ item.originalName ?? item.name|e('html') }}"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-download"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></a>
 			<a href="#"
 			   role="button"
 			   data-testid="move-file-btn-{{ item.id }}"
-			   class="move-btn group relative p-2 rounded-lg text-gray-400 hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-950/40 transition-all duration-200 flex items-center gap-1.5"
+			   class="move-btn group relative hc-item-action hc-item-action--move flex items-center gap-1.5"
 			   title="Déplacer {{ (item.originalName ?? item.name)|e('html') }}"
 			   onclick="openGlobalMoveModal('file', '{{ item.id }}', '{{ (item.originalName ?? item.name)|e('js') }}'); return false;"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-arrow-up-right"><line x1="7" y1="17" x2="17" y2="7"/><polyline points="7 7 17 7 17 17"/></svg>
 				<span class="hidden group-hover:inline text-xs font-medium whitespace-nowrap">Déplacer {{ (item.originalName ?? item.name)|e('html') }}</span>
@@ -43,8 +52,8 @@
 			<form method="post" action="{{ path('app_file_delete', { id: item.id }) }}"
 			      onsubmit="return confirm('Supprimer « {{ item.originalName|e('js') }} » ?')">
 				<input type="hidden" name="folder_id" value="{{ item.folderId ?? '' }}">
-				<button type="submit" style="cursor:pointer;" 
-					class="delete-btn p-2 rounded-lg text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950/40 transition-colors"
+				<button type="submit"
+					class="delete-btn hc-item-action hc-item-action--danger"
 					title="Supprimer {{ (item.originalName ?? item.name)|e('html') }}"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-trash"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg></button>
 			</form>
 		{% endif %}

--- a/templates/components/FolderCard.html.twig
+++ b/templates/components/FolderCard.html.twig
@@ -1,19 +1,19 @@
 {# Composant FolderCard — Carte dossier #}
 {% import 'macros/icon.html.twig' as icons %}
-<div class="folder-card p-4 rounded-md border border-gray-200 dark:border-gray-700 shadow-[var(--hc-shadow-crisp)]">
+<div class="folder-card hc-item-card">
 	<a href="{{ path('app_explorer', { folder: item.id }) }}" class="block">
-		<div class="folder-icon text-gray-600 dark:text-gray-400 mb-2">{{ icons.icon('folder', 24) }}</div>
-		<div class="folder-name font-semibold text-sm text-gray-800 dark:text-gray-100 truncate">{{ item.name }}</div>
+		<div class="folder-icon hc-item-icon hc-item-icon--folder mb-2">{{ icons.icon('folder', 16) }}</div>
+		<div class="folder-name hc-item-name truncate">{{ item.name }}</div>
 	</a>
-	<div class="folder-actions flex justify-end items-center mt-2 gap-2">
+	<div class="folder-actions hc-item-actions">
 		<button type="button"
 		        data-testid="rename-folder-btn-{{ item.id }}"
-		        class="rename-btn p-2 rounded-lg text-gray-400 hover:text-green-600 hover:bg-green-50 dark:hover:bg-green-950/40 transition-colors"
+		        class="rename-btn hc-item-action hc-item-action--edit"
 		        title="Renommer {{ item.name|e('html') }}"
 		        data-folder-id="{{ item.id }}"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-pencil"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg></button>
 		<button type="button"
 		        data-testid="move-folder-btn-{{ item.id }}"
-		        class="move-btn group relative p-2 rounded-lg text-gray-400 hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-950/40 transition-all duration-200 flex items-center gap-1.5"
+		        class="move-btn group relative hc-item-action hc-item-action--move flex items-center gap-1.5"
 		        title="Déplacer {{ item.name|e('html') }}"
 		        onclick="openGlobalMoveModal('folder', '{{ item.id }}', '{{ item.name|e('js') }}')">
 			<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-arrow-up-right"><line x1="7" y1="17" x2="17" y2="7"/><polyline points="7 7 17 7 17 17"/></svg>
@@ -22,7 +22,7 @@
 		<button type="button"
 		        data-testid="delete-folder-btn-{{ item.id }}"
 		        data-empty="{{ ((item.children|length) == 0 and (item.files|length) == 0) ? '1' : '0' }}"
-		        class="delete-folder-btn p-2 rounded-lg text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950/40 transition-colors"
+		        class="delete-folder-btn hc-item-action hc-item-action--danger"
 		        title="Supprimer {{ item.name|e('html') }}"
 		        onclick="openDeleteFolderModal('{{ item.id }}', '{{ item.name|e('js') }}', '{{ item.parentId ?? '' }}', '{{ ((item.children|length) == 0 and (item.files|length) == 0) ? '1' : '0' }}')"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-trash"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg></button>
 	</div>

--- a/templates/components/ImportCard.html.twig
+++ b/templates/components/ImportCard.html.twig
@@ -2,15 +2,17 @@
 {% import 'macros/icon.html.twig' as icons %}
 
 {# Composant ImportCard — Zone d'import drag & drop + bouton #}
-<div class="import-card" id="main-import-card" data-testid="upload-zone">
-  <form method="post" action="{{ path('app_file_upload') }}" enctype="multipart/form-data" id="main-upload-form" style="display:flex; flex-direction:column; align-items:center; gap:1.2rem; width:100%;">
-    <div class="import-icon" style="font-size:2.5rem; color:#a5b4fc;">{{ icons.icon('cloud', 40) }}</div>
-    <div class="import-text" style="color:var(--hc-text); font-size:1.15rem; text-align:center; margin-bottom:0.5rem;">
+<div class="import-card hc-dropzone flex flex-col items-center gap-4 p-8 text-center" id="main-import-card" data-testid="upload-zone">
+  <form method="post" action="{{ path('app_file_upload') }}" enctype="multipart/form-data" id="main-upload-form" class="flex flex-col items-center gap-4 w-full">
+    <div class="import-icon hc-item-icon hc-item-icon--image" style="width:56px; height:56px;">{{ icons.icon('cloud', 28) }}</div>
+    <div class="import-text" style="color:var(--hc-text); font-size:1.05rem; text-align:center;">
       Cliquez pour importer un fichier<br>ou glissez-déposez ici
     </div>
     <input type="hidden" name="folder_id" value="{{ currentFolder ? currentFolder.id : '' }}">
     <input type="file" name="file" id="import-file-input" class="hidden" onchange="this.form.submit()">
-    <button type="button" class="import-btn" style="border:none; border-radius:1.2rem; background:linear-gradient(135deg, #e0c3fc 0%, #8ec5fc 100%); color:#222; font-weight:600; font-size:1.1rem; padding:0.8rem 2.2rem; box-shadow:0 2px 12px 0 rgba(31,38,135,0.10); cursor:pointer;" onclick="document.getElementById('import-file-input').click();">
+    <button type="button" class="import-btn hc-btn-soft font-semibold text-sm px-4 py-2 rounded-md cursor-pointer"
+            style="border:none; background: var(--hc-accent-soft); color: var(--hc-accent);"
+            onclick="document.getElementById('import-file-input').click();">
       Parcourir
     </button>
   </form>

--- a/templates/components/ImportCard.html.twig
+++ b/templates/components/ImportCard.html.twig
@@ -4,7 +4,7 @@
 {# Composant ImportCard — Zone d'import drag & drop + bouton #}
 <div class="import-card hc-dropzone flex flex-col items-center gap-4 p-8 text-center" id="main-import-card" data-testid="upload-zone">
   <form method="post" action="{{ path('app_file_upload') }}" enctype="multipart/form-data" id="main-upload-form" class="flex flex-col items-center gap-4 w-full">
-    <div class="import-icon hc-item-icon hc-item-icon--image" style="width:56px; height:56px;">{{ icons.icon('cloud', 28) }}</div>
+    <div class="import-icon hc-item-icon hc-item-icon--image hc-item-icon--lg">{{ icons.icon('cloud', 28) }}</div>
     <div class="import-text" style="color:var(--hc-text); font-size:1.05rem; text-align:center;">
       Cliquez pour importer un fichier<br>ou glissez-déposez ici
     </div>

--- a/templates/web/explorer.html.twig
+++ b/templates/web/explorer.html.twig
@@ -6,29 +6,38 @@
 
 {% set folderIcon %}<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/></svg>{% endset %}
 
-{# === ImportCard component === #}
-<twig:ImportCard :current-folder="currentFolder ?? null" />
+<div class="flex flex-col gap-7 max-w-[1100px] mx-auto h-full">
 
-{# === Explorateur === #}
-<div data-testid="file-explorer" class="flex gap-4">
-
-    {# Sidebar dossiers #}
-
-    <aside class="w-auto min-w-36 max-w-80 shrink-0">
-        <twig:SectionTitle text="Dossiers" :icon="folderIcon" />
-        <twig:SidebarFolders :tree="sidebarTree" />
-    </aside>
-
-    {# Liste fichiers #}
-    <div class="flex-1" data-testid="file-list">
-        {# Breadcrumbs inline avec le sidebar #}
-        <twig:Breadcrumbs :segments="breadcrumbSegments" />
-
-                {# === FoldersGrid component === #}
-                {# Fusionne dossiers et fichiers pour affichage unifié #}
-                <twig:FoldersGrid :folders="folders" :files="files" />
-                <!-- Suppression du code orphelin après migration vers FoldersGrid -->
+  {# En-tête de page #}
+  <div class="flex items-center justify-between">
+    <div>
+      <h1 class="text-2xl font-black tracking-tight mb-1">Mes fichiers</h1>
+      <p class="hc-page-sub">{{ folderCount }} dossiers · {{ fileCount }} fichiers</p>
     </div>
+  </div>
+
+  <twig:Breadcrumbs :segments="breadcrumbSegments" />
+
+  {# === ImportCard component === #}
+  <twig:ImportCard :current-folder="currentFolder ?? null" />
+
+  {# === Explorateur === #}
+  <div data-testid="file-explorer" class="hc-explorer-grid">
+
+      {# Sidebar dossiers #}
+      <aside class="w-auto min-w-36 max-w-80 shrink-0">
+          <twig:SectionTitle text="Dossiers" :icon="folderIcon" />
+          <twig:SidebarFolders :tree="sidebarTree" />
+      </aside>
+
+      {# Liste fichiers #}
+      <div class="flex-1" data-testid="file-list">
+          {# === FoldersGrid component === #}
+          {# Fusionne dossiers et fichiers pour affichage unifié #}
+          <twig:FoldersGrid :folders="folders" :files="files" />
+      </div>
+
+  </div>
 
 </div>
 

--- a/tests/Web/ExplorerPageTest.php
+++ b/tests/Web/ExplorerPageTest.php
@@ -57,6 +57,10 @@ final class ExplorerPageTest extends WebTestCase
         if ($this->client->getResponse()->isRedirect()) {
             $this->client->followRedirect();
         }
+
+        // Depuis #185, la redirection post-login pointe vers le dashboard (/) —
+        // ces tests ciblent l'explorateur, on y navigue donc explicitement.
+        $this->client->request('GET', '/explorer');
     }
 
     // --- Route /explorer ---
@@ -211,5 +215,49 @@ final class ExplorerPageTest extends WebTestCase
 
         $cloudIcons = $this->client->getCrawler()->filter('.import-card svg.hc-icon-cloud');
         $this->assertGreaterThanOrEqual(1, $cloudIcons->count(), 'ImportCard doit avoir icône cloud SVG');
+    }
+
+    // --- Alignement design system (dashboard) ---
+
+    public function testExplorerHasPageHeaderWithTitle(): void
+    {
+        $this->createUser();
+        $this->login();
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h1', 'Mes fichiers');
+    }
+
+    public function testExplorerHeaderShowsFolderAndFileCount(): void
+    {
+        $user = $this->createUser();
+
+        $folder = new Folder('Uploads', $user);
+        $this->em->persist($folder);
+        $this->em->flush();
+
+        $this->login();
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('.hc-page-sub', 'dossier');
+    }
+
+    public function testExplorerHasNoHardcodedLegacyColors(): void
+    {
+        $this->createUser();
+        $this->login();
+
+        $this->assertResponseIsSuccessful();
+        $crawler = $this->client->getCrawler();
+        $scoped = ($crawler->filter('.import-card')->html() ?: '')
+            . ($crawler->filter('[data-testid="file-explorer"]')->html() ?: '');
+
+        foreach (['#a5b4fc', '#e0c3fc', '#8ec5fc', 'bg-blue-500', 'text-white'] as $forbidden) {
+            $this->assertStringNotContainsString(
+                $forbidden,
+                $scoped,
+                sprintf('L\'explorateur ne doit plus contenir "%s" (couleur legacy hors design system)', $forbidden)
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Migration de la page `/explorer` (Mes fichiers) vers le design system `--hc-*` déjà en place sur le dashboard (#183/#185) : cartes, pastilles icône, actions, dropzone, état vide, sidebar dossiers — fini les hex en dur (`#a5b4fc`, `#e0c3fc`, `text-white`, dégradés violets)
- Ajout d'un en-tête de page (titre + décompte dossiers/fichiers) cohérent avec le dashboard
- **Bug corrigé** : `FolderRepository::findAllAsTree()` et `SearchController` généraient des URLs de dossiers en `/?folder=...` (route dashboard) au lieu de `/explorer?folder=...` — cliquer sur n'importe quel dossier dans la sidebar ou dans les résultats de recherche redirigeait vers le dashboard
- **Bug corrigé** : `login()` dans `ExplorerPageTest` suivait la redirection post-login vers `/dashboard` (#185) au lieu de rester sur `/explorer`, cassant 6 tests existants
- Suppression d'un bloc `@media (prefers-color-scheme: dark)` redondant dans la sidebar dossiers, qui ignorait le toggle `[data-theme]` de l'app

## Test plan
- [x] `./vendor/bin/phpunit` — 368/368 tests verts
- [x] Vérification visuelle manuelle (racine + navigation sous-dossier) par l'utilisateur, captures à l'appui
- [x] Sidebar : clic sur un dossier (n'importe lequel) navigue bien vers `/explorer?folder=...`
- [x] Aucune couleur legacy résiduelle dans l'explorateur (grep ciblé + test de non-régression)