### PR TITLE
✨ Ajouter le tri à la galerie médias

### DIFF
--- a/.github/avancement.md
+++ b/.github/avancement.md
@@ -2,7 +2,17 @@
 
 > Dernière mise à jour : 2026-07-12
 
-> **Status git :** branche `feat/albums-design-alignment` — 374 tests ✅
+> **Status git :** branche `feat/gallery-sort` — 383 tests ✅
+
+---
+
+## ✨ Tri de la galerie médias (2026-07-12)
+
+Ajout d'un menu de tri sur `/gallery` (Plus récent, Plus ancien, Nom A→Z/Z→A, Taille croissante/décroissante).
+
+- Réutilise la convention `?order[champ]=direction` déjà en place dans `FileRepository`/`FolderRepository` (PR #168) plutôt que d'en créer une nouvelle — `MediaRepository::findByOwner()` accepte désormais un `array $orderBy` avec la même whitelist et le même comportement d'ignorance silencieuse des champs inconnus (pas de 400, cohérence avec l'API)
+- `<select>` natif dans `gallery.html.twig`, propage le tri courant dans les liens de filtre photo/vidéo pour que les deux se combinent
+- `WebFixturesTrait::createMediaFile()` étendu (`$size`, `$createdAt` optionnels, Reflection pour `createdAt` qui n'a pas de setter en prod) pour pouvoir tester le tri
 
 ---
 

--- a/assets/styles/gallery.css
+++ b/assets/styles/gallery.css
@@ -5,6 +5,21 @@
  * Dépend des variables --hc-* définies dans layout.css.
  */
 
+/* ── Sélecteur de tri ── */
+.hc-sort-select {
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  background: var(--hc-surface);
+  color: var(--hc-text);
+  border: 1px solid var(--hc-border);
+  cursor: pointer;
+}
+.hc-sort-select:hover {
+  border-color: var(--hc-border-strong);
+}
+
 /* ── Pilules de filtre photo/vidéo ── */
 .hc-filter-pill {
   display: inline-flex;

--- a/src/Controller/Web/MediaGalleryController.php
+++ b/src/Controller/Web/MediaGalleryController.php
@@ -29,12 +29,14 @@ final class MediaGalleryController extends AbstractController
         /** @var User $user */
         $user = $this->getUser();
         $type = $request->query->get('type');
+        $order = $request->query->all('order');
 
-        $medias = $this->mediaRepository->findByOwner($user, $type ?: null);
+        $medias = $this->mediaRepository->findByOwner($user, $type ?: null, $order);
 
         return $this->render('web/gallery.html.twig', [
             'medias' => $medias,
             'type'   => $type,
+            'order'  => $order,
         ]);
     }
 
@@ -50,6 +52,7 @@ final class MediaGalleryController extends AbstractController
         return $this->render('web/gallery.html.twig', [
             'medias' => [$media],
             'type'   => null,
+            'order'  => [],
         ]);
     }
 }

--- a/src/Interface/MediaRepositoryInterface.php
+++ b/src/Interface/MediaRepositoryInterface.php
@@ -10,8 +10,12 @@ use Symfony\Component\Uid\Uuid;
 
 interface MediaRepositoryInterface
 {
-    /** @return Media[] */
-    public function findByOwner(User $user, ?string $type = null): array;
+    /**
+     * @param array<string, string> $orderBy Champ => direction ('asc'|'desc'). Champs
+     *                                        inconnus ignorés silencieusement.
+     * @return Media[]
+     */
+    public function findByOwner(User $user, ?string $type = null, array $orderBy = []): array;
 
     public function findById(Uuid $id): ?Media;
 }

--- a/src/Repository/MediaRepository.php
+++ b/src/Repository/MediaRepository.php
@@ -8,7 +8,6 @@ use App\Entity\Media;
 use App\Entity\User;
 use App\Interface\MediaRepositoryInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\ORM\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Uid\Uuid;
 
@@ -30,18 +29,35 @@ class MediaRepository extends ServiceEntityRepository implements MediaRepository
         return $this->find($id);
     }
 
-    /** @return Media[] */
-    public function findByOwner(User $user, ?string $type = null): array
+    /**
+     * @param array<string, string> $orderBy Champ => direction ('asc'|'desc'). Même
+     *                                        convention que FileRepository::findFiltered() :
+     *                                        champs inconnus ignorés silencieusement.
+     * @return Media[]
+     */
+    public function findByOwner(User $user, ?string $type = null, array $orderBy = []): array
     {
         $qb = $this->createQueryBuilder('m')
             ->join('m.file', 'f')
             ->join('f.owner', 'u')
             ->where('u.id = :userId')
-            ->setParameter('userId', $user->getId(), 'uuid')
-            ->orderBy('f.createdAt', 'DESC');
+            ->setParameter('userId', $user->getId(), 'uuid');
 
         if ($type !== null) {
             $qb->andWhere('m.mediaType = :type')->setParameter('type', $type);
+        }
+
+        $allowed = ['originalName' => 'f.originalName', 'size' => 'f.size', 'createdAt' => 'f.createdAt'];
+        $applied = false;
+        foreach ($orderBy as $field => $dir) {
+            if (isset($allowed[$field])) {
+                $qb->addOrderBy($allowed[$field], strtoupper($dir) === 'DESC' ? 'DESC' : 'ASC');
+                $applied = true;
+            }
+        }
+
+        if (!$applied) {
+            $qb->orderBy('f.createdAt', 'DESC');
         }
 
         return $qb->getQuery()->getResult();

--- a/templates/web/gallery.html.twig
+++ b/templates/web/gallery.html.twig
@@ -16,22 +16,36 @@
       <p class="hc-page-sub">{{ medias|length }} médias</p>
     </div>
 
-    {# Filtres photo/vidéo #}
-    <div class="flex gap-2">
-      <a href="{{ path('app_gallery') }}"
-         class="hc-filter-pill {{ type is null ? 'hc-filter-pill--active' : '' }}">
-        Tous
-      </a>
-      <a href="{{ path('app_gallery', {type: 'photo'}) }}"
-         class="hc-filter-pill {{ type == 'photo' ? 'hc-filter-pill--active' : '' }}">
-        <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-images"><path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5z"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
-        Photos
-      </a>
-      <a href="{{ path('app_gallery', {type: 'video'}) }}"
-         class="hc-filter-pill {{ type == 'video' ? 'hc-filter-pill--active' : '' }}">
-        <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-video"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
-        Vidéos
-      </a>
+    <div class="flex gap-2 items-center">
+      {# Tri #}
+      {% set currentSortField = order|keys|first %}
+      {% set currentSortDir = order|length ? order|first : 'desc' %}
+      <select class="hc-sort-select" onchange="window.location.href = this.value" aria-label="Trier la galerie">
+        <option value="{{ path('app_gallery', {type: type, order: {createdAt: 'desc'}}) }}" {{ (currentSortField is null or (currentSortField == 'createdAt' and currentSortDir == 'desc')) ? 'selected' }}>Plus récent</option>
+        <option value="{{ path('app_gallery', {type: type, order: {createdAt: 'asc'}}) }}" {{ (currentSortField == 'createdAt' and currentSortDir == 'asc') ? 'selected' }}>Plus ancien</option>
+        <option value="{{ path('app_gallery', {type: type, order: {originalName: 'asc'}}) }}" {{ (currentSortField == 'originalName' and currentSortDir == 'asc') ? 'selected' }}>Nom (A→Z)</option>
+        <option value="{{ path('app_gallery', {type: type, order: {originalName: 'desc'}}) }}" {{ (currentSortField == 'originalName' and currentSortDir == 'desc') ? 'selected' }}>Nom (Z→A)</option>
+        <option value="{{ path('app_gallery', {type: type, order: {size: 'asc'}}) }}" {{ (currentSortField == 'size' and currentSortDir == 'asc') ? 'selected' }}>Taille (petit→grand)</option>
+        <option value="{{ path('app_gallery', {type: type, order: {size: 'desc'}}) }}" {{ (currentSortField == 'size' and currentSortDir == 'desc') ? 'selected' }}>Taille (grand→petit)</option>
+      </select>
+
+      {# Filtres photo/vidéo #}
+      <div class="flex gap-2">
+        <a href="{{ path('app_gallery', {order: order}) }}"
+           class="hc-filter-pill {{ type is null ? 'hc-filter-pill--active' : '' }}">
+          Tous
+        </a>
+        <a href="{{ path('app_gallery', {type: 'photo', order: order}) }}"
+           class="hc-filter-pill {{ type == 'photo' ? 'hc-filter-pill--active' : '' }}">
+          <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-images"><path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5z"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+          Photos
+        </a>
+        <a href="{{ path('app_gallery', {type: 'video', order: order}) }}"
+           class="hc-filter-pill {{ type == 'video' ? 'hc-filter-pill--active' : '' }}">
+          <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-video"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
+          Vidéos
+        </a>
+      </div>
     </div>
   </div>
 

--- a/tests/Web/Fixtures/WebFixturesTrait.php
+++ b/tests/Web/Fixtures/WebFixturesTrait.php
@@ -50,11 +50,22 @@ trait WebFixturesTrait
         User $user,
         string $name = 'photo.jpg',
         string $mediaType = 'photo',
+        int $size = 1024,
+        ?\DateTimeImmutable $createdAt = null,
     ): Media {
         $folder = new Folder('Photos', $user);
         $this->em->persist($folder);
 
-        $file = new File($name, 'image/jpeg', 1024, "test/{$name}", $folder, $user);
+        $file = new File($name, 'image/jpeg', $size, "test/{$name}", $folder, $user);
+
+        if ($createdAt !== null) {
+            // File::$createdAt n'a pas de setter (immuable en production) — écriture
+            // directe réservée aux tests pour pouvoir varier la date dans les fixtures.
+            $prop = new \ReflectionProperty(File::class, 'createdAt');
+            $prop->setAccessible(true);
+            $prop->setValue($file, $createdAt);
+        }
+
         $this->em->persist($file);
 
         $media = new Media($file, $mediaType);

--- a/tests/Web/MediaGalleryTest.php
+++ b/tests/Web/MediaGalleryTest.php
@@ -212,4 +212,147 @@ final class MediaGalleryTest extends WebTestCase
             );
         }
     }
+
+    // --- Tri ---
+
+    public function testGalleryDefaultSortIsMostRecentFirst(): void
+    {
+        $user = $this->createUser();
+        $this->createMediaFile($user, 'old.jpg', 'photo', 1024, new \DateTimeImmutable('-2 days'));
+        $this->createMediaFile($user, 'new.jpg', 'photo', 1024, new \DateTimeImmutable('-1 hour'));
+        $this->login();
+
+        $this->client->request('GET', '/gallery');
+        $content = $this->client->getResponse()->getContent();
+        $this->assertLessThan(
+            strpos($content, 'old.jpg'),
+            strpos($content, 'new.jpg'),
+            'Sans tri explicite, le média le plus récent doit apparaître en premier'
+        );
+    }
+
+    public function testGallerySortByOldestFirst(): void
+    {
+        $user = $this->createUser();
+        $this->createMediaFile($user, 'old.jpg', 'photo', 1024, new \DateTimeImmutable('-2 days'));
+        $this->createMediaFile($user, 'new.jpg', 'photo', 1024, new \DateTimeImmutable('-1 hour'));
+        $this->login();
+
+        $this->client->request('GET', '/gallery?order[createdAt]=asc');
+        $content = $this->client->getResponse()->getContent();
+        $this->assertLessThan(
+            strpos($content, 'new.jpg'),
+            strpos($content, 'old.jpg'),
+            '?order[createdAt]=asc doit afficher le plus ancien en premier'
+        );
+    }
+
+    public function testGallerySortByNameAscending(): void
+    {
+        $user = $this->createUser();
+        $this->createMediaFile($user, 'banane.jpg', 'photo');
+        $this->createMediaFile($user, 'abricot.jpg', 'photo');
+        $this->login();
+
+        $this->client->request('GET', '/gallery?order[originalName]=asc');
+        $content = $this->client->getResponse()->getContent();
+        $this->assertLessThan(
+            strpos($content, 'banane.jpg'),
+            strpos($content, 'abricot.jpg'),
+            '?order[originalName]=asc doit afficher "abricot" avant "banane"'
+        );
+    }
+
+    public function testGallerySortByNameDescending(): void
+    {
+        $user = $this->createUser();
+        $this->createMediaFile($user, 'banane.jpg', 'photo');
+        $this->createMediaFile($user, 'abricot.jpg', 'photo');
+        $this->login();
+
+        $this->client->request('GET', '/gallery?order[originalName]=desc');
+        $content = $this->client->getResponse()->getContent();
+        $this->assertLessThan(
+            strpos($content, 'abricot.jpg'),
+            strpos($content, 'banane.jpg'),
+            '?order[originalName]=desc doit afficher "banane" avant "abricot"'
+        );
+    }
+
+    public function testGallerySortBySizeAscending(): void
+    {
+        $user = $this->createUser();
+        $this->createMediaFile($user, 'gros.jpg', 'photo', 5_000_000);
+        $this->createMediaFile($user, 'petit.jpg', 'photo', 1_000);
+        $this->login();
+
+        $this->client->request('GET', '/gallery?order[size]=asc');
+        $content = $this->client->getResponse()->getContent();
+        $this->assertLessThan(
+            strpos($content, 'gros.jpg'),
+            strpos($content, 'petit.jpg'),
+            '?order[size]=asc doit afficher le plus petit fichier en premier'
+        );
+    }
+
+    public function testGallerySortBySizeDescending(): void
+    {
+        $user = $this->createUser();
+        $this->createMediaFile($user, 'gros.jpg', 'photo', 5_000_000);
+        $this->createMediaFile($user, 'petit.jpg', 'photo', 1_000);
+        $this->login();
+
+        $this->client->request('GET', '/gallery?order[size]=desc');
+        $content = $this->client->getResponse()->getContent();
+        $this->assertLessThan(
+            strpos($content, 'petit.jpg'),
+            strpos($content, 'gros.jpg'),
+            '?order[size]=desc doit afficher le plus gros fichier en premier'
+        );
+    }
+
+    public function testGalleryUnknownSortFieldIsIgnoredNotRejected(): void
+    {
+        $user = $this->createUser();
+        $this->createMediaFile($user, 'photo.jpg', 'photo');
+        $this->login();
+
+        $this->client->request('GET', '/gallery?order[champInconnu]=asc');
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testGallerySortMenuShowsAllOptionsWithActiveMarked(): void
+    {
+        $this->createUser();
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/gallery?order[originalName]=asc');
+        $this->assertResponseIsSuccessful();
+
+        $select = $crawler->filter('.hc-sort-select');
+        $this->assertGreaterThanOrEqual(1, $select->count(), 'Le sélecteur de tri doit exister');
+        $this->assertCount(6, $select->filter('option'), 'Le sélecteur de tri doit proposer 6 options');
+
+        $selected = $select->filter('option[selected]');
+        $this->assertCount(1, $selected, 'Une seule option doit être marquée comme sélectionnée');
+    }
+
+    public function testGallerySortCombinesWithTypeFilter(): void
+    {
+        $user = $this->createUser();
+        $this->createMediaFile($user, 'banane.jpg', 'photo');
+        $this->createMediaFile($user, 'abricot.jpg', 'photo');
+        $this->createMediaFile($user, 'video-z.mp4', 'video');
+        $this->login();
+
+        $this->client->request('GET', '/gallery?type=photo&order[originalName]=asc');
+        $content = $this->client->getResponse()->getContent();
+
+        $this->assertStringNotContainsString('video-z.mp4', $content);
+        $this->assertLessThan(
+            strpos($content, 'banane.jpg'),
+            strpos($content, 'abricot.jpg'),
+            'Le tri doit continuer à s\'appliquer quand il est combiné au filtre type'
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Ajoute un menu de tri sur `/gallery` : Plus récent, Plus ancien, Nom (A→Z / Z→A), Taille (petit→grand / grand→petit)
- Réutilise la convention `?order[champ]=direction` déjà en place dans `FileRepository`/`FolderRepository` (#168) plutôt que d'en créer une seconde — `MediaRepository::findByOwner()` accepte un `array $orderBy` avec la même whitelist et le même comportement d'ignorance silencieuse des champs inconnus (pas de 400, cohérent avec le reste de l'API)
- `<select>` natif, pas de dropdown custom — accessible au clavier gratuitement
- Le tri se combine avec le filtre photo/vidéo existant (chaque lien de filtre propage le tri courant)

## Notes
- `WebFixturesTrait::createMediaFile()` étendu avec `$size` et `$createdAt` optionnels (Reflection pour `createdAt`, qui n'a pas de setter en production) pour pouvoir tester le tri par taille/date
- Le badge ▶ sur les vignettes vidéo et l'affichage de la taille sous le nom (visibles dans la maquette d'origine) sont **hors scope** — sans rapport avec le tri, à traiter séparément si souhaité

## Test plan
- [x] `./vendor/bin/phpunit` — 383/383 tests verts
- [x] Tests RED→GREEN : tri par défaut, `createdAt` asc, `originalName` asc/desc, `size` asc/desc, champ inconnu ignoré (200, pas 400), menu à 6 options avec une seule sélectionnée, combinaison tri + filtre type