### PR TITLE
✨ feat(gallery): diaporama avec auto-avance dans la lightbox

### DIFF
--- a/assets/controllers/Slideshow.js
+++ b/assets/controllers/Slideshow.js
@@ -1,0 +1,34 @@
+const DEFAULT_INTERVAL_MS = 4000;
+
+/**
+ * Minuteur d'auto-avance pour un diaporama. Ne connaît rien du DOM ni de
+ * Stimulus : reçoit juste une fonction "advance" à appeler à intervalle
+ * régulier. Séparé du contrôleur pour rester testable isolément et éviter
+ * un contrôleur monolithique.
+ */
+export default class Slideshow {
+    constructor(onAdvance, intervalMs = DEFAULT_INTERVAL_MS) {
+        this.onAdvance = onAdvance;
+        this.intervalMs = intervalMs;
+        this.timer = null;
+    }
+
+    get isPlaying() {
+        return this.timer !== null;
+    }
+
+    start() {
+        if (this.isPlaying) return;
+        this.timer = setInterval(this.onAdvance, this.intervalMs);
+    }
+
+    stop() {
+        if (!this.isPlaying) return;
+        clearInterval(this.timer);
+        this.timer = null;
+    }
+
+    toggle() {
+        this.isPlaying ? this.stop() : this.start();
+    }
+}

--- a/assets/controllers/gallery_lightbox_controller.js
+++ b/assets/controllers/gallery_lightbox_controller.js
@@ -1,14 +1,17 @@
 import { Controller } from '@hotwired/stimulus';
+import Slideshow from './Slideshow.js';
 
 /* Lightbox de la galerie médias : ouvre le média en plein écran au clic
- * sur une vignette, navigation précédent/suivant au clavier et via boutons. */
+ * sur une vignette, navigation précédent/suivant au clavier et via boutons.
+ * Le diaporama (auto-avance, pause/lecture) est délégué à Slideshow. */
 export default class extends Controller {
-    static targets = ['img', 'prev', 'next'];
+    static targets = ['img', 'prev', 'next', 'play'];
 
     connect() {
         this.links = Array.from(document.querySelectorAll('[data-lightbox]'));
         this.srcs = this.links.map((el) => el.getAttribute('data-full-src'));
         this.current = -1;
+        this.slideshow = new Slideshow(() => this.next());
 
         this.links.forEach((el, index) => {
             el.addEventListener('click', (e) => {
@@ -24,6 +27,7 @@ export default class extends Controller {
 
     disconnect() {
         document.removeEventListener('keydown', this.boundKeydown);
+        this.slideshow.stop();
     }
 
     show(index) {
@@ -40,11 +44,24 @@ export default class extends Controller {
     }
 
     next() {
-        this.show(this.current + 1);
+        this.show(this.current === this.srcs.length - 1 ? 0 : this.current + 1);
     }
 
     close() {
         this.element.style.display = 'none';
+        this.slideshow.stop();
+        this.updatePlayTarget();
+    }
+
+    togglePlay() {
+        this.slideshow.toggle();
+        this.updatePlayTarget();
+    }
+
+    updatePlayTarget() {
+        if (this.hasPlayTarget) {
+            this.playTarget.setAttribute('aria-pressed', String(this.slideshow.isPlaying));
+        }
     }
 
     onKeydown(e) {
@@ -52,5 +69,9 @@ export default class extends Controller {
         if (e.key === 'ArrowLeft') this.prev();
         if (e.key === 'ArrowRight') this.next();
         if (e.key === 'Escape') this.close();
+        if (e.key === ' ') {
+            e.preventDefault();
+            this.togglePlay();
+        }
     }
 }

--- a/assets/styles/gallery.css
+++ b/assets/styles/gallery.css
@@ -258,6 +258,36 @@
   background: rgba(255, 255, 255, 0.2);
 }
 
+.hc-lightbox-play {
+  position: absolute;
+  top: 1.5rem;
+  right: 5.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  transition: background .15s ease;
+}
+.hc-lightbox-play:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.hc-lightbox-play-icon--pause {
+  display: none;
+}
+.hc-lightbox-play[aria-pressed="true"] .hc-lightbox-play-icon--play {
+  display: none;
+}
+.hc-lightbox-play[aria-pressed="true"] .hc-lightbox-play-icon--pause {
+  display: block;
+}
+
 .hc-lightbox-nav {
   position: absolute;
   top: 50%;

--- a/assets/tests/gallery-lightbox-slideshow.test.js
+++ b/assets/tests/gallery-lightbox-slideshow.test.js
@@ -1,0 +1,98 @@
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { Application } from '../vendor/@hotwired/stimulus/stimulus.index.js';
+import GalleryLightboxController from '../controllers/gallery_lightbox_controller.js';
+
+/**
+ * Diaporama de la lightbox galerie : auto-avance à intervalle fixe,
+ * pause/lecture, arrêt à la fermeture.
+ */
+describe('gallery-lightbox slideshow', () => {
+  let application;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+
+    document.body.innerHTML = `
+      <a data-lightbox data-full-src="/a.jpg"></a>
+      <a data-lightbox data-full-src="/b.jpg"></a>
+      <a data-lightbox data-full-src="/c.jpg"></a>
+      <div id="lightbox" data-controller="gallery-lightbox">
+        <button data-gallery-lightbox-target="prev" data-action="gallery-lightbox#prev"></button>
+        <img data-gallery-lightbox-target="img">
+        <button data-gallery-lightbox-target="next" data-action="gallery-lightbox#next"></button>
+        <button data-gallery-lightbox-target="play" data-action="gallery-lightbox#togglePlay"></button>
+      </div>
+    `;
+
+    application = Application.start();
+    application.register('gallery-lightbox', GalleryLightboxController);
+  });
+
+  afterEach(() => {
+    application.stop();
+    jest.useRealTimers();
+  });
+
+  function getController() {
+    const el = document.getElementById('lightbox');
+    return application.getControllerForElementAndIdentifier(el, 'gallery-lightbox');
+  }
+
+  test('togglePlay advances to the next slide every 4 seconds', () => {
+    const controller = getController();
+    controller.show(0);
+
+    controller.togglePlay();
+    expect(controller.imgTarget.src).toContain('a.jpg');
+
+    jest.advanceTimersByTime(4000);
+    expect(controller.imgTarget.src).toContain('b.jpg');
+
+    jest.advanceTimersByTime(4000);
+    expect(controller.imgTarget.src).toContain('c.jpg');
+  });
+
+  test('togglePlay again pauses the slideshow', () => {
+    const controller = getController();
+    controller.show(0);
+    controller.togglePlay();
+
+    jest.advanceTimersByTime(4000);
+    expect(controller.imgTarget.src).toContain('b.jpg');
+
+    controller.togglePlay();
+    jest.advanceTimersByTime(8000);
+    expect(controller.imgTarget.src).toContain('b.jpg');
+  });
+
+  test('slideshow loops back to the first slide after the last', () => {
+    const controller = getController();
+    controller.show(2);
+    controller.togglePlay();
+
+    jest.advanceTimersByTime(4000);
+    expect(controller.imgTarget.src).toContain('a.jpg');
+  });
+
+  test('closing the lightbox stops the slideshow', () => {
+    const controller = getController();
+    controller.show(0);
+    controller.togglePlay();
+
+    controller.close();
+    jest.advanceTimersByTime(8000);
+    expect(controller.element.style.display).toBe('none');
+  });
+
+  test('manual navigation while playing does not desync the timer', () => {
+    const controller = getController();
+    controller.show(0);
+    controller.togglePlay();
+
+    controller.next();
+    expect(controller.imgTarget.src).toContain('b.jpg');
+
+    jest.advanceTimersByTime(4000);
+    expect(controller.imgTarget.src).toContain('c.jpg');
+  });
+});

--- a/assets/tests/gallery-lightbox-slideshow.test.js
+++ b/assets/tests/gallery-lightbox-slideshow.test.js
@@ -1,5 +1,5 @@
 import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
-import { Application } from '../vendor/@hotwired/stimulus/stimulus.index.js';
+import { Application } from '@hotwired/stimulus';
 import GalleryLightboxController from '../controllers/gallery_lightbox_controller.js';
 
 /**

--- a/assets/tests/slideshow.test.js
+++ b/assets/tests/slideshow.test.js
@@ -1,0 +1,62 @@
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import Slideshow from '../controllers/Slideshow.js';
+
+describe('Slideshow', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('is not playing initially', () => {
+    const slideshow = new Slideshow(() => {});
+    expect(slideshow.isPlaying).toBe(false);
+  });
+
+  test('start() calls onAdvance every intervalMs', () => {
+    const onAdvance = jest.fn();
+    const slideshow = new Slideshow(onAdvance, 1000);
+
+    slideshow.start();
+    jest.advanceTimersByTime(3000);
+
+    expect(onAdvance).toHaveBeenCalledTimes(3);
+    expect(slideshow.isPlaying).toBe(true);
+  });
+
+  test('stop() halts further calls', () => {
+    const onAdvance = jest.fn();
+    const slideshow = new Slideshow(onAdvance, 1000);
+
+    slideshow.start();
+    jest.advanceTimersByTime(1000);
+    slideshow.stop();
+    jest.advanceTimersByTime(3000);
+
+    expect(onAdvance).toHaveBeenCalledTimes(1);
+    expect(slideshow.isPlaying).toBe(false);
+  });
+
+  test('toggle() switches between playing and stopped', () => {
+    const slideshow = new Slideshow(() => {}, 1000);
+
+    slideshow.toggle();
+    expect(slideshow.isPlaying).toBe(true);
+
+    slideshow.toggle();
+    expect(slideshow.isPlaying).toBe(false);
+  });
+
+  test('start() is idempotent while already playing', () => {
+    const onAdvance = jest.fn();
+    const slideshow = new Slideshow(onAdvance, 1000);
+
+    slideshow.start();
+    slideshow.start();
+    jest.advanceTimersByTime(1000);
+
+    expect(onAdvance).toHaveBeenCalledTimes(1);
+  });
+});

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -2,7 +2,4 @@ module.exports = {
   testEnvironment: './jest.environment.cjs',
   testTimeout: 10000,
   transform: {},
-  moduleNameMapper: {
-    '^@hotwired/stimulus$': '<rootDir>/assets/vendor/@hotwired/stimulus/stimulus.index.js',
-  },
 };

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -2,4 +2,7 @@ module.exports = {
   testEnvironment: './jest.environment.cjs',
   testTimeout: 10000,
   transform: {},
+  moduleNameMapper: {
+    '^@hotwired/stimulus$': '<rootDir>/assets/vendor/@hotwired/stimulus/stimulus.index.js',
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "homecloud-frontend-tests",
       "version": "0.1.0",
       "devDependencies": {
+        "@hotwired/stimulus": "^3.2.2",
         "jest": "^29.6.0",
         "jest-environment-jsdom": "^29.7.0",
         "jsdom": "^21.1.0"
@@ -507,6 +508,13 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@hotwired/stimulus": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.2.tgz",
+      "integrity": "sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "node --experimental-vm-modules node_modules/.bin/jest --config jest.config.cjs"
   },
   "devDependencies": {
+    "@hotwired/stimulus": "^3.2.2",
     "jest": "^29.6.0",
     "jest-environment-jsdom": "^29.7.0",
     "jsdom": "^21.1.0"

--- a/templates/components/GalleryLightbox.html.twig
+++ b/templates/components/GalleryLightbox.html.twig
@@ -1,0 +1,19 @@
+{# Lightbox réutilisable : ouverture plein écran des médias marqués [data-lightbox],
+   navigation précédent/suivant et diaporama (auto-avance, pause/lecture). #}
+<div id="lightbox" class="hc-lightbox" data-controller="gallery-lightbox">
+  <button data-gallery-lightbox-target="prev" data-action="gallery-lightbox#prev" class="hc-lightbox-nav hc-lightbox-nav--prev" aria-label="Média précédent">
+    <svg width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="15 6 9 12 15 18"/></svg>
+  </button>
+  <img data-gallery-lightbox-target="img" src="" alt="" class="hc-lightbox-img">
+  <button data-gallery-lightbox-target="next" data-action="gallery-lightbox#next" class="hc-lightbox-nav hc-lightbox-nav--next" aria-label="Média suivant">
+    <svg width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="9 6 15 12 9 18"/></svg>
+  </button>
+  <button data-gallery-lightbox-target="play" data-action="gallery-lightbox#togglePlay"
+          data-testid="lightbox-slideshow-toggle" class="hc-lightbox-play" aria-label="Lancer le diaporama" aria-pressed="false">
+    <svg width="18" height="18" fill="currentColor" viewBox="0 0 24 24" class="hc-lightbox-play-icon hc-lightbox-play-icon--play"><polygon points="6 4 20 12 6 20 6 4"/></svg>
+    <svg width="18" height="18" fill="currentColor" viewBox="0 0 24 24" class="hc-lightbox-play-icon hc-lightbox-play-icon--pause"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
+  </button>
+  <button data-action="gallery-lightbox#close" class="hc-lightbox-close" aria-label="Fermer">
+    <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M18 6L6 18M6 6l12 12"/></svg>
+  </button>
+</div>

--- a/templates/web/album_detail.html.twig
+++ b/templates/web/album_detail.html.twig
@@ -63,26 +63,33 @@
             <button type="submit" class="hc-media-thumb-remove" data-testid="remove-media-from-album"
                     title="Retirer de l'album" aria-label="Retirer de l'album">×</button>
           </form>
-          {% if media.thumbnailPath %}
-            <img src="{{ path('app_media_thumbnail', {id: media.id}) }}"
-                 alt="{{ media.file.originalName }}"
-                 loading="lazy"
-                 class="hc-media-thumb-img">
-          {% else %}
-            <div class="hc-media-thumb-fallback">
-              {% if media.mediaType == 'video' %}
-                <svg width="28" height="28" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-video"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
-              {% else %}
-                <svg width="28" height="28" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-images"><path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5z"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
-              {% endif %}
-            </div>
-          {% endif %}
+          <a href="{{ path('app_media_view', {id: media.id}) }}"
+             data-lightbox
+             data-full-src="{{ path('app_media_full', {id: media.id}) }}"
+             class="hc-media-thumb-link">
+            {% if media.thumbnailPath %}
+              <img src="{{ path('app_media_thumbnail', {id: media.id}) }}"
+                   alt="{{ media.file.originalName }}"
+                   loading="lazy"
+                   class="hc-media-thumb-img">
+            {% else %}
+              <div class="hc-media-thumb-fallback">
+                {% if media.mediaType == 'video' %}
+                  <svg width="28" height="28" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-video"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
+                {% else %}
+                  <svg width="28" height="28" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-images"><path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5z"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+                {% endif %}
+              </div>
+            {% endif %}
+          </a>
           <div class="hc-media-thumb-caption">
             {{ media.file.originalName }}
           </div>
         </div>
       {% endfor %}
     </div>
+
+    <twig:GalleryLightbox />
   {% endif %}
 
 </div>

--- a/templates/web/gallery.html.twig
+++ b/templates/web/gallery.html.twig
@@ -116,19 +116,7 @@
       {% endif %}
     </div>
 
-    {# Lightbox simple #}
-    <div id="lightbox" class="hc-lightbox" data-controller="gallery-lightbox">
-      <button data-gallery-lightbox-target="prev" data-action="gallery-lightbox#prev" class="hc-lightbox-nav hc-lightbox-nav--prev" aria-label="Média précédent">
-        <svg width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="15 6 9 12 15 18"/></svg>
-      </button>
-      <img data-gallery-lightbox-target="img" src="" alt="" class="hc-lightbox-img">
-      <button data-gallery-lightbox-target="next" data-action="gallery-lightbox#next" class="hc-lightbox-nav hc-lightbox-nav--next" aria-label="Média suivant">
-        <svg width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="9 6 15 12 9 18"/></svg>
-      </button>
-      <button data-action="gallery-lightbox#close" class="hc-lightbox-close" aria-label="Fermer">
-        <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M18 6L6 18M6 6l12 12"/></svg>
-      </button>
-    </div>
+    <twig:GalleryLightbox />
   {% endif %}
 
 </div>

--- a/tests/Web/AlbumWebTest.php
+++ b/tests/Web/AlbumWebTest.php
@@ -453,4 +453,33 @@ final class AlbumWebTest extends WebTestCase
             );
         }
     }
+
+    // --- Diaporama ---
+
+    public function testAlbumDetailThumbnailsAreLightboxLinks(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $media = $this->createMedia($user, 'photo.jpg');
+        $album->addMedia($media);
+        $this->em->flush();
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/albums/' . $album->getId()->toRfc4122());
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-lightbox][data-full-src]');
+    }
+
+    public function testAlbumDetailHasSlideshowToggle(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $media = $this->createMedia($user, 'photo.jpg');
+        $album->addMedia($media);
+        $this->em->flush();
+        $this->login();
+
+        $this->client->request('GET', '/albums/' . $album->getId()->toRfc4122());
+        $this->assertSelectorExists('[data-testid="lightbox-slideshow-toggle"]');
+    }
 }


### PR DESCRIPTION
## Résumé
- `Slideshow.js` : minuteur d'auto-avance isolé (SRP), injecté par composition dans `gallery_lightbox_controller.js` plutôt que fusionné dedans.
- Bouton play/pause dans la lightbox (clic ou barre d'espace), auto-avance en boucle toutes les 4s, arrêt à la fermeture.
- Lightbox factorisée en composant Twig réutilisable (`GalleryLightbox.html.twig`), maintenant utilisée à la fois dans `/gallery` et `/albums/{id}` (qui n'avait aucune lightbox auparavant).

## Test plan
- [x] TDD complet : `slideshow.test.js` + `gallery-lightbox-slideshow.test.js` (Jest, contrôleur Stimulus monté réellement) + `AlbumWebTest` — RED → GREEN
- [x] Suite complète verte : PHPUnit 414/414, Jest 53/53
- [x] Vérifié visuellement en local