### PR TITLE
✨ feat(search): afficher une vraie vignette photo dans les résultats de recherche

### DIFF
--- a/src/Controller/Web/SearchController.php
+++ b/src/Controller/Web/SearchController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller\Web;
 
 use App\Entity\User;
+use App\Interface\MediaRepositoryInterface;
 use App\Repository\FileRepository;
 use App\Repository\FolderRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -23,6 +24,7 @@ final class SearchController extends AbstractController
     public function __construct(
         private readonly FolderRepository $folderRepository,
         private readonly FileRepository $fileRepository,
+        private readonly MediaRepositoryInterface $mediaRepository,
     ) {}
 
     #[Route('/search', name: 'app_search', methods: ['GET'])]
@@ -52,7 +54,7 @@ final class SearchController extends AbstractController
         }
 
         foreach ($files as $file) {
-            $items[] = [
+            $item = [
                 'id'         => $file->getId()->toRfc4122(),
                 'name'       => $file->getOriginalName(),
                 'isFolder'   => false,
@@ -62,6 +64,14 @@ final class SearchController extends AbstractController
                 'folderName' => $file->getFolder()->getName(),
                 'folderUrl'  => '/explorer?folder=' . $file->getFolder()->getId()->toRfc4122(),
             ];
+
+            $media = $this->mediaRepository->findByFile($file);
+            if ($media !== null && $media->getThumbnailPath() !== null) {
+                $item['mediaId']      = $media->getId()->toRfc4122();
+                $item['thumbnailUrl'] = $this->generateUrl('app_media_thumbnail', ['id' => $media->getId()->toRfc4122()]);
+            }
+
+            $items[] = $item;
         }
 
         return $this->json(['items' => $items]);

--- a/src/Interface/MediaRepositoryInterface.php
+++ b/src/Interface/MediaRepositoryInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Interface;
 
+use App\Entity\File;
 use App\Entity\Media;
 use App\Entity\User;
 use Symfony\Component\Uid\Uuid;
@@ -18,4 +19,6 @@ interface MediaRepositoryInterface
     public function findByOwner(User $user, ?string $type = null, array $orderBy = []): array;
 
     public function findById(Uuid $id): ?Media;
+
+    public function findByFile(File $file): ?Media;
 }

--- a/src/Repository/MediaRepository.php
+++ b/src/Repository/MediaRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\Entity\File;
 use App\Entity\Media;
 use App\Entity\User;
 use App\Interface\MediaRepositoryInterface;
@@ -27,6 +28,11 @@ class MediaRepository extends ServiceEntityRepository implements MediaRepository
     public function findById(Uuid $id): ?Media
     {
         return $this->find($id);
+    }
+
+    public function findByFile(File $file): ?Media
+    {
+        return $this->findOneBy(['file' => $file]);
     }
 
     /**

--- a/templates/components/MainToolbar.html.twig
+++ b/templates/components/MainToolbar.html.twig
@@ -86,8 +86,18 @@
             a.addEventListener('click', closeSearch);
 
             var iconSpan = document.createElement('span');
-            iconSpan.className = 'shrink-0 text-white/70';
-            iconSpan.innerHTML = iconSvg;
+            iconSpan.className = 'shrink-0 text-white/70 flex items-center justify-center w-6 h-6';
+
+            if (item.thumbnailUrl) {
+                var thumb = document.createElement('img');
+                thumb.src = item.thumbnailUrl;
+                thumb.alt = '';
+                thumb.className = 'w-6 h-6 rounded object-cover';
+                thumb.onerror = function () { iconSpan.innerHTML = iconSvg; };
+                iconSpan.appendChild(thumb);
+            } else {
+                iconSpan.innerHTML = iconSvg;
+            }
 
             var textWrap = document.createElement('div');
             textWrap.className = 'min-w-0';

--- a/tests/Web/SearchTest.php
+++ b/tests/Web/SearchTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Web;
 
 use App\Entity\File;
 use App\Entity\Folder;
+use App\Entity\Media;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -29,6 +30,7 @@ final class SearchTest extends WebTestCase
 
         $conn = $this->em->getConnection();
         $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM medias');
         $conn->executeStatement('DELETE FROM files');
         $conn->executeStatement('DELETE FROM folders');
         $conn->executeStatement('DELETE FROM users');
@@ -99,6 +101,41 @@ final class SearchTest extends WebTestCase
         $this->assertResponseIsSuccessful();
         $data = json_decode($this->client->getResponse()->getContent(), true);
         $this->assertEmpty($data['items']);
+    }
+
+    public function testSearchExposesThumbnailUrlForMediaWithThumbnail(): void
+    {
+        $owner = $this->em->getRepository(User::class)->find($this->user->getId());
+
+        $folder = new Folder('Photos', $owner);
+        $this->em->persist($folder);
+        $file = new File('vacances.jpg', 'image/jpeg', 4096, '2026/03/vacances.jpg', $folder, $owner);
+        $this->em->persist($file);
+
+        $media = new Media($file, 'photo');
+        $media->setThumbnailPath('thumbs/vacances.jpg');
+        $this->em->persist($media);
+        $this->em->flush();
+
+        $this->client->request('GET', '/search?q=vacances', [], [], ['HTTP_ACCEPT' => 'application/json']);
+        $this->assertResponseIsSuccessful();
+        $data = json_decode($this->client->getResponse()->getContent(), true);
+
+        $item = current(array_filter($data['items'], fn (array $i) => $i['name'] === 'vacances.jpg'));
+        $this->assertNotFalse($item);
+        $this->assertSame($media->getId()->toRfc4122(), $item['mediaId']);
+        $this->assertStringContainsString('/gallery/' . $media->getId()->toRfc4122() . '/thumbnail', $item['thumbnailUrl']);
+    }
+
+    public function testSearchOmitsThumbnailUrlForFileWithoutMedia(): void
+    {
+        $this->client->request('GET', '/search?q=rapport', [], [], ['HTTP_ACCEPT' => 'application/json']);
+        $data = json_decode($this->client->getResponse()->getContent(), true);
+
+        $item = current(array_filter($data['items'], fn (array $i) => $i['name'] === 'rapport-annuel.pdf'));
+        $this->assertNotFalse($item);
+        $this->assertArrayNotHasKey('mediaId', $item);
+        $this->assertArrayNotHasKey('thumbnailUrl', $item);
     }
 
     public function testSearchDoesNotReturnOtherUsersData(): void


### PR DESCRIPTION
## Résumé
- `MediaRepositoryInterface::findByFile()` ajouté pour retrouver le `Media` associé à un `File` (SRP).
- `SearchController` enrichit chaque résultat fichier avec `mediaId`/`thumbnailUrl` quand un `Media` avec vignette existe, en réutilisant la route `app_media_thumbnail` déjà en place pour la galerie.
- La modale de recherche affiche désormais une vraie vignette (`<img>`) pour les résultats médias, avec repli automatique sur l'icône SVG (`onerror`) si la vignette est introuvable.

## Test plan
- [x] TDD : `SearchTest::testSearchExposesThumbnailUrlForMediaWithThumbnail` et `testSearchOmitsThumbnailUrlForFileWithoutMedia` (RED → GREEN)
- [x] Suite complète PHPUnit (386/386) verte
- [x] Vérifié visuellement en local