### PR TITLE
🎨 Aligner /albums sur le design system du dashboard

### DIFF
--- a/.github/avancement.md
+++ b/.github/avancement.md
@@ -2,7 +2,18 @@
 
 > Dernière mise à jour : 2026-07-12
 
-> **Status git :** branche `feat/gallery-design-alignment` — 371 tests ✅
+> **Status git :** branche `feat/albums-design-alignment` — 374 tests ✅
+
+---
+
+## 🎨 Alignement design /albums sur le dashboard (2026-07-12)
+
+Migration de `albums.html.twig` et `album_detail.html.twig` vers le design system `--hc-*`, troisième étape après `/explorer` (#186) et `/gallery` (#187).
+
+- `assets/styles/albums.css` créé : grille de cartes, réutilise `.hc-item-card`/`.hc-item-icon` (explorer.css) et `.hc-media-*` (gallery.css) plutôt que de dupliquer
+- Suppression de tous les styles inline et hex en dur (`#111827`, `#3b82f6`, `#ef4444`, `#e5e7eb`, `#d1d5db`, `#9ca3af`, `#6b7280`, `#f3f4f6`)
+- Réutilisation du composant `EmptyState` partagé pour les deux pages (liste vide, album sans média)
+- En-tête de page ajouté (titre + décompte d'albums)
 
 ---
 

--- a/assets/styles/albums.css
+++ b/assets/styles/albums.css
@@ -1,0 +1,19 @@
+/*
+ * assets/styles/albums.css
+ * Styles pour la page albums (/albums, /albums/{id})
+ * Aligné sur le design system du dashboard (assets/styles/dashboard.css).
+ * Dépend des variables --hc-* définies dans layout.css et des classes
+ * .hc-item-card / .hc-item-icon / .hc-media-* définies dans explorer.css / gallery.css.
+ */
+
+.hc-album-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 16px;
+}
+
+.hc-album-card {
+  display: block;
+  text-decoration: none;
+  cursor: pointer;
+}

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -5,6 +5,7 @@
 @import "./dashboard.css";
 @import "./explorer.css";
 @import "./gallery.css";
+@import "./albums.css";
 @import "./liquid-glass.css";
 @import "./upload.css";
 @import "./settings.css";

--- a/templates/web/album_detail.html.twig
+++ b/templates/web/album_detail.html.twig
@@ -5,60 +5,66 @@
 
 {% block content %}
 
-<div class="flex items-center justify-between mb-6">
+<div class="flex flex-col gap-7 max-w-[1100px] mx-auto h-full">
+
+  {# En-tête de page #}
+  <div class="flex items-center justify-between">
     <div>
-        <a href="{{ path('app_albums') }}"
-           style="font-size:0.875rem; color:#6b7280; text-decoration:none;">← Albums</a>
-        <h1 style="font-size:1.5rem; font-weight:700; color:#111827; margin-top:0.25rem;">
-            {{ icons.icon('album', 20) }} {{ album.name }}
-        </h1>
-        <p style="font-size:0.875rem; color:#9ca3af;">
-            <span data-testid="album-media-count">{{ album.medias|length }}</span> média{{ album.medias|length != 1 ? 's' : '' }}
-            · Créé le {{ album.createdAt|date('d/m/Y') }}
-        </p>
+      <a href="{{ path('app_albums') }}" class="hc-page-sub" style="text-decoration:none;">← Albums</a>
+      <h1 class="text-2xl font-black tracking-tight mb-1 flex items-center gap-2" style="margin-top:0.25rem;">
+        {{ icons.icon('album', 22) }}
+        {{ album.name }}
+      </h1>
+      <p class="hc-page-sub">
+        <span data-testid="album-media-count">{{ album.medias|length }}</span> média{{ album.medias|length != 1 ? 's' : '' }}
+        · Créé le {{ album.createdAt|date('d/m/Y') }}
+      </p>
     </div>
 
     <form method="post" action="{{ path('app_album_delete', {id: album.id}) }}"
-          onsubmit="return confirm('Supprimer l\'album « {{ album.name }} » ?')">
-        <button type="submit"
-                style="padding:0.4rem 0.9rem; background:#ef4444; color:#fff; border:none; border-radius:0.5rem; font-size:0.875rem; cursor:pointer; display:flex; align-items:center; gap:0.4rem;">
-            {{ icons.icon('trash', 16) }} Supprimer
-        </button>
+          onsubmit="return confirm('Supprimer l\'album « {{ album.name|e('js') }} » ?')">
+      <button type="submit" class="hc-item-action hc-item-action--danger flex items-center gap-2 px-4 py-2 rounded-md font-semibold text-sm"
+              style="border:1px solid var(--hc-border); color: var(--hc-err);">
+        {{ icons.icon('trash', 16) }}
+        Supprimer
+      </button>
     </form>
-</div>
+  </div>
 
-{% if album.medias is empty %}
-    <div style="text-align:center; padding:3rem 2rem; color:#9ca3af; border:2px dashed #e5e7eb; border-radius:0.75rem;">
-        <p style="font-size:2rem;"><svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-images"><path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5z"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg></p>
-        <p style="margin-top:0.5rem; font-size:0.875rem;">Cet album ne contient aucun média.</p>
-        <a href="{{ path('app_gallery') }}"
-           style="display:inline-block; margin-top:1rem; padding:0.4rem 0.9rem; background:#3b82f6;
-                  color:#fff; border-radius:0.5rem; text-decoration:none; font-size:0.875rem;">
-            Ajouter depuis la galerie
-        </a>
-    </div>
-{% else %}
-    <div style="display:grid; grid-template-columns:repeat(auto-fill, minmax(160px, 1fr)); gap:1rem;">
-        {% for media in album.medias %}
-            <div style="border-radius:0.75rem; overflow:hidden; background:#f3f4f6; aspect-ratio:1; position:relative;">
-                {% if media.thumbnailPath %}
-                    <img src="{{ asset('storage/thumbs/' ~ media.thumbnailPath|split('/')|last) }}"
-                         alt="{{ media.file.originalName }}"
-                         loading="lazy"
-                         style="width:100%; height:100%; object-fit:cover;">
-                {% else %}
-                    <div style="display:flex; align-items:center; justify-content:center; height:100%; font-size:2rem;">
-                        {{ media.mediaType == 'video' ? '<svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-video"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>' : '<svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-images"><path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5z"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>' }}
-                    </div>
-                {% endif %}
-                <div style="position:absolute; bottom:0; left:0; right:0; padding:0.3rem 0.5rem;
-                            background:linear-gradient(transparent, rgba(0,0,0,0.55));
-                            font-size:0.65rem; color:#fff; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">
-                    {{ media.file.originalName }}
-                </div>
+  {% if album.medias is empty %}
+    <twig:EmptyState
+      title="Cet album ne contient aucun média"
+      subtitle="Ajoutez des photos ou vidéos depuis la galerie."
+      actionLabel="Ajouter depuis la galerie"
+      actionUrl="{{ path('app_gallery') }}"
+      icon="<svg width='64' height='64' fill='none' stroke='currentColor' stroke-width='1.5' viewBox='0 0 24 24' class='hc-icon hc-icon-images'><path d='M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5z'/><circle cx='8.5' cy='8.5' r='1.5'/><polyline points='21 15 16 10 5 21'/></svg>"
+    />
+  {% else %}
+    <div class="hc-media-grid">
+      {% for media in album.medias %}
+        <div class="hc-media-thumb">
+          {% if media.thumbnailPath %}
+            <img src="{{ asset('storage/thumbs/' ~ media.thumbnailPath|split('/')|last) }}"
+                 alt="{{ media.file.originalName }}"
+                 loading="lazy"
+                 class="hc-media-thumb-img">
+          {% else %}
+            <div class="hc-media-thumb-fallback">
+              {% if media.mediaType == 'video' %}
+                <svg width="28" height="28" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-video"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
+              {% else %}
+                <svg width="28" height="28" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-images"><path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5z"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+              {% endif %}
             </div>
-        {% endfor %}
+          {% endif %}
+          <div class="hc-media-thumb-caption">
+            {{ media.file.originalName }}
+          </div>
+        </div>
+      {% endfor %}
     </div>
-{% endif %}
+  {% endif %}
+
+</div>
 
 {% endblock %}

--- a/templates/web/albums.html.twig
+++ b/templates/web/albums.html.twig
@@ -5,45 +5,50 @@
 
 {% block content %}
 
-<div class="flex items-center justify-between mb-6">
-    <h1 style="font-size:1.5rem; font-weight:700; color:#111827;">{{ icons.icon('album', 20) }} Mes albums</h1>
+<div class="flex flex-col gap-7 max-w-[1100px] mx-auto h-full">
 
-    <form method="post" action="{{ path('app_album_create') }}" style="display:flex; gap:0.5rem; align-items:center;">
-        <input type="text" name="name" placeholder="Nom du nouvel album"
-               style="padding:0.4rem 0.8rem; border:1px solid #d1d5db; border-radius:0.5rem; font-size:0.875rem; outline:none;"
-               required />
-        <button type="submit"
-                style="padding:0.4rem 0.9rem; background:#3b82f6; color:#fff; border:none; border-radius:0.5rem; font-size:0.875rem; cursor:pointer;">
-            + Créer
-        </button>
+  {# En-tête de page #}
+  <div class="flex items-center justify-between">
+    <div>
+      <h1 class="text-2xl font-black tracking-tight mb-1 flex items-center gap-2">
+        {{ icons.icon('album', 22) }}
+        Mes albums
+      </h1>
+      <p class="hc-page-sub">{{ albums|length }} album{{ albums|length != 1 ? 's' : '' }}</p>
+    </div>
+
+    <form method="post" action="{{ path('app_album_create') }}" class="flex gap-2 items-center">
+      <input type="text" name="name" placeholder="Nom du nouvel album" class="hc-search" style="width:auto;" required />
+      <button type="submit" class="hc-btn-soft flex items-center gap-2 px-4 py-2 rounded-md font-semibold text-sm cursor-pointer"
+              style="background: var(--hc-accent-soft); color: var(--hc-accent); border:none;">
+        <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg>
+        Créer
+      </button>
     </form>
-</div>
+  </div>
 
-{% if albums is empty %}
-    <div data-testid="albums-empty"
-         style="text-align:center; padding:4rem 2rem; color:#9ca3af;">
-        <div style="font-size:3rem; opacity:0.5; display:flex; justify-content:center;">{{ icons.icon('album', 48) }}</div>
-        <p style="font-size:1.1rem; font-weight:600; margin-top:1rem;">Aucun album pour l'instant</p>
-        <p style="font-size:0.875rem; margin-top:0.5rem;">Créez un album pour regrouper vos photos et vidéos.</p>
+  {% if albums is empty %}
+    <div data-testid="albums-empty">
+      <twig:EmptyState
+        title="Aucun album pour l'instant"
+        subtitle="Créez un album pour regrouper vos photos et vidéos."
+        icon="<svg width='64' height='64' fill='none' stroke='currentColor' stroke-width='1.5' viewBox='0 0 24 24' class='hc-icon hc-icon-album'><path d='M4 19V6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v13'/><path d='M4 19a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2'/></svg>"
+      />
     </div>
-{% else %}
-    <div style="display:grid; grid-template-columns:repeat(auto-fill, minmax(220px, 1fr)); gap:1.25rem;">
-        {% for album in albums %}
-            <a href="{{ path('app_album_detail', {id: album.id}) }}"
-               data-testid="album-card"
-               style="display:block; border:1px solid #e5e7eb; border-radius:0.75rem; padding:1.25rem;
-                      text-decoration:none; color:#111827; background:#fff;
-                      box-shadow:0 1px 3px rgba(0,0,0,0.07); transition:box-shadow 0.15s;"
-               onmouseover="this.style.boxShadow='0 4px 12px rgba(0,0,0,0.12)'"
-               onmouseout="this.style.boxShadow='0 1px 3px rgba(0,0,0,0.07)'">
-                <div style="font-size:1.5rem; margin-bottom:0.5rem;">{{ icons.icon('album', 24) }}</div>
-                <div style="font-weight:600; font-size:0.95rem;">{{ album.name }}</div>
-                <div style="font-size:0.78rem; color:#9ca3af; margin-top:0.3rem;">
-                    {{ album.medias|length }} média{{ album.medias|length != 1 ? 's' : '' }}
-                </div>
-            </a>
-        {% endfor %}
+  {% else %}
+    <div class="hc-album-grid">
+      {% for album in albums %}
+        <a href="{{ path('app_album_detail', {id: album.id}) }}" data-testid="album-card" class="hc-item-card hc-album-card">
+          <div class="hc-item-icon hc-item-icon--folder mb-2">{{ icons.icon('album', 16) }}</div>
+          <div class="hc-item-name">{{ album.name }}</div>
+          <div class="hc-item-meta">
+            {{ album.medias|length }} média{{ album.medias|length != 1 ? 's' : '' }}
+          </div>
+        </a>
+      {% endfor %}
     </div>
-{% endif %}
+  {% endif %}
+
+</div>
 
 {% endblock %}

--- a/tests/Web/AlbumWebTest.php
+++ b/tests/Web/AlbumWebTest.php
@@ -197,4 +197,57 @@ final class AlbumWebTest extends WebTestCase
         $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/delete');
         $this->assertResponseStatusCodeSame(403);
     }
+
+    // --- Alignement design system (dashboard) ---
+
+    public function testAlbumsListHasPageHeaderWithTitle(): void
+    {
+        $this->createUser();
+        $this->login();
+
+        $this->client->request('GET', '/albums');
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h1', 'Mes albums');
+    }
+
+    public function testAlbumsListHasNoHardcodedLegacyColors(): void
+    {
+        $user = $this->createUser();
+        $this->createAlbum($user, 'Vacances 2024');
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/albums');
+        $this->assertResponseIsSuccessful();
+        $main = $crawler->filter('main')->html();
+
+        foreach (['#111827', '#3b82f6', '#e5e7eb', '#d1d5db', '#9ca3af', '#ef4444'] as $forbidden) {
+            $this->assertStringNotContainsString(
+                $forbidden,
+                $main,
+                sprintf('La liste des albums ne doit plus contenir "%s" (couleur legacy hors design system)', $forbidden)
+            );
+        }
+    }
+
+    public function testAlbumDetailHasNoHardcodedLegacyColors(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Album Détail');
+        $media = $this->createMedia($user, 'pic.jpg');
+        $album->addMedia($media);
+        $this->em->flush();
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/albums/' . $album->getId()->toRfc4122());
+        $this->assertResponseIsSuccessful();
+        $main = $crawler->filter('main')->html();
+
+        foreach (['#111827', '#3b82f6', '#e5e7eb', '#d1d5db', '#9ca3af', '#ef4444', '#6b7280', '#f3f4f6'] as $forbidden) {
+            $this->assertStringNotContainsString(
+                $forbidden,
+                $main,
+                sprintf('Le détail d\'album ne doit plus contenir "%s" (couleur legacy hors design system)', $forbidden)
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Migration de `albums.html.twig` et `album_detail.html.twig` vers le design system `--hc-*`, troisième étape après #186 (`/explorer`) et #187 (`/gallery`)
- Suppression de tous les styles inline et hex en dur (`#111827`, `#3b82f6`, `#ef4444`, `#e5e7eb`, `#d1d5db`, `#9ca3af`, `#6b7280`, `#f3f4f6`)
- Réutilisation d'`EmptyState`, `.hc-item-card`/`.hc-item-icon` (explorer.css) et `.hc-media-*` (gallery.css) plutôt que de dupliquer du CSS
- Ajout d'un en-tête de page (titre + décompte d'albums), cohérent avec le dashboard

## Test plan
- [x] `./vendor/bin/phpunit` — 374/374 tests verts
- [x] Nouveaux tests RED→GREEN : en-tête de page, absence de couleurs legacy (liste + détail)
- [x] Création/suppression d'album, ajout de médias : comportement inchangé, seulement le style