### PR TITLE
🐛 Corriger l'URL cassée des vignettes média

### DIFF
--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -56,7 +56,6 @@ class AppFixtures extends Fixture
         foreach (self::PHOTO_SPECS as $i => $spec) {
             $filename = sprintf('demo-photo-%d.svg', $i + 1);
             $relativePath = $this->writePlaceholderSvg($filename, $spec['label'], $spec['color']);
-            $thumbnailRelativePath = $this->writePlaceholderSvg('thumb-' . $filename, $spec['label'], $spec['color'], thumbs: true);
 
             $file = new File(
                 originalName: $spec['label'] . '.svg',
@@ -68,10 +67,13 @@ class AppFixtures extends Fixture
             );
             $manager->persist($file);
 
+            // Pas de thumbnailPath : ThumbnailService génère toujours un vrai JPEG via
+            // GD (absent de cet environnement), jamais de SVG. Simuler un thumbnail
+            // inexistant mentirait sur le contrat réel — le template retombe sur son
+            // icône de repli déjà prévue quand thumbnailPath est null.
             $media = new Media($file, 'photo');
             $media->setWidth(800);
             $media->setHeight(600);
-            $media->setThumbnailPath($thumbnailRelativePath);
             $manager->persist($media);
 
             $medias[] = $media;
@@ -94,31 +96,26 @@ class AppFixtures extends Fixture
 
     /**
      * Génère un SVG placeholder simple (fond coloré + libellé) et l'écrit sur
-     * disque dans var/storage/, en réutilisant les conventions de StorageService.
+     * disque dans var/storage/demo/, en réutilisant les conventions de StorageService.
      * Aucune dépendance à GD ni au réseau — juste du balisage SVG texte.
      *
      * @return string Chemin relatif à storageDir (ex: "demo/demo-photo-1.svg")
      */
-    private function writePlaceholderSvg(string $filename, string $label, string $color, bool $thumbs = false): string
+    private function writePlaceholderSvg(string $filename, string $label, string $color): string
     {
-        $subDir = $thumbs ? 'thumbs' : 'demo';
-        $width = $thumbs ? 300 : 800;
-        $height = $thumbs ? 300 : 600;
-        $fontSize = $thumbs ? 20 : 32;
-
         $svg = <<<SVG
-            <svg xmlns="http://www.w3.org/2000/svg" width="{$width}" height="{$height}" viewBox="0 0 {$width} {$height}">
+            <svg xmlns="http://www.w3.org/2000/svg" width="800" height="600" viewBox="0 0 800 600">
               <rect width="100%" height="100%" fill="{$color}"/>
-              <text x="50%" y="50%" font-family="sans-serif" font-size="{$fontSize}" fill="#ffffff" text-anchor="middle" dominant-baseline="middle">{$label}</text>
+              <text x="50%" y="50%" font-family="sans-serif" font-size="32" fill="#ffffff" text-anchor="middle" dominant-baseline="middle">{$label}</text>
             </svg>
             SVG;
 
-        $dir = $this->storageDir . '/' . $subDir;
+        $dir = $this->storageDir . '/demo';
         if (!is_dir($dir)) {
             mkdir($dir, 0775, true);
         }
 
-        $relativePath = $subDir . '/' . $filename;
+        $relativePath = 'demo/' . $filename;
         file_put_contents($this->storageDir . '/' . $relativePath, $svg);
 
         return $relativePath;

--- a/templates/web/album_detail.html.twig
+++ b/templates/web/album_detail.html.twig
@@ -44,7 +44,7 @@
       {% for media in album.medias %}
         <div class="hc-media-thumb">
           {% if media.thumbnailPath %}
-            <img src="{{ asset('storage/thumbs/' ~ media.thumbnailPath|split('/')|last) }}"
+            <img src="{{ path('media_thumbnail', {id: media.id}) }}"
                  alt="{{ media.file.originalName }}"
                  loading="lazy"
                  class="hc-media-thumb-img">

--- a/templates/web/gallery.html.twig
+++ b/templates/web/gallery.html.twig
@@ -52,7 +52,7 @@
              data-media-type="{{ media.mediaType }}"
              class="hc-media-thumb-link">
             {% if media.thumbnailPath %}
-              <img src="{{ asset('storage/thumbs/' ~ media.thumbnailPath|split('/')|last) }}"
+              <img src="{{ path('media_thumbnail', {id: media.id}) }}"
                    alt="{{ media.file.originalName }}"
                    loading="lazy"
                    class="hc-media-thumb-img">

--- a/tests/Web/MediaGalleryTest.php
+++ b/tests/Web/MediaGalleryTest.php
@@ -84,6 +84,29 @@ final class MediaGalleryTest extends WebTestCase
         $this->assertSelectorTextContains('[data-testid="media-thumbnail"]', 'sunset.jpg');
     }
 
+    public function testGalleryThumbnailSrcPointsToRealRoute(): void
+    {
+        $user = $this->createUser();
+        $media = $this->createMediaFile($user, 'sunset.jpg', 'photo');
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/gallery');
+        $this->assertResponseIsSuccessful();
+
+        $img = $crawler->filter('[data-testid="media-thumbnail"] img');
+        $this->assertCount(1, $img, 'La vignette doit être une image');
+        $this->assertStringNotContainsString(
+            '/storage/thumbs/',
+            $img->attr('src'),
+            'Le src ne doit plus pointer vers le chemin public inexistant /storage/thumbs/'
+        );
+        $this->assertStringContainsString(
+            '/api/v1/medias/' . $media->getId()->toRfc4122() . '/thumbnail',
+            $img->attr('src'),
+            'Le src doit pointer vers la route media_thumbnail'
+        );
+    }
+
     public function testGalleryShowsEmptyStateWhenNoMedia(): void
     {
         $this->createUser();


### PR DESCRIPTION
## Summary
- `gallery.html.twig` et `album_detail.html.twig` construisaient l'URL des vignettes via `asset('storage/thumbs/...')`, un chemin public **qui n'a jamais existé** — aucun symlink ni route ne sert `var/storage/` sous `/storage/`. Les vignettes étaient cassées depuis leur création, repéré en testant visuellement la galerie avec des fixtures de démo.
- Remplacé par `path('media_thumbnail', {id: media.id})`, qui pointe vers la vraie route (`MediaThumbnailController` → `/api/v1/medias/{id}/thumbnail`), seule à savoir effectivement streamer le fichier.
- Fixtures de démo (#189) : retiré le `thumbnailPath` factice des photos placeholder SVG. `ThumbnailService` génère toujours un vrai JPEG via GD, jamais de SVG, et GD est absent de cet environnement — un thumbnail légitime ne peut donc jamais exister pour ces fichiers de démo. Le simuler mentait sur le contrat réel et entrait en contradiction avec le `Content-Type: image/jpeg` forcé dans `MediaThumbnailController` (correct pour le vrai pipeline). Sans thumbnail, la galerie retombe sur l'icône de repli déjà prévue par le template.

## Test plan
- [x] `./vendor/bin/phpunit` — 375/375 tests verts
- [x] Nouveau test RED→GREEN : le `src` de la vignette pointe vers la route `media_thumbnail`, plus vers `/storage/thumbs/`
- [x] Vérifié visuellement `/gallery` avec les fixtures de démo chargées en local (`--append`, sans purger les données existantes)