### PR TITLE
✨ feat(album): réordonner les photos par glisser-déposer

### DIFF
--- a/assets/controllers/album_reorder_controller.js
+++ b/assets/controllers/album_reorder_controller.js
@@ -1,0 +1,54 @@
+import { Controller } from '@hotwired/stimulus';
+
+/* Réordonnancement des photos d'un album par glisser-déposer (HTML5 natif,
+ * pas de dépendance externe). Soumet le nouvel ordre complet des mediaIds
+ * à l'URL de la valeur "url" après chaque dépôt. */
+export default class extends Controller {
+    static targets = ['item'];
+    static values = { url: String };
+
+    dragStart(event) {
+        this.dragged = event.currentTarget;
+        event.dataTransfer.effectAllowed = 'move';
+        this.dragged.classList.add('hc-media-thumb--dragging');
+    }
+
+    dragOver(event) {
+        event.preventDefault();
+        const target = event.currentTarget;
+        if (!this.dragged || target === this.dragged) return;
+
+        const items = this.itemTargets;
+        const draggedIndex = items.indexOf(this.dragged);
+        const targetIndex = items.indexOf(target);
+
+        if (draggedIndex < targetIndex) {
+            target.after(this.dragged);
+        } else {
+            target.before(this.dragged);
+        }
+    }
+
+    drop(event) {
+        event.preventDefault();
+    }
+
+    dragEnd() {
+        if (!this.dragged) return;
+        this.dragged.classList.remove('hc-media-thumb--dragging');
+        this.dragged = null;
+        this.submitNewOrder();
+    }
+
+    async submitNewOrder() {
+        const mediaIds = this.itemTargets.map((el) => el.dataset.mediaId);
+        const body = new URLSearchParams();
+        mediaIds.forEach((id) => body.append('mediaIds[]', id));
+
+        await fetch(this.urlValue, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: body.toString(),
+        });
+    }
+}

--- a/assets/styles/gallery.css
+++ b/assets/styles/gallery.css
@@ -63,6 +63,14 @@
   box-shadow: var(--hc-shadow-crisp);
 }
 
+.hc-media-thumb[draggable="true"] {
+  cursor: grab;
+}
+
+.hc-media-thumb--dragging {
+  opacity: 0.4;
+}
+
 .hc-media-thumb-link {
   display: block;
   width: 100%;

--- a/migrations/Version20260713082311.php
+++ b/migrations/Version20260713082311.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Transforme la table pivot album_media (clé composite album_id+media_id)
+ * en entité de jointure à part entière (id, position), pour supporter le
+ * réordonnancement manuel des médias dans un album.
+ *
+ * Backfill : les lignes existantes reçoivent un id généré et une position
+ * basée sur leur ordre d'insertion naturel (rowid), avant que les colonnes
+ * ne deviennent NOT NULL.
+ */
+final class Version20260713082311 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'album_media : ajoute id (uuid) et position pour le réordonnancement des médias dans un album';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE album_media ADD id BINARY(16) DEFAULT NULL, ADD position INT DEFAULT NULL');
+
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT album_id, media_id FROM album_media ORDER BY album_id, media_id'
+        );
+
+        $positionByAlbum = [];
+        foreach ($rows as $row) {
+            $albumId = $row['album_id'];
+            $positionByAlbum[$albumId] ??= 0;
+
+            $this->addSql(
+                'UPDATE album_media SET id = :id, position = :position WHERE album_id = :albumId AND media_id = :mediaId',
+                [
+                    'id'       => Uuid::v7()->toBinary(),
+                    'position' => $positionByAlbum[$albumId],
+                    'albumId'  => $albumId,
+                    'mediaId'  => $row['media_id'],
+                ],
+                [
+                    'id'       => \Doctrine\DBAL\ParameterType::BINARY,
+                    'position' => \Doctrine\DBAL\ParameterType::INTEGER,
+                    'albumId'  => \Doctrine\DBAL\ParameterType::BINARY,
+                    'mediaId'  => \Doctrine\DBAL\ParameterType::BINARY,
+                ]
+            );
+
+            $positionByAlbum[$albumId]++;
+        }
+
+        $this->addSql('ALTER TABLE album_media MODIFY id BINARY(16) NOT NULL, MODIFY position INT NOT NULL');
+        $this->addSql('ALTER TABLE album_media DROP PRIMARY KEY, ADD PRIMARY KEY (id)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_album_media ON album_media (album_id, media_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX uniq_album_media ON album_media');
+        $this->addSql('ALTER TABLE album_media DROP id, DROP position, DROP PRIMARY KEY, ADD PRIMARY KEY (album_id, media_id)');
+    }
+}

--- a/src/Controller/Web/AlbumWebController.php
+++ b/src/Controller/Web/AlbumWebController.php
@@ -93,6 +93,20 @@ final class AlbumWebController extends AbstractController
         return $this->redirectToRoute('app_album_detail', ['id' => $album->getId()->toRfc4122()]);
     }
 
+    #[Route('/albums/{id}/reorder', name: 'app_album_reorder', methods: ['POST'], requirements: ['id' => '[0-9a-f\-]+'])]
+    public function reorder(string $id, Request $request): Response
+    {
+        $album = $this->albumRepository->findById(Uuid::fromString($id))
+            ?? throw $this->createNotFoundException('Album introuvable.');
+
+        $this->denyAccessUnlessGranted(AlbumVoter::VIEW, $album);
+
+        $mediaIds = $request->request->all('mediaIds');
+        $this->albumService->reorder($album, $mediaIds);
+
+        return $this->redirectToRoute('app_album_detail', ['id' => $album->getId()->toRfc4122()]);
+    }
+
     #[Route('/albums/{id}', name: 'app_album_detail', requirements: ['id' => '[0-9a-f\-]+'])]
     public function detail(string $id): Response
     {

--- a/src/Entity/Album.php
+++ b/src/Entity/Album.php
@@ -7,19 +7,23 @@ namespace App\Entity;
 use App\Repository\AlbumRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Order;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
 
 /**
  * Entité représentant un album de médias.
  *
- * Rôle : regrouper des médias sous un nom sans imposer de structure de dossier.
+ * Rôle : regrouper des médias sous un nom sans imposer de structure de dossier,
+ * dans un ordre choisi par l'utilisateur (réordonnancement manuel).
  *
  * Choix :
- * - ManyToMany avec Media (table pivot album_media) : un média peut appartenir
- *   à plusieurs albums, un album contient plusieurs médias.
+ * - AlbumMedia (jointure explicite avec position) plutôt qu'une ManyToMany
+ *   brute : porter l'ordre d'affichage nécessite une colonne métier sur la
+ *   table pivot, donc une entité à part entière.
  * - Pas de suppression en cascade des médias : supprimer un album ne supprime
- *   pas les fichiers/médias, seulement les associations.
+ *   pas les fichiers/médias, seulement les associations (AlbumMedia).
  * - owner ManyToOne User : un album appartient à un seul utilisateur.
  */
 #[ORM\Entity(repositoryClass: AlbumRepository::class)]
@@ -37,10 +41,9 @@ class Album
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     private User $owner;
 
-    /** @var Collection<int, Media> */
-    #[ORM\ManyToMany(targetEntity: Media::class)]
-    #[ORM\JoinTable(name: 'album_media')]
-    private Collection $medias;
+    /** @var Collection<int, AlbumMedia> */
+    #[ORM\OneToMany(targetEntity: AlbumMedia::class, mappedBy: 'album', cascade: ['persist'], orphanRemoval: true)]
+    private Collection $albumMedias;
 
     #[ORM\Column]
     private \DateTimeImmutable $createdAt;
@@ -55,7 +58,7 @@ class Album
         $this->id = Uuid::v7();
         $this->name = $trimmed;
         $this->owner = $owner;
-        $this->medias = new ArrayCollection();
+        $this->albumMedias = new ArrayCollection();
         $this->createdAt = new \DateTimeImmutable();
     }
 
@@ -83,21 +86,78 @@ class Album
         return $this->owner;
     }
 
+    /**
+     * @return Collection<int, Media> Médias triés par position croissante.
+     */
     public function getMedias(): Collection
     {
-        return $this->medias;
+        $criteria = Criteria::create()->orderBy(['position' => Order::Ascending]);
+        $sorted   = $this->albumMedias->matching($criteria)->map(
+            fn (AlbumMedia $am) => $am->getMedia()
+        );
+
+        return new ArrayCollection(array_values($sorted->toArray()));
     }
 
     public function addMedia(Media $media): void
     {
-        if (!$this->medias->contains($media)) {
-            $this->medias->add($media);
+        if ($this->findAlbumMedia($media) !== null) {
+            return;
         }
+
+        $nextPosition = $this->albumMedias->count();
+        $this->albumMedias->add(new AlbumMedia($this, $media, $nextPosition));
     }
 
     public function removeMedia(Media $media): void
     {
-        $this->medias->removeElement($media);
+        $albumMedia = $this->findAlbumMedia($media);
+        if ($albumMedia !== null) {
+            $this->albumMedias->removeElement($albumMedia);
+        }
+    }
+
+    /**
+     * Réordonne les médias selon la liste d'IDs fournie (nouvel ordre complet).
+     * Les IDs inconnus ou ne correspondant à aucun média de l'album sont
+     * ignorés silencieusement ; les médias non mentionnés conservent leur
+     * position relative à la fin.
+     *
+     * @param Uuid[] $mediaIds
+     */
+    public function reorder(array $mediaIds): void
+    {
+        $byMediaId = [];
+        foreach ($this->albumMedias as $albumMedia) {
+            $byMediaId[$albumMedia->getMedia()->getId()->toRfc4122()] = $albumMedia;
+        }
+
+        $position = 0;
+        foreach ($mediaIds as $mediaId) {
+            $albumMedia = $byMediaId[$mediaId->toRfc4122()] ?? null;
+            if ($albumMedia === null) {
+                continue;
+            }
+            $albumMedia->setPosition($position);
+            unset($byMediaId[$mediaId->toRfc4122()]);
+            $position++;
+        }
+
+        foreach ($byMediaId as $remaining) {
+            $remaining->setPosition($position);
+            $position++;
+        }
+    }
+
+    private function findAlbumMedia(Media $media): ?AlbumMedia
+    {
+        foreach ($this->albumMedias as $albumMedia) {
+            if ($albumMedia->getMedia() === $media) {
+                return $albumMedia;
+            }
+        }
+
+        return null;
     }
 
     public function getCreatedAt(): \DateTimeImmutable

--- a/src/Entity/AlbumMedia.php
+++ b/src/Entity/AlbumMedia.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\AlbumMediaRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Entité de jointure explicite Album↔Media, portant l'ordre d'affichage.
+ *
+ * Remplace une simple relation ManyToMany : une table pivot "brute" ne peut
+ * pas porter de colonne métier (position) sans devenir elle-même une entité.
+ *
+ * Choix :
+ * - position : entier croissant, unique par album, réattribué en bloc à
+ *   chaque réordonnancement (pas de gestion de trous/fractions).
+ * - Pas de cascade remove : supprimer un Album supprime ses AlbumMedia
+ *   (onDelete CASCADE au niveau DB), mais jamais les Media eux-mêmes.
+ */
+#[ORM\Entity(repositoryClass: AlbumMediaRepository::class)]
+#[ORM\Table(name: 'album_media')]
+#[ORM\UniqueConstraint(name: 'uniq_album_media', columns: ['album_id', 'media_id'])]
+class AlbumMedia
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    private Uuid $id;
+
+    #[ORM\ManyToOne(targetEntity: Album::class, inversedBy: 'albumMedias')]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private Album $album;
+
+    #[ORM\ManyToOne(targetEntity: Media::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private Media $media;
+
+    #[ORM\Column]
+    private int $position;
+
+    public function __construct(Album $album, Media $media, int $position)
+    {
+        $this->id = Uuid::v7();
+        $this->album = $album;
+        $this->media = $media;
+        $this->position = $position;
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getAlbum(): Album
+    {
+        return $this->album;
+    }
+
+    public function getMedia(): Media
+    {
+        return $this->media;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): void
+    {
+        $this->position = $position;
+    }
+}

--- a/src/Repository/AlbumMediaRepository.php
+++ b/src/Repository/AlbumMediaRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\AlbumMedia;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<AlbumMedia>
+ */
+class AlbumMediaRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, AlbumMedia::class);
+    }
+}

--- a/src/Service/AlbumService.php
+++ b/src/Service/AlbumService.php
@@ -70,6 +70,27 @@ final class AlbumService
     }
 
     /**
+     * Applique un nouvel ordre d'affichage aux médias de l'album.
+     * Les identifiants invalides ou hors de l'album sont ignorés silencieusement.
+     *
+     * @param string[] $mediaIds Nouvel ordre complet, du premier au dernier.
+     */
+    public function reorder(Album $album, array $mediaIds): void
+    {
+        $uuids = [];
+        foreach ($mediaIds as $mediaId) {
+            try {
+                $uuids[] = Uuid::fromString($mediaId);
+            } catch (\InvalidArgumentException) {
+                continue;
+            }
+        }
+
+        $album->reorder($uuids);
+        $this->repository->save($album);
+    }
+
+    /**
      * Supprime un album (et ses associations album_media — pas les médias eux-mêmes).
      */
     public function delete(Album $album): void

--- a/templates/web/album_detail.html.twig
+++ b/templates/web/album_detail.html.twig
@@ -48,9 +48,15 @@
       icon="<svg width='64' height='64' fill='none' stroke='currentColor' stroke-width='1.5' viewBox='0 0 24 24' class='hc-icon hc-icon-images'><path d='M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5z'/><circle cx='8.5' cy='8.5' r='1.5'/><polyline points='21 15 16 10 5 21'/></svg>"
     />
   {% else %}
-    <div class="hc-media-grid">
+    <p class="hc-page-sub" data-testid="album-reorder-hint">Glissez-déposez une photo pour changer son ordre.</p>
+
+    <div class="hc-media-grid" data-controller="album-reorder"
+         data-album-reorder-url-value="{{ path('app_album_reorder', {id: album.id}) }}">
       {% for media in album.medias %}
-        <div class="hc-media-thumb">
+        <div class="hc-media-thumb" draggable="true"
+             data-album-reorder-target="item"
+             data-media-id="{{ media.id }}"
+             data-action="dragstart->album-reorder#dragStart dragover->album-reorder#dragOver drop->album-reorder#drop dragend->album-reorder#dragEnd">
           <form method="post" action="{{ path('app_album_remove_media', {id: album.id, mediaId: media.id}) }}"
                 class="hc-media-thumb-remove-form" data-controller="confirm-submit"
                 data-confirm-submit-message-value="Retirer « {{ media.file.originalName }} » de l'album ?">

--- a/tests/Entity/AlbumOrderingTest.php
+++ b/tests/Entity/AlbumOrderingTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Media;
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires — ordre des médias dans un album (position persistée
+ * via AlbumMedia). TDD RED → GREEN.
+ */
+final class AlbumOrderingTest extends TestCase
+{
+    private function makeMedia(User $owner, string $name): Media
+    {
+        $folder = new Folder('Photos', $owner);
+        $file   = new File($name, 'image/jpeg', 1024, '2026/' . $name, $folder, $owner);
+
+        return new Media($file, 'photo');
+    }
+
+    public function testAddMediaAssignsIncrementingPosition(): void
+    {
+        $owner = new User('test@example.com', 'Test');
+        $album = new Album('Vacances', $owner);
+        $m1 = $this->makeMedia($owner, 'a.jpg');
+        $m2 = $this->makeMedia($owner, 'b.jpg');
+
+        $album->addMedia($m1);
+        $album->addMedia($m2);
+
+        $medias = $album->getMedias()->toArray();
+        $this->assertSame([$m1, $m2], $medias);
+    }
+
+    public function testAddMediaIsIdempotent(): void
+    {
+        $owner = new User('test@example.com', 'Test');
+        $album = new Album('Vacances', $owner);
+        $media = $this->makeMedia($owner, 'a.jpg');
+
+        $album->addMedia($media);
+        $album->addMedia($media);
+
+        $this->assertCount(1, $album->getMedias());
+    }
+
+    public function testRemoveMediaRemovesFromCollection(): void
+    {
+        $owner = new User('test@example.com', 'Test');
+        $album = new Album('Vacances', $owner);
+        $m1 = $this->makeMedia($owner, 'a.jpg');
+        $m2 = $this->makeMedia($owner, 'b.jpg');
+        $album->addMedia($m1);
+        $album->addMedia($m2);
+
+        $album->removeMedia($m1);
+
+        $this->assertCount(1, $album->getMedias());
+        $this->assertFalse($album->getMedias()->contains($m1));
+        $this->assertTrue($album->getMedias()->contains($m2));
+    }
+
+    public function testReorderChangesMediaOrder(): void
+    {
+        $owner = new User('test@example.com', 'Test');
+        $album = new Album('Vacances', $owner);
+        $m1 = $this->makeMedia($owner, 'a.jpg');
+        $m2 = $this->makeMedia($owner, 'b.jpg');
+        $m3 = $this->makeMedia($owner, 'c.jpg');
+        $album->addMedia($m1);
+        $album->addMedia($m2);
+        $album->addMedia($m3);
+
+        $album->reorder([$m3->getId(), $m1->getId(), $m2->getId()]);
+
+        $medias = $album->getMedias()->toArray();
+        $this->assertSame([$m3, $m1, $m2], $medias);
+    }
+
+    public function testReorderIgnoresUnknownMediaIds(): void
+    {
+        $owner = new User('test@example.com', 'Test');
+        $album = new Album('Vacances', $owner);
+        $m1 = $this->makeMedia($owner, 'a.jpg');
+        $m2 = $this->makeMedia($owner, 'b.jpg');
+        $album->addMedia($m1);
+        $album->addMedia($m2);
+
+        $unknownId = \Symfony\Component\Uid\Uuid::v7();
+        $album->reorder([$m2->getId(), $unknownId, $m1->getId()]);
+
+        $medias = $album->getMedias()->toArray();
+        $this->assertSame([$m2, $m1], $medias);
+    }
+}

--- a/tests/Web/AlbumWebTest.php
+++ b/tests/Web/AlbumWebTest.php
@@ -307,6 +307,66 @@ final class AlbumWebTest extends WebTestCase
         $this->assertStringContainsString('photo.jpg', $this->client->getResponse()->getContent());
     }
 
+    // --- Réordonnancement des médias d'un album ---
+
+    public function testReorderAlbumMediaRedirectsToAlbumDetail(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $m1 = $this->createMedia($user, 'a.jpg');
+        $m2 = $this->createMedia($user, 'b.jpg');
+        $album->addMedia($m1);
+        $album->addMedia($m2);
+        $this->em->flush();
+        $this->login();
+
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/reorder', [
+            'mediaIds' => [$m2->getId()->toRfc4122(), $m1->getId()->toRfc4122()],
+        ]);
+
+        $this->assertResponseRedirects('/albums/' . $album->getId()->toRfc4122());
+    }
+
+    public function testReorderAlbumMediaPersistsNewOrder(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $m1 = $this->createMedia($user, 'a.jpg');
+        $m2 = $this->createMedia($user, 'b.jpg');
+        $album->addMedia($m1);
+        $album->addMedia($m2);
+        $this->em->flush();
+        $albumId = $album->getId()->toRfc4122();
+        $this->login();
+
+        $this->client->request('POST', '/albums/' . $albumId . '/reorder', [
+            'mediaIds' => [$m2->getId()->toRfc4122(), $m1->getId()->toRfc4122()],
+        ]);
+
+        $this->em->clear();
+        $reloaded = $this->em->getRepository(Album::class)->find($album->getId());
+        $medias = $reloaded->getMedias()->toArray();
+        $this->assertSame($m2->getId()->toRfc4122(), $medias[0]->getId()->toRfc4122());
+        $this->assertSame($m1->getId()->toRfc4122(), $medias[1]->getId()->toRfc4122());
+    }
+
+    public function testReorderAlbumMediaForbiddenForOtherUser(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob   = $this->createUser('bob@example.com');
+        $album = $this->createAlbum($alice, 'Album Alice');
+        $media = $this->createMedia($alice, 'photo.jpg');
+        $album->addMedia($media);
+        $this->em->flush();
+
+        $this->login('bob@example.com');
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/reorder', [
+            'mediaIds' => [$media->getId()->toRfc4122()],
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
     // --- Suppression ---
 
     public function testDeleteAlbumRedirectsToList(): void


### PR DESCRIPTION
## Résumé
- Nouvelle entité `AlbumMedia` (jointure explicite Album↔Media avec `position`), remplaçant la `ManyToMany` brute qui ne pouvait pas porter d'ordre. API publique de `Album` (`getMedias()`, `addMedia()`, `removeMedia()`) inchangée — aucun des 9 fichiers appelants n'est impacté.
- Migration Doctrine avec backfill sûr (id + position générés pour les lignes existantes avant `NOT NULL`).
- `POST /albums/{id}/reorder` (owner-only) + `AlbumService::reorder()`.
- Drag & drop natif HTML5 (`album_reorder_controller.js`, aucune dépendance externe) sur `album_detail.html.twig` : glisser une vignette réordonne immédiatement le DOM puis sauvegarde en arrière-plan.

## Test plan
- [x] TDD complet : `AlbumOrderingTest` (entité) + `AlbumWebTest` (route web) — RED → GREEN
- [x] Suite complète PHPUnit verte (412/412)
- [x] Migration appliquée et vérifiée en dev et test (`doctrine:schema:validate` OK)
- [x] Vérifié visuellement en local