### PR TITLE
✨ feat(album): sélection de photos, ajout depuis la galerie et retrait de média

### DIFF
--- a/assets/controllers/confirm_submit_controller.js
+++ b/assets/controllers/confirm_submit_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from '@hotwired/stimulus';
+
+/* Demande confirmation avant la soumission d'un formulaire destructeur.
+ * Usage : data-controller="confirm-submit" data-confirm-submit-message-value="..." */
+export default class extends Controller {
+    static values = { message: String };
+
+    connect() {
+        this.element.addEventListener('submit', this.onSubmit.bind(this));
+    }
+
+    onSubmit(event) {
+        if (!window.confirm(this.messageValue)) {
+            event.preventDefault();
+        }
+    }
+}

--- a/assets/controllers/gallery_lightbox_controller.js
+++ b/assets/controllers/gallery_lightbox_controller.js
@@ -1,0 +1,56 @@
+import { Controller } from '@hotwired/stimulus';
+
+/* Lightbox de la galerie médias : ouvre le média en plein écran au clic
+ * sur une vignette, navigation précédent/suivant au clavier et via boutons. */
+export default class extends Controller {
+    static targets = ['img', 'prev', 'next'];
+
+    connect() {
+        this.links = Array.from(document.querySelectorAll('[data-lightbox]'));
+        this.srcs = this.links.map((el) => el.getAttribute('data-full-src'));
+        this.current = -1;
+
+        this.links.forEach((el, index) => {
+            el.addEventListener('click', (e) => {
+                if (!this.srcs[index]) return;
+                e.preventDefault();
+                this.show(index);
+            });
+        });
+
+        this.boundKeydown = this.onKeydown.bind(this);
+        document.addEventListener('keydown', this.boundKeydown);
+    }
+
+    disconnect() {
+        document.removeEventListener('keydown', this.boundKeydown);
+    }
+
+    show(index) {
+        if (index < 0 || index >= this.srcs.length) return;
+        this.current = index;
+        this.imgTarget.src = this.srcs[this.current];
+        this.element.style.display = 'flex';
+        this.prevTarget.style.visibility = this.current > 0 ? 'visible' : 'hidden';
+        this.nextTarget.style.visibility = this.current < this.srcs.length - 1 ? 'visible' : 'hidden';
+    }
+
+    prev() {
+        this.show(this.current - 1);
+    }
+
+    next() {
+        this.show(this.current + 1);
+    }
+
+    close() {
+        this.element.style.display = 'none';
+    }
+
+    onKeydown(e) {
+        if (this.element.style.display !== 'flex') return;
+        if (e.key === 'ArrowLeft') this.prev();
+        if (e.key === 'ArrowRight') this.next();
+        if (e.key === 'Escape') this.close();
+    }
+}

--- a/assets/controllers/gallery_selection_controller.js
+++ b/assets/controllers/gallery_selection_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from '@hotwired/stimulus';
+
+/* Sélection multiple de médias dans la galerie, active uniquement en contexte
+ * d'ajout à un album (?album=...). Affiche la barre d'action flottante dès
+ * qu'au moins un média est coché. */
+export default class extends Controller {
+    static targets = ['thumb', 'checkbox', 'bar', 'count'];
+
+    update() {
+        const checked = this.checkboxTargets.filter((cb) => cb.checked);
+
+        this.checkboxTargets.forEach((cb) => {
+            cb.closest('[data-gallery-selection-target="thumb"]')
+                .classList.toggle('hc-media-thumb--selected', cb.checked);
+        });
+
+        this.countTarget.textContent = `${checked.length} sélectionné${checked.length > 1 ? 's' : ''}`;
+        this.barTarget.classList.toggle('hidden', checked.length === 0);
+    }
+}

--- a/assets/styles/gallery.css
+++ b/assets/styles/gallery.css
@@ -97,6 +97,89 @@
   text-overflow: ellipsis;
 }
 
+/* ── Sélection multiple (toujours visible, pour ajout à un album) ── */
+.hc-media-thumb-select {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 2;
+}
+
+.hc-media-thumb-checkbox {
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+}
+
+.hc-media-thumb--selected {
+  outline: 3px solid var(--hc-accent);
+  outline-offset: -3px;
+}
+
+.hc-selection-bar {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: var(--hc-surface);
+  border: 1px solid var(--hc-border);
+  box-shadow: var(--hc-shadow-crisp);
+}
+
+.hc-selection-count {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--hc-text-2);
+}
+
+.hc-selection-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hc-selection-confirm {
+  padding: 8px 16px;
+  border-radius: 999px;
+  border: none;
+  background: var(--hc-accent);
+  color: #fff;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background .15s ease;
+}
+.hc-selection-confirm:hover {
+  background: var(--hc-accent-2);
+}
+
+.hc-selection-cancel {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: none;
+  background: none;
+  font-size: 0.8125rem;
+  color: var(--hc-text-3);
+  cursor: pointer;
+  text-decoration: none;
+}
+
+/* ── Bandeau d'info en contexte "ajout à un album" ── */
+.hc-gallery-picking-banner {
+  padding: 10px 16px;
+  border-radius: 8px;
+  background: var(--hc-accent-soft);
+  color: var(--hc-accent);
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
 /* ── Lightbox ── */
 .hc-lightbox {
   display: none;

--- a/assets/styles/gallery.css
+++ b/assets/styles/gallery.css
@@ -97,6 +97,37 @@
   text-overflow: ellipsis;
 }
 
+/* ── Retrait d'un média d'un album ── */
+.hc-media-thumb-remove-form {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 2;
+}
+
+.hc-media-thumb-remove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity .15s ease, background .15s ease;
+}
+.hc-media-thumb:hover .hc-media-thumb-remove {
+  opacity: 1;
+}
+.hc-media-thumb-remove:hover {
+  background: var(--hc-err);
+}
+
 /* ── Sélection multiple (toujours visible, pour ajout à un album) ── */
 .hc-media-thumb-select {
   position: absolute;

--- a/src/Controller/Web/AlbumWebController.php
+++ b/src/Controller/Web/AlbumWebController.php
@@ -77,6 +77,22 @@ final class AlbumWebController extends AbstractController
         return $this->redirectToRoute('app_album_detail', ['id' => $album->getId()->toRfc4122()]);
     }
 
+    #[Route('/albums/{id}/medias/{mediaId}/remove', name: 'app_album_remove_media', methods: ['POST'], requirements: ['id' => '[0-9a-f\-]+', 'mediaId' => '[0-9a-f\-]+'])]
+    public function removeMedia(string $id, string $mediaId): Response
+    {
+        $album = $this->albumRepository->findById(Uuid::fromString($id))
+            ?? throw $this->createNotFoundException('Album introuvable.');
+
+        $this->denyAccessUnlessGranted(AlbumVoter::VIEW, $album);
+
+        $media = $this->mediaRepository->findById(Uuid::fromString($mediaId))
+            ?? throw $this->createNotFoundException('Média introuvable.');
+
+        $this->albumService->removeMedia($album, $media);
+
+        return $this->redirectToRoute('app_album_detail', ['id' => $album->getId()->toRfc4122()]);
+    }
+
     #[Route('/albums/{id}', name: 'app_album_detail', requirements: ['id' => '[0-9a-f\-]+'])]
     public function detail(string $id): Response
     {

--- a/src/Controller/Web/AlbumWebController.php
+++ b/src/Controller/Web/AlbumWebController.php
@@ -6,6 +6,7 @@ namespace App\Controller\Web;
 
 use App\Entity\User;
 use App\Interface\AlbumRepositoryInterface;
+use App\Interface\MediaRepositoryInterface;
 use App\Security\AlbumVoter;
 use App\Service\AlbumService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -26,6 +27,7 @@ final class AlbumWebController extends AbstractController
     public function __construct(
         private readonly AlbumRepositoryInterface $albumRepository,
         private readonly AlbumService $albumService,
+        private readonly MediaRepositoryInterface $mediaRepository,
     ) {}
 
     #[Route('/albums', name: 'app_albums')]
@@ -36,22 +38,41 @@ final class AlbumWebController extends AbstractController
 
         return $this->render('web/albums.html.twig', [
             'albums' => $this->albumRepository->findByOwner($user),
+            'medias' => $this->mediaRepository->findByOwner($user),
         ]);
     }
 
     #[Route('/albums/create', name: 'app_album_create', methods: ['POST'])]
     public function create(Request $request): Response
     {
-        $name = (string) $request->request->get('name', '');
+        $name     = (string) $request->request->get('name', '');
+        $mediaIds = $request->request->all('mediaIds');
 
         /** @var User $user */
         $user  = $this->getUser();
 
         try {
-            $album = $this->albumService->create($name, $user);
+            $album = $this->albumService->create($name, $user, $mediaIds);
         } catch (\InvalidArgumentException $e) {
             throw new BadRequestHttpException($e->getMessage());
         }
+
+        return $this->redirectToRoute('app_album_detail', ['id' => $album->getId()->toRfc4122()]);
+    }
+
+    #[Route('/albums/{id}/add-media', name: 'app_album_add_media', methods: ['POST'], requirements: ['id' => '[0-9a-f\-]+'])]
+    public function addMedia(string $id, Request $request): Response
+    {
+        $album = $this->albumRepository->findById(Uuid::fromString($id))
+            ?? throw $this->createNotFoundException('Album introuvable.');
+
+        $this->denyAccessUnlessGranted(AlbumVoter::VIEW, $album);
+
+        /** @var User $user */
+        $user     = $this->getUser();
+        $mediaIds = $request->request->all('mediaIds');
+
+        $this->albumService->addMedias($album, $mediaIds, $user);
 
         return $this->redirectToRoute('app_album_detail', ['id' => $album->getId()->toRfc4122()]);
     }

--- a/src/Controller/Web/MediaGalleryController.php
+++ b/src/Controller/Web/MediaGalleryController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller\Web;
 
 use App\Entity\User;
+use App\Interface\AlbumRepositoryInterface;
 use App\Interface\MediaRepositoryInterface;
 use App\Interface\StorageServiceInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -25,6 +26,7 @@ final class MediaGalleryController extends AbstractController
     public function __construct(
         private readonly MediaRepositoryInterface $mediaRepository,
         private readonly StorageServiceInterface $storageService,
+        private readonly AlbumRepositoryInterface $albumRepository,
     ) {}
 
     #[Route('/gallery', name: 'app_gallery')]
@@ -37,10 +39,21 @@ final class MediaGalleryController extends AbstractController
 
         $medias = $this->mediaRepository->findByOwner($user, $type ?: null, $order);
 
+        $targetAlbum = null;
+        $albumParam = $request->query->get('album');
+        if ($albumParam !== null) {
+            $targetAlbum = $this->albumRepository->findById(Uuid::fromString($albumParam));
+
+            if ($targetAlbum !== null && !$targetAlbum->getOwner()->getId()->equals($user->getId())) {
+                throw $this->createAccessDeniedException('Cet album ne vous appartient pas.');
+            }
+        }
+
         return $this->render('web/gallery.html.twig', [
-            'medias' => $medias,
-            'type'   => $type,
-            'order'  => $order,
+            'medias'      => $medias,
+            'type'        => $type,
+            'order'       => $order,
+            'targetAlbum' => $targetAlbum,
         ]);
     }
 
@@ -54,9 +67,10 @@ final class MediaGalleryController extends AbstractController
         }
 
         return $this->render('web/gallery.html.twig', [
-            'medias' => [$media],
-            'type'   => null,
-            'order'  => [],
+            'medias'      => [$media],
+            'type'        => null,
+            'order'       => [],
+            'targetAlbum' => null,
         ]);
     }
 

--- a/src/Service/AlbumService.php
+++ b/src/Service/AlbumService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service;
 
 use App\Entity\Album;
+use App\Entity\Media;
 use App\Entity\User;
 use App\Interface\AlbumRepositoryInterface;
 use App\Interface\MediaRepositoryInterface;
@@ -55,6 +56,16 @@ final class AlbumService
     public function addMedias(Album $album, array $mediaIds, User $owner): void
     {
         $this->addOwnedMediasTo($album, $mediaIds, $owner);
+        $this->repository->save($album);
+    }
+
+    /**
+     * Retire un média d'un album. Ne supprime que l'association — le Media
+     * (et son File) restent intacts et disponibles dans la galerie.
+     */
+    public function removeMedia(Album $album, Media $media): void
+    {
+        $album->removeMedia($media);
         $this->repository->save($album);
     }
 

--- a/src/Service/AlbumService.php
+++ b/src/Service/AlbumService.php
@@ -7,7 +7,9 @@ namespace App\Service;
 use App\Entity\Album;
 use App\Entity\User;
 use App\Interface\AlbumRepositoryInterface;
+use App\Interface\MediaRepositoryInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * Service métier pour la gestion des albums (SRP).
@@ -20,19 +22,40 @@ final class AlbumService
 {
     public function __construct(
         private readonly AlbumRepositoryInterface $repository,
+        private readonly MediaRepositoryInterface $mediaRepository,
     ) {}
 
     /**
-     * Crée un nouvel album pour l'utilisateur donné.
+     * Crée un nouvel album pour l'utilisateur donné, avec une sélection
+     * optionnelle de médias à y ajouter immédiatement.
      *
+     * Les identifiants invalides, introuvables ou n'appartenant pas à $owner
+     * sont ignorés silencieusement (pas d'erreur bloquante sur la création).
+     *
+     * @param string[] $mediaIds
      * @throws InvalidArgumentException si le nom est vide ou uniquement des espaces
      */
-    public function create(string $name, User $owner): Album
+    public function create(string $name, User $owner, array $mediaIds = []): Album
     {
         $album = new Album($name, $owner);
+        $this->addOwnedMediasTo($album, $mediaIds, $owner);
         $this->repository->save($album);
 
         return $album;
+    }
+
+    /**
+     * Ajoute une sélection de médias à un album existant.
+     *
+     * Les identifiants invalides, introuvables ou n'appartenant pas à $owner
+     * sont ignorés silencieusement (idempotent, pas d'erreur bloquante).
+     *
+     * @param string[] $mediaIds
+     */
+    public function addMedias(Album $album, array $mediaIds, User $owner): void
+    {
+        $this->addOwnedMediasTo($album, $mediaIds, $owner);
+        $this->repository->save($album);
     }
 
     /**
@@ -41,5 +64,24 @@ final class AlbumService
     public function delete(Album $album): void
     {
         $this->repository->remove($album);
+    }
+
+    /**
+     * @param string[] $mediaIds
+     */
+    private function addOwnedMediasTo(Album $album, array $mediaIds, User $owner): void
+    {
+        foreach ($mediaIds as $mediaId) {
+            try {
+                $uuid = Uuid::fromString($mediaId);
+            } catch (\InvalidArgumentException) {
+                continue;
+            }
+
+            $media = $this->mediaRepository->findById($uuid);
+            if ($media !== null && $media->isOwnedBy($owner)) {
+                $album->addMedia($media);
+            }
+        }
     }
 }

--- a/templates/components/NewAlbumModal.html.twig
+++ b/templates/components/NewAlbumModal.html.twig
@@ -1,0 +1,123 @@
+{# === NewAlbumModal component ===
+   Modale de création d'album avec sélection de photos/vidéos existantes.
+   Soumet un formulaire POST classique vers app_album_create (pas d'API JWT),
+   cohérent avec le flux existant de la page /albums. #}
+<div id="new-album-modal"
+     data-testid="new-album-modal"
+     class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/45"
+     tabindex="-1"
+     aria-modal="true"
+     role="dialog">
+
+  <form method="post" action="{{ path('app_album_create') }}"
+        class="flex flex-col"
+        style="background: var(--hc-surface); color: var(--hc-text); border: 1px solid var(--hc-border);
+               border-radius: 1rem; box-shadow: var(--hc-shadow-crisp); width: 100%; max-width: 560px;
+               margin: 1rem; max-height: 85vh;">
+
+    {# Header #}
+    <div class="flex items-center justify-between px-6 py-4" style="border-bottom: 1px solid var(--hc-border);">
+      <h2 class="text-base font-semibold m-0">Nouvel album</h2>
+      <button type="button" id="new-album-modal-close" aria-label="Fermer"
+              class="flex items-center justify-center w-8 h-8 rounded-full"
+              style="background: var(--hc-surface-2); color: var(--hc-text-2); border: none; cursor: pointer;">×</button>
+    </div>
+
+    {# Nom #}
+    <div class="px-6 pt-4">
+      <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
+        Nom de l'album
+      </label>
+      <input type="text" name="name" id="new-album-name-input" data-testid="new-album-name"
+             placeholder="Vacances d'été…" required
+             class="w-full px-3 py-2 rounded-md text-sm"
+             style="border: 1px solid var(--hc-border); background: var(--hc-bg); color: var(--hc-text);">
+    </div>
+
+    {# Sélection des médias #}
+    <div class="px-6 pt-4 pb-2" style="overflow-y: auto;">
+      <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
+        Photos à ajouter {% if medias|length %}({{ medias|length }}){% endif %}
+      </label>
+
+      {% if medias is empty %}
+        <p class="text-sm" style="color: var(--hc-text-3);">Aucun média disponible pour le moment.</p>
+      {% else %}
+        <div class="grid gap-2" style="grid-template-columns: repeat(auto-fill, minmax(88px, 1fr));">
+          {% for media in medias %}
+            <label class="relative block rounded-md overflow-hidden cursor-pointer"
+                   style="aspect-ratio: 1; border: 2px solid var(--hc-border);">
+              <input type="checkbox" name="mediaIds[]" value="{{ media.id }}"
+                     class="hc-album-media-checkbox"
+                     style="position: absolute; top: 6px; left: 6px; z-index: 1; width: 18px; height: 18px;">
+              {% if media.thumbnailPath %}
+                <img src="{{ path('app_media_thumbnail', {id: media.id}) }}"
+                     alt="{{ media.file.originalName }}" loading="lazy"
+                     class="w-full h-full object-cover">
+              {% else %}
+                <div class="w-full h-full flex items-center justify-center" style="background: var(--hc-surface-2); color: var(--hc-text-3);">
+                  <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5z"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+                </div>
+              {% endif %}
+            </label>
+          {% endfor %}
+        </div>
+      {% endif %}
+    </div>
+
+    {# Actions #}
+    <div class="flex gap-2 justify-end px-6 py-4" style="border-top: 1px solid var(--hc-border);">
+      <button type="button" id="new-album-modal-cancel"
+              class="px-4 py-2 rounded-md text-sm font-medium"
+              style="background: none; border: none; color: var(--hc-text-2); cursor: pointer;">
+        Annuler
+      </button>
+      <button type="submit" data-testid="new-album-submit"
+              class="px-4 py-2 rounded-md text-sm font-semibold"
+              style="background: var(--hc-accent); color: var(--hc-accent-contrast, #fff); border: none; cursor: pointer;">
+        Créer
+      </button>
+    </div>
+  </form>
+</div>
+
+<style>
+  .hc-album-media-checkbox:checked + img,
+  .hc-album-media-checkbox:checked ~ div {
+    outline: 3px solid var(--hc-accent);
+    outline-offset: -3px;
+  }
+</style>
+
+<script>
+(function () {
+    var openBtn   = document.getElementById('new-album-open-btn');
+    var modal     = document.getElementById('new-album-modal');
+    var closeBtn  = document.getElementById('new-album-modal-close');
+    var cancelBtn = document.getElementById('new-album-modal-cancel');
+    var nameInput = document.getElementById('new-album-name-input');
+
+    if (!openBtn || !modal) return;
+
+    function open() {
+        modal.classList.remove('hidden');
+        modal.style.display = 'flex';
+        setTimeout(function () { nameInput.focus(); }, 50);
+    }
+
+    function close() {
+        modal.classList.add('hidden');
+        modal.style.display = 'none';
+    }
+
+    openBtn.addEventListener('click', open);
+    closeBtn.addEventListener('click', close);
+    cancelBtn.addEventListener('click', close);
+    modal.addEventListener('click', function (e) {
+        if (e.target === modal) close();
+    });
+    document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape' && modal.style.display === 'flex') close();
+    });
+}());
+</script>

--- a/templates/web/album_detail.html.twig
+++ b/templates/web/album_detail.html.twig
@@ -51,6 +51,12 @@
     <div class="hc-media-grid">
       {% for media in album.medias %}
         <div class="hc-media-thumb">
+          <form method="post" action="{{ path('app_album_remove_media', {id: album.id, mediaId: media.id}) }}"
+                class="hc-media-thumb-remove-form" data-controller="confirm-submit"
+                data-confirm-submit-message-value="Retirer « {{ media.file.originalName }} » de l'album ?">
+            <button type="submit" class="hc-media-thumb-remove" data-testid="remove-media-from-album"
+                    title="Retirer de l'album" aria-label="Retirer de l'album">×</button>
+          </form>
           {% if media.thumbnailPath %}
             <img src="{{ path('app_media_thumbnail', {id: media.id}) }}"
                  alt="{{ media.file.originalName }}"

--- a/templates/web/album_detail.html.twig
+++ b/templates/web/album_detail.html.twig
@@ -21,14 +21,22 @@
       </p>
     </div>
 
-    <form method="post" action="{{ path('app_album_delete', {id: album.id}) }}"
-          onsubmit="return confirm('Supprimer l\'album « {{ album.name|e('js') }} » ?')">
-      <button type="submit" class="hc-item-action hc-item-action--danger flex items-center gap-2 px-4 py-2 rounded-md font-semibold text-sm"
-              style="border:1px solid var(--hc-border); color: var(--hc-err);">
-        {{ icons.icon('trash', 16) }}
-        Supprimer
-      </button>
-    </form>
+    <div class="flex gap-2">
+      <a href="{{ path('app_gallery', {album: album.id}) }}"
+         class="hc-btn-soft flex items-center gap-2 px-4 py-2 rounded-md font-semibold text-sm"
+         style="background: var(--hc-accent-soft); color: var(--hc-accent); text-decoration:none;">
+        {{ icons.icon('images', 16) }}
+        Ajouter des photos
+      </a>
+      <form method="post" action="{{ path('app_album_delete', {id: album.id}) }}"
+            onsubmit="return confirm('Supprimer l\'album « {{ album.name|e('js') }} » ?')">
+        <button type="submit" class="hc-item-action hc-item-action--danger flex items-center gap-2 px-4 py-2 rounded-md font-semibold text-sm"
+                style="border:1px solid var(--hc-border); color: var(--hc-err);">
+          {{ icons.icon('trash', 16) }}
+          Supprimer
+        </button>
+      </form>
+    </div>
   </div>
 
   {% if album.medias is empty %}
@@ -36,7 +44,7 @@
       title="Cet album ne contient aucun média"
       subtitle="Ajoutez des photos ou vidéos depuis la galerie."
       actionLabel="Ajouter depuis la galerie"
-      actionUrl="{{ path('app_gallery') }}"
+      actionUrl="{{ path('app_gallery', {album: album.id}) }}"
       icon="<svg width='64' height='64' fill='none' stroke='currentColor' stroke-width='1.5' viewBox='0 0 24 24' class='hc-icon hc-icon-images'><path d='M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5z'/><circle cx='8.5' cy='8.5' r='1.5'/><polyline points='21 15 16 10 5 21'/></svg>"
     />
   {% else %}

--- a/templates/web/albums.html.twig
+++ b/templates/web/albums.html.twig
@@ -17,15 +17,14 @@
       <p class="hc-page-sub">{{ albums|length }} album{{ albums|length != 1 ? 's' : '' }}</p>
     </div>
 
-    <form method="post" action="{{ path('app_album_create') }}" class="flex gap-2 items-center">
-      <input type="text" name="name" placeholder="Nom du nouvel album" class="hc-search" style="width:auto;" required />
-      <button type="submit" class="hc-btn-soft flex items-center gap-2 px-4 py-2 rounded-md font-semibold text-sm cursor-pointer"
-              style="background: var(--hc-accent-soft); color: var(--hc-accent); border:none;">
-        <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg>
-        Créer
-      </button>
-    </form>
+    <button type="button" id="new-album-open-btn" class="hc-btn-soft flex items-center gap-2 px-4 py-2 rounded-md font-semibold text-sm cursor-pointer"
+            style="background: var(--hc-accent-soft); color: var(--hc-accent); border:none;">
+      <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg>
+      Nouvel album
+    </button>
   </div>
+
+  <twig:NewAlbumModal :medias="medias" />
 
   {% if albums is empty %}
     <div data-testid="albums-empty">

--- a/templates/web/gallery.html.twig
+++ b/templates/web/gallery.html.twig
@@ -46,6 +46,7 @@
           Vidéos
         </a>
       </div>
+
     </div>
   </div>
 
@@ -58,9 +59,22 @@
       />
     </div>
   {% else %}
-    <div data-testid="media-gallery" class="hc-media-grid">
+    {% if targetAlbum %}
+      <div class="hc-gallery-picking-banner">
+        Sélectionnez les photos à ajouter à « {{ targetAlbum.name }} »
+      </div>
+    {% endif %}
+
+    <div data-testid="media-gallery" class="hc-media-grid" data-controller="gallery-selection">
       {% for media in medias %}
-        <div data-testid="media-thumbnail" class="hc-media-thumb">
+        <div data-testid="media-thumbnail" class="hc-media-thumb" data-gallery-selection-target="thumb">
+          {% if targetAlbum %}
+            <label class="hc-media-thumb-select">
+              <input type="checkbox" name="mediaIds[]" value="{{ media.id }}" form="gallery-add-to-album-form"
+                     class="hc-media-thumb-checkbox" data-gallery-selection-target="checkbox"
+                     data-action="change->gallery-selection#update">
+            </label>
+          {% endif %}
           <a href="{{ path('app_media_view', {id: media.id}) }}"
              data-lightbox
              data-media-type="{{ media.mediaType }}"
@@ -86,60 +100,35 @@
           </div>
         </div>
       {% endfor %}
+
+      {% if targetAlbum %}
+        {# Barre d'action flottante — ajout direct à l'album ciblé par ?album= #}
+        <form id="gallery-add-to-album-form" method="post" action="{{ path('app_album_add_media', {id: targetAlbum.id}) }}"
+              class="hc-selection-bar hidden" data-gallery-selection-target="bar">
+          <span class="hc-selection-count" data-gallery-selection-target="count">0 sélectionné</span>
+          <div class="hc-selection-actions">
+            <button type="submit" class="hc-selection-confirm" data-testid="gallery-add-to-current-album" data-album-id="{{ targetAlbum.id }}">
+              Ajouter à « {{ targetAlbum.name }} »
+            </button>
+            <a href="{{ path('app_album_detail', {id: targetAlbum.id}) }}" class="hc-selection-cancel">Annuler</a>
+          </div>
+        </form>
+      {% endif %}
     </div>
 
-    {# Lightbox simple (CSS + JS inline — pas de dépendance externe) #}
-    <div id="lightbox" class="hc-lightbox">
-      <button id="lightbox-prev" class="hc-lightbox-nav hc-lightbox-nav--prev" aria-label="Média précédent">
+    {# Lightbox simple #}
+    <div id="lightbox" class="hc-lightbox" data-controller="gallery-lightbox">
+      <button data-gallery-lightbox-target="prev" data-action="gallery-lightbox#prev" class="hc-lightbox-nav hc-lightbox-nav--prev" aria-label="Média précédent">
         <svg width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="15 6 9 12 15 18"/></svg>
       </button>
-      <img id="lightbox-img" src="" alt="" class="hc-lightbox-img">
-      <button id="lightbox-next" class="hc-lightbox-nav hc-lightbox-nav--next" aria-label="Média suivant">
+      <img data-gallery-lightbox-target="img" src="" alt="" class="hc-lightbox-img">
+      <button data-gallery-lightbox-target="next" data-action="gallery-lightbox#next" class="hc-lightbox-nav hc-lightbox-nav--next" aria-label="Média suivant">
         <svg width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="9 6 15 12 9 18"/></svg>
       </button>
-      <button onclick="document.getElementById('lightbox').style.display='none'" class="hc-lightbox-close" aria-label="Fermer">
+      <button data-action="gallery-lightbox#close" class="hc-lightbox-close" aria-label="Fermer">
         <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M18 6L6 18M6 6l12 12"/></svg>
       </button>
     </div>
-    <script>
-    (function () {
-        var links = Array.prototype.slice.call(document.querySelectorAll('[data-lightbox]'));
-        var srcs = links.map(function (el) { return el.getAttribute('data-full-src'); });
-        var current = -1;
-
-        var lightbox = document.getElementById('lightbox');
-        var img = document.getElementById('lightbox-img');
-        var prevBtn = document.getElementById('lightbox-prev');
-        var nextBtn = document.getElementById('lightbox-next');
-
-        function show(index) {
-            if (index < 0 || index >= srcs.length) return;
-            current = index;
-            img.src = srcs[current];
-            lightbox.style.display = 'flex';
-            prevBtn.style.visibility = current > 0 ? 'visible' : 'hidden';
-            nextBtn.style.visibility = current < srcs.length - 1 ? 'visible' : 'hidden';
-        }
-
-        links.forEach(function (el, index) {
-            el.addEventListener('click', function (e) {
-                if (!srcs[index]) return;
-                e.preventDefault();
-                show(index);
-            });
-        });
-
-        prevBtn.addEventListener('click', function () { show(current - 1); });
-        nextBtn.addEventListener('click', function () { show(current + 1); });
-
-        document.addEventListener('keydown', function (e) {
-            if (lightbox.style.display !== 'flex') return;
-            if (e.key === 'ArrowLeft') show(current - 1);
-            if (e.key === 'ArrowRight') show(current + 1);
-            if (e.key === 'Escape') lightbox.style.display = 'none';
-        });
-    })();
-    </script>
   {% endif %}
 
 </div>

--- a/tests/Service/AlbumServiceTest.php
+++ b/tests/Service/AlbumServiceTest.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 namespace App\Tests\Service;
 
 use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Media;
 use App\Entity\User;
 use App\Interface\AlbumRepositoryInterface;
+use App\Interface\MediaRepositoryInterface;
 use App\Service\AlbumService;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -20,17 +24,28 @@ final class AlbumServiceTest extends TestCase
     private AlbumService $service;
     /** @var AlbumRepositoryInterface&MockObject */
     private AlbumRepositoryInterface $repository;
+    /** @var MediaRepositoryInterface&MockObject */
+    private MediaRepositoryInterface $mediaRepository;
 
     protected function setUp(): void
     {
         $this->repository = $this->createMock(AlbumRepositoryInterface::class);
-        $this->service = new AlbumService($this->repository);
+        $this->mediaRepository = $this->createMock(MediaRepositoryInterface::class);
+        $this->service = new AlbumService($this->repository, $this->mediaRepository);
     }
 
     private function makeUser(): User
     {
         $user = new User('test@example.com', 'Test User');
         return $user;
+    }
+
+    private function makeMedia(User $owner): Media
+    {
+        $folder = new Folder('Photos', $owner);
+        $file   = new File('photo.jpg', 'image/jpeg', 1024, '2026/photo.jpg', $folder, $owner);
+
+        return new Media($file, 'photo');
     }
 
     // --- create() ---
@@ -86,6 +101,69 @@ final class AlbumServiceTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         $this->service->create('   ', $user);
+    }
+
+    public function testCreateWithMediaIdsAddsOwnedMediaToAlbum(): void
+    {
+        $user  = $this->makeUser();
+        $media = $this->makeMedia($user);
+
+        $this->mediaRepository
+            ->expects($this->once())
+            ->method('findById')
+            ->with($media->getId())
+            ->willReturn($media);
+
+        $this->repository->expects($this->once())->method('save');
+
+        $album = $this->service->create('Vacances', $user, [$media->getId()->toRfc4122()]);
+
+        $this->assertTrue($album->getMedias()->contains($media));
+    }
+
+    public function testCreateIgnoresMediaIdNotOwnedByUser(): void
+    {
+        $user       = $this->makeUser();
+        $otherUser  = new User('other@example.com', 'Other');
+        $otherMedia = $this->makeMedia($otherUser);
+
+        $this->mediaRepository
+            ->expects($this->once())
+            ->method('findById')
+            ->willReturn($otherMedia);
+
+        $this->repository->expects($this->once())->method('save');
+
+        $album = $this->service->create('Vacances', $user, [$otherMedia->getId()->toRfc4122()]);
+
+        $this->assertFalse($album->getMedias()->contains($otherMedia));
+    }
+
+    public function testCreateIgnoresUnknownMediaId(): void
+    {
+        $user = $this->makeUser();
+
+        $this->mediaRepository
+            ->expects($this->once())
+            ->method('findById')
+            ->willReturn(null);
+
+        $this->repository->expects($this->once())->method('save');
+
+        $album = $this->service->create('Vacances', $user, ['019f5700-0000-7000-8000-000000000000']);
+
+        $this->assertCount(0, $album->getMedias());
+    }
+
+    public function testCreateWithoutMediaIdsCreatesEmptyAlbum(): void
+    {
+        $user = $this->makeUser();
+        $this->mediaRepository->expects($this->never())->method('findById');
+        $this->repository->expects($this->once())->method('save');
+
+        $album = $this->service->create('Vacances', $user);
+
+        $this->assertCount(0, $album->getMedias());
     }
 
     // --- delete() ---

--- a/tests/Web/AlbumWebTest.php
+++ b/tests/Web/AlbumWebTest.php
@@ -138,6 +138,41 @@ final class AlbumWebTest extends WebTestCase
         $this->assertResponseStatusCodeSame(400);
     }
 
+    public function testCreateAlbumWithSelectedMediaIdsAddsThemToAlbum(): void
+    {
+        $user   = $this->createUser();
+        $media1 = $this->createMedia($user, 'photo1.jpg');
+        $media2 = $this->createMedia($user, 'photo2.jpg');
+        $this->login();
+
+        $this->client->request('POST', '/albums/create', [
+            'name'     => 'Vacances',
+            'mediaIds' => [$media1->getId()->toRfc4122(), $media2->getId()->toRfc4122()],
+        ]);
+
+        $response = $this->client->getResponse();
+        $this->assertTrue($response->isRedirect());
+
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('[data-testid="album-media-count"]', '2');
+    }
+
+    public function testCreateAlbumIgnoresMediaIdNotOwnedByUser(): void
+    {
+        $alice      = $this->createUser('alice@example.com');
+        $bob        = $this->createUser('bob@example.com');
+        $bobsMedia  = $this->createMedia($bob, 'secret.jpg');
+
+        $this->login('alice@example.com');
+        $this->client->request('POST', '/albums/create', [
+            'name'     => 'Vacances',
+            'mediaIds' => [$bobsMedia->getId()->toRfc4122()],
+        ]);
+
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('[data-testid="album-media-count"]', '0');
+    }
+
     // --- Détail ---
 
     public function testAlbumDetailPageReturns200(): void
@@ -175,6 +210,55 @@ final class AlbumWebTest extends WebTestCase
         $this->assertResponseStatusCodeSame(403);
     }
 
+    // --- Ajout de médias à un album existant ---
+
+    public function testAddMediaToAlbumRedirectsToAlbumDetail(): void
+    {
+        $user   = $this->createUser();
+        $album  = $this->createAlbum($user, 'Vacances');
+        $media  = $this->createMedia($user, 'photo.jpg');
+        $this->login();
+
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/add-media', [
+            'mediaIds' => [$media->getId()->toRfc4122()],
+        ]);
+
+        $this->assertResponseRedirects('/albums/' . $album->getId()->toRfc4122());
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('[data-testid="album-media-count"]', '1');
+    }
+
+    public function testAddMediaToAlbumIgnoresMediaNotOwnedByUser(): void
+    {
+        $alice     = $this->createUser('alice@example.com');
+        $bob       = $this->createUser('bob@example.com');
+        $album     = $this->createAlbum($alice, 'Vacances');
+        $bobsMedia = $this->createMedia($bob, 'secret.jpg');
+
+        $this->login('alice@example.com');
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/add-media', [
+            'mediaIds' => [$bobsMedia->getId()->toRfc4122()],
+        ]);
+
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('[data-testid="album-media-count"]', '0');
+    }
+
+    public function testAddMediaToAlbumForbiddenForOtherUser(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob   = $this->createUser('bob@example.com');
+        $album = $this->createAlbum($alice, 'Album Alice');
+        $media = $this->createMedia($bob, 'photo.jpg');
+
+        $this->login('bob@example.com');
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/add-media', [
+            'mediaIds' => [$media->getId()->toRfc4122()],
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
     // --- Suppression ---
 
     public function testDeleteAlbumRedirectsToList(): void
@@ -199,6 +283,17 @@ final class AlbumWebTest extends WebTestCase
     }
 
     // --- Alignement design system (dashboard) ---
+
+    public function testAlbumsPageShowsSelectablePhotosForCreation(): void
+    {
+        $user  = $this->createUser();
+        $media = $this->createMedia($user, 'photo.jpg');
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/albums');
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('input[type="checkbox"][name="mediaIds[]"][value="' . $media->getId()->toRfc4122() . '"]');
+    }
 
     public function testAlbumsListHasPageHeaderWithTitle(): void
     {

--- a/tests/Web/AlbumWebTest.php
+++ b/tests/Web/AlbumWebTest.php
@@ -259,6 +259,54 @@ final class AlbumWebTest extends WebTestCase
         $this->assertResponseStatusCodeSame(403);
     }
 
+    // --- Retrait d'un média d'un album ---
+
+    public function testRemoveMediaFromAlbumRedirectsToAlbumDetail(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $media = $this->createMedia($user, 'photo.jpg');
+        $album->addMedia($media);
+        $this->em->flush();
+        $this->login();
+
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/medias/' . $media->getId()->toRfc4122() . '/remove');
+
+        $this->assertResponseRedirects('/albums/' . $album->getId()->toRfc4122());
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('[data-testid="album-media-count"]', '0');
+    }
+
+    public function testRemoveMediaFromAlbumForbiddenForOtherUser(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob   = $this->createUser('bob@example.com');
+        $album = $this->createAlbum($alice, 'Album Alice');
+        $media = $this->createMedia($alice, 'photo.jpg');
+        $album->addMedia($media);
+        $this->em->flush();
+
+        $this->login('bob@example.com');
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/medias/' . $media->getId()->toRfc4122() . '/remove');
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testRemoveMediaFromAlbumDoesNotDeleteTheMediaItself(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $media = $this->createMedia($user, 'photo.jpg');
+        $album->addMedia($media);
+        $this->em->flush();
+        $this->login();
+
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/medias/' . $media->getId()->toRfc4122() . '/remove');
+
+        $this->client->request('GET', '/gallery');
+        $this->assertStringContainsString('photo.jpg', $this->client->getResponse()->getContent());
+    }
+
     // --- Suppression ---
 
     public function testDeleteAlbumRedirectsToList(): void

--- a/tests/Web/MediaGalleryTest.php
+++ b/tests/Web/MediaGalleryTest.php
@@ -25,6 +25,8 @@ final class MediaGalleryTest extends WebTestCase
         $this->em = static::getContainer()->get(EntityManagerInterface::class);
         $conn = $this->em->getConnection();
         $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM album_media');
+        $conn->executeStatement('DELETE FROM albums');
         $conn->executeStatement('DELETE FROM medias');
         $conn->executeStatement('DELETE FROM files');
         $conn->executeStatement('DELETE FROM folders');
@@ -354,5 +356,68 @@ final class MediaGalleryTest extends WebTestCase
             strpos($content, 'abricot.jpg'),
             'Le tri doit continuer à s\'appliquer quand il est combiné au filtre type'
         );
+    }
+
+    // --- Sélection multiple pour ajout à un album ---
+
+    public function testGalleryWithoutAlbumParamHasNoSelectionCheckboxes(): void
+    {
+        $user  = $this->createUser();
+        $media = $this->createMediaFile($user, 'photo.jpg', 'photo');
+        $this->login();
+
+        $this->client->request('GET', '/gallery');
+        $this->assertSelectorNotExists('input[type="checkbox"][name="mediaIds[]"][value="' . $media->getId()->toRfc4122() . '"]');
+    }
+
+    public function testGalleryWithAlbumParamShowsSelectionCheckboxes(): void
+    {
+        $user  = $this->createUser();
+        $media = $this->createMediaFile($user, 'photo.jpg', 'photo');
+        $album = new \App\Entity\Album('Vacances', $user);
+        $this->em->persist($album);
+        $this->em->flush();
+        $this->login();
+
+        $this->client->request('GET', '/gallery?album=' . $album->getId()->toRfc4122());
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('input[type="checkbox"][name="mediaIds[]"][value="' . $media->getId()->toRfc4122() . '"]');
+    }
+
+    public function testGalleryWithAlbumParamShowsAddToThisAlbumBar(): void
+    {
+        $user  = $this->createUser();
+        $this->createMediaFile($user, 'photo.jpg', 'photo');
+        $album = new \App\Entity\Album('Vacances', $user);
+        $this->em->persist($album);
+        $this->em->flush();
+        $this->login();
+
+        $this->client->request('GET', '/gallery?album=' . $album->getId()->toRfc4122());
+        $this->assertSelectorExists('[data-testid="gallery-add-to-current-album"][data-album-id="' . $album->getId()->toRfc4122() . '"]');
+    }
+
+    public function testGalleryWithUnknownAlbumParamIgnoresIt(): void
+    {
+        $user  = $this->createUser();
+        $media = $this->createMediaFile($user, 'photo.jpg', 'photo');
+        $this->login();
+
+        $this->client->request('GET', '/gallery?album=019f5700-0000-7000-8000-000000000000');
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorNotExists('input[type="checkbox"][name="mediaIds[]"][value="' . $media->getId()->toRfc4122() . '"]');
+    }
+
+    public function testGalleryWithAlbumParamNotOwnedByUserIsForbidden(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob   = $this->createUser('bob@example.com');
+        $album = new \App\Entity\Album('Album Alice', $alice);
+        $this->em->persist($album);
+        $this->em->flush();
+
+        $this->login('bob@example.com');
+        $this->client->request('GET', '/gallery?album=' . $album->getId()->toRfc4122());
+        $this->assertResponseStatusCodeSame(403);
     }
 }


### PR DESCRIPTION
## Résumé
- Sélectionner des photos existantes à la création d'un album (modale avec grille de vignettes à cocher).
- Ajouter des photos à un album existant depuis la galerie (`/gallery?album={id}`), avec mode sélection contextuel et barre d'action flottante.
- Retirer un média d'un album (bouton × discret sur chaque vignette, confirmation avant suppression, ne supprime que l'association — le média reste dans la galerie).
- Refactor : JS de la lightbox et du mode sélection extraits en vrais contrôleurs Stimulus (`gallery_lightbox_controller.js`, `gallery_selection_controller.js`) au lieu de `<script>` inline. Contrôleur générique `confirm_submit_controller.js` réutilisable pour toute action destructive.

## Test plan
- [x] TDD complet sur chaque étape (AlbumServiceTest, AlbumWebTest, MediaGalleryTest) — RED → GREEN
- [x] Suite complète PHPUnit verte (404/404)
- [x] Vérifié visuellement en local : création avec sélection, ajout depuis galerie, retrait avec confirmation