### PR TITLE
✨ Ajouter les fixtures de démo avec photos placeholder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,6 +103,7 @@
     },
     "require-dev": {
         "dama/doctrine-test-bundle": "^8.6",
+        "doctrine/doctrine-fixtures-bundle": "^4.3",
         "phpunit/phpunit": "^13.2.4",
         "symfony/browser-kit": "8.0.*",
         "symfony/css-selector": "8.0.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7f612bfd8f3051b2ba99f021e2c5834e",
+    "content-hash": "ee09c374c5e9db592bb40ee3f8e7c599",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -9035,6 +9035,177 @@
                 "source": "https://github.com/dmaicher/doctrine-test-bundle/tree/v8.6.0"
             },
             "time": "2026-01-21T07:39:44+00:00"
+        },
+        {
+            "name": "doctrine/data-fixtures",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/data-fixtures.git",
+                "reference": "bf7ac3a050b54b261cedfb3d0a44733819062275"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/data-fixtures/zipball/bf7ac3a050b54b261cedfb3d0a44733819062275",
+                "reference": "bf7ac3a050b54b261cedfb3d0a44733819062275",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/persistence": "^3.1 || ^4.0",
+                "php": "^8.1",
+                "psr/log": "^1.1 || ^2 || ^3"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.5 || >=5",
+                "doctrine/orm": "<2.14 || >=4",
+                "doctrine/phpcr-odm": "<1.3.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "doctrine/dbal": "^3.5 || ^4",
+                "doctrine/mongodb-odm": "^1.3.0 || ^2.0.0",
+                "doctrine/orm": "^2.14 || ^3",
+                "doctrine/phpcr-odm": "^1.8 || ^2.0",
+                "ext-sqlite3": "*",
+                "fig/log-test": "^1",
+                "jackalope/jackalope-fs": "*",
+                "phpstan/phpstan": "2.1.46",
+                "phpunit/phpunit": "10.5.63 || 12.5.12",
+                "symfony/cache": "^6.4 || ^7 || ^8",
+                "symfony/var-exporter": "^6.4 || ^7 || ^8"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "For using MongoDB ODM 1.3 with PHP 7 (deprecated)",
+                "doctrine/mongodb-odm": "For loading MongoDB ODM fixtures",
+                "doctrine/orm": "For loading ORM fixtures",
+                "doctrine/phpcr-odm": "For loading PHPCR ODM fixtures"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\DataFixtures\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Data Fixtures for all Doctrine Object Managers",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "database"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/data-fixtures/issues",
+                "source": "https://github.com/doctrine/data-fixtures/tree/2.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdata-fixtures",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-01T13:56:01+00:00"
+        },
+        {
+            "name": "doctrine/doctrine-fixtures-bundle",
+            "version": "4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/DoctrineFixturesBundle.git",
+                "reference": "9e013ed10d49bf7746b07204d336384a7d9b5a4d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/DoctrineFixturesBundle/zipball/9e013ed10d49bf7746b07204d336384a7d9b5a4d",
+                "reference": "9e013ed10d49bf7746b07204d336384a7d9b5a4d",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/data-fixtures": "^2.2",
+                "doctrine/doctrine-bundle": "^2.2 || ^3.0",
+                "doctrine/orm": "^2.14.0 || ^3.0",
+                "doctrine/persistence": "^2.4 || ^3.0 || ^4.0",
+                "php": "^8.1",
+                "psr/log": "^2 || ^3",
+                "symfony/config": "^6.4 || ^7.0 || ^8.0",
+                "symfony/console": "^6.4 || ^7.0 || ^8.0",
+                "symfony/dependency-injection": "^6.4 || ^7.0 || ^8.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3",
+                "symfony/doctrine-bridge": "^6.4.16 || ^7.1.9 || ^8.0",
+                "symfony/http-kernel": "^6.4 || ^7.0 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "< 3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "14.0.0",
+                "phpstan/phpstan": "2.1.11",
+                "phpunit/phpunit": "^10.5.38 || 11.4.14"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Bundle\\FixturesBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Doctrine Project",
+                    "homepage": "https://www.doctrine-project.org"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DoctrineFixturesBundle",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "Fixture",
+                "persistence"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/DoctrineFixturesBundle/issues",
+                "source": "https://github.com/doctrine/DoctrineFixturesBundle/tree/4.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdoctrine-fixtures-bundle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-03T16:05:42+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -15,6 +15,6 @@ return [
     Symfony\UX\LiveComponent\LiveComponentBundle::class => ['all' => true],
     Symfonycasts\TailwindBundle\SymfonycastsTailwindBundle::class => ['all' => true],
     SymfonyCasts\Bundle\ResetPassword\SymfonyCastsResetPasswordBundle::class => ['all' => true],
-    // DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
     DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
+    Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
 ];

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -108,6 +108,10 @@ services:
         arguments:
             $storageDir: '%app.storage_dir%'
 
+    App\DataFixtures\AppFixtures:
+        arguments:
+            $storageDir: '%app.storage_dir%'
+
     App\EventListener\SecurityHeadersListener:
         arguments:
             $env: '%kernel.environment%'

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures;
+
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Media;
+use App\Entity\User;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Fixtures de démo — utilisateur, dossiers, fichiers/médias (SVG placeholder
+ * générés localement, aucune dépendance réseau) et albums.
+ *
+ * Usage : php bin/console doctrine:fixtures:load
+ * Chargées uniquement en dev/test (voir config/bundles.php).
+ */
+class AppFixtures extends Fixture
+{
+    private const DEMO_EMAIL = 'demo@homecloud.local';
+    private const DEMO_PASSWORD = 'demo12345';
+
+    /** @var array<int, array{label: string, color: string}> */
+    private const PHOTO_SPECS = [
+        ['label' => 'Vacances plage',    'color' => '#4A90D9'],
+        ['label' => 'Montagne',          'color' => '#5FA65F'],
+        ['label' => 'Portrait',          'color' => '#D97A4A'],
+        ['label' => 'Ville la nuit',     'color' => '#6B5FA8'],
+        ['label' => 'Coucher de soleil', 'color' => '#D9A84A'],
+        ['label' => 'Forêt',             'color' => '#3F8F6B'],
+    ];
+
+    public function __construct(
+        private readonly UserPasswordHasherInterface $passwordHasher,
+        private readonly string $storageDir,
+    ) {}
+
+    public function load(ObjectManager $manager): void
+    {
+        $user = new User(self::DEMO_EMAIL, 'Utilisateur Démo');
+        $user->setPassword($this->passwordHasher->hashPassword($user, self::DEMO_PASSWORD));
+        $manager->persist($user);
+
+        $photosFolder = new Folder('Photos', $user);
+        $manager->persist($photosFolder);
+
+        $docsFolder = new Folder('Documents', $user);
+        $manager->persist($docsFolder);
+
+        $medias = [];
+        foreach (self::PHOTO_SPECS as $i => $spec) {
+            $filename = sprintf('demo-photo-%d.svg', $i + 1);
+            $relativePath = $this->writePlaceholderSvg($filename, $spec['label'], $spec['color']);
+            $thumbnailRelativePath = $this->writePlaceholderSvg('thumb-' . $filename, $spec['label'], $spec['color'], thumbs: true);
+
+            $file = new File(
+                originalName: $spec['label'] . '.svg',
+                mimeType: 'image/svg+xml',
+                size: filesize($this->storageDir . '/' . $relativePath) ?: 0,
+                path: $relativePath,
+                folder: $photosFolder,
+                owner: $user,
+            );
+            $manager->persist($file);
+
+            $media = new Media($file, 'photo');
+            $media->setWidth(800);
+            $media->setHeight(600);
+            $media->setThumbnailPath($thumbnailRelativePath);
+            $manager->persist($media);
+
+            $medias[] = $media;
+        }
+
+        $vacationAlbum = new Album('Vacances 2026', $user);
+        foreach (array_slice($medias, 0, 3) as $media) {
+            $vacationAlbum->addMedia($media);
+        }
+        $manager->persist($vacationAlbum);
+
+        $natureAlbum = new Album('Nature', $user);
+        foreach (array_slice($medias, 3) as $media) {
+            $natureAlbum->addMedia($media);
+        }
+        $manager->persist($natureAlbum);
+
+        $manager->flush();
+    }
+
+    /**
+     * Génère un SVG placeholder simple (fond coloré + libellé) et l'écrit sur
+     * disque dans var/storage/, en réutilisant les conventions de StorageService.
+     * Aucune dépendance à GD ni au réseau — juste du balisage SVG texte.
+     *
+     * @return string Chemin relatif à storageDir (ex: "demo/demo-photo-1.svg")
+     */
+    private function writePlaceholderSvg(string $filename, string $label, string $color, bool $thumbs = false): string
+    {
+        $subDir = $thumbs ? 'thumbs' : 'demo';
+        $width = $thumbs ? 300 : 800;
+        $height = $thumbs ? 300 : 600;
+        $fontSize = $thumbs ? 20 : 32;
+
+        $svg = <<<SVG
+            <svg xmlns="http://www.w3.org/2000/svg" width="{$width}" height="{$height}" viewBox="0 0 {$width} {$height}">
+              <rect width="100%" height="100%" fill="{$color}"/>
+              <text x="50%" y="50%" font-family="sans-serif" font-size="{$fontSize}" fill="#ffffff" text-anchor="middle" dominant-baseline="middle">{$label}</text>
+            </svg>
+            SVG;
+
+        $dir = $this->storageDir . '/' . $subDir;
+        if (!is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+
+        $relativePath = $subDir . '/' . $filename;
+        file_put_contents($this->storageDir . '/' . $relativePath, $svg);
+
+        return $relativePath;
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -48,6 +48,18 @@
             "src/Repository/.gitignore"
         ]
     },
+    "doctrine/doctrine-fixtures-bundle": {
+        "version": "4.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "3.0",
+            "ref": "1f5514cfa15b947298df4d771e694e578d4c204d"
+        },
+        "files": [
+            "src/DataFixtures/AppFixtures.php"
+        ]
+    },
     "doctrine/doctrine-migrations-bundle": {
         "version": "4.0",
         "recipe": {

--- a/tests/ResetPasswordControllerTest.php
+++ b/tests/ResetPasswordControllerTest.php
@@ -28,18 +28,20 @@ class ResetPasswordControllerTest extends WebTestCase
 
         $this->userRepository = $container->get(UserRepository::class);
 
-        // Purge d'abord les reset_password_request pour éviter les violations de clé étrangère
-        $resetPasswordRequestRepo = $this->em->getRepository(\App\Entity\ResetPasswordRequest::class);
-        foreach ($resetPasswordRequestRepo->findAll() as $resetRequest) {
-            $this->em->remove($resetRequest);
-        }
-        $this->em->flush();
-
-        foreach ($this->userRepository->findAll() as $user) {
-            $this->em->remove($user);
-        }
-
-        $this->em->flush();
+        // Purge complète (cascade FK désactivée le temps du nettoyage) — la base
+        // de test peut contenir des dossiers/fichiers/médias/albums liés aux users
+        // (ex: fixtures de démo), pas seulement des reset_password_request.
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM reset_password_request');
+        $conn->executeStatement('DELETE FROM album_media');
+        $conn->executeStatement('DELETE FROM albums');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
     }
 
     public function testResetPasswordController(): void


### PR DESCRIPTION
## Summary
- Installe `doctrine/doctrine-fixtures-bundle` (dev/test uniquement, jamais chargé en prod)
- `AppFixtures` crée un utilisateur de démo (`demo@homecloud.local` / `demo12345`), 2 dossiers (Photos, Documents), 6 photos placeholder SVG générées localement (formes colorées + libellé — aucune dépendance GD ni réseau) avec vrais fichiers sur disque + thumbnails, et 2 albums (Vacances 2026, Nature)
- **Fix inclus** : `ResetPasswordControllerTest::setUp()` ne purgeait que `users` + `reset_password_request`, en présupposant que ce sont les seules FK vers `users`. Faux depuis longtemps (Folder/File/Album référencent aussi `users`) — le test ne passait que parce que la base de test était systématiquement vide avant lui. Repéré en chargeant les fixtures sur une base de test partagée. Harmonisé avec le pattern `SET FOREIGN_KEY_CHECKS=0` déjà utilisé par les autres suites.

## Notes
- Deux commits sont passés avec `--no-verify` (accord explicite) : le hook pre-commit fait un grep aveugle sur "password" et bloquait à tort sur le nom de table légitime `reset_password_request` et sur `DEMO_PASSWORD` (mot de passe de démo pour un utilisateur fictif, dev/test uniquement).
- `.env.test.local` (non versionné) a été repointé vers une base `home_cloud_test` dédiée — la base dev (`home_cloud`) partageait auparavant le même nom que la base de test, ce qui rendait risqué tout chargement manuel de fixtures.

## Test plan
- [x] `./vendor/bin/phpunit` — 371/371 tests verts
- [x] `php bin/console doctrine:fixtures:load` testé manuellement sur la base de test isolée — utilisateur, dossiers, 6 fichiers/médias SVG (avec vrais fichiers sur disque), 2 albums créés correctement
- [x] Vérifié qu'aucune donnée dev existante n'a été touchée (base de test désormais séparée)