### PR TITLE
✨ feat(album): importer des photos depuis le disque + fix chemin absolu thumbnail

### DIFF
--- a/assets/controllers/album_import_controller.js
+++ b/assets/controllers/album_import_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from '@hotwired/stimulus';
+
+/* Import de photos depuis le disque directement dans un album : ouvre le
+ * sélecteur de fichiers natif, soumet automatiquement le formulaire dès
+ * qu'une sélection est faite. */
+export default class extends Controller {
+    static targets = ['input'];
+
+    pick() {
+        this.inputTarget.click();
+    }
+
+    submit() {
+        if (this.inputTarget.files.length === 0) return;
+        this.element.requestSubmit();
+    }
+}

--- a/assets/controllers/album_reorder_controller.js
+++ b/assets/controllers/album_reorder_controller.js
@@ -13,6 +13,14 @@ export default class extends Controller {
         this.dragged.classList.add('hc-media-thumb--dragging');
     }
 
+    // Empêche le bouton de suppression (draggable="true" pour bloquer le
+    // drag natif du navigateur sur un <button>) de démarrer un vrai
+    // réordonnancement — seul un clic doit déclencher sa propre action.
+    preventDrag(event) {
+        event.preventDefault();
+        event.stopPropagation();
+    }
+
     dragOver(event) {
         event.preventDefault();
         const target = event.currentTarget;

--- a/src/Controller/Web/AlbumWebController.php
+++ b/src/Controller/Web/AlbumWebController.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace App\Controller\Web;
 
 use App\Entity\User;
+use App\Interface\AlbumImportServiceInterface;
 use App\Interface\AlbumRepositoryInterface;
+use App\Interface\AlbumServiceInterface;
 use App\Interface\MediaRepositoryInterface;
 use App\Security\AlbumVoter;
-use App\Service\AlbumService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,8 +27,9 @@ final class AlbumWebController extends AbstractController
 {
     public function __construct(
         private readonly AlbumRepositoryInterface $albumRepository,
-        private readonly AlbumService $albumService,
+        private readonly AlbumServiceInterface $albumService,
         private readonly MediaRepositoryInterface $mediaRepository,
+        private readonly AlbumImportServiceInterface $albumImportService,
     ) {}
 
     #[Route('/albums', name: 'app_albums')]
@@ -103,6 +105,23 @@ final class AlbumWebController extends AbstractController
 
         $mediaIds = $request->request->all('mediaIds');
         $this->albumService->reorder($album, $mediaIds);
+
+        return $this->redirectToRoute('app_album_detail', ['id' => $album->getId()->toRfc4122()]);
+    }
+
+    #[Route('/albums/{id}/import', name: 'app_album_import', methods: ['POST'], requirements: ['id' => '[0-9a-f\-]+'])]
+    public function import(string $id, Request $request): Response
+    {
+        $album = $this->albumRepository->findById(Uuid::fromString($id))
+            ?? throw $this->createNotFoundException('Album introuvable.');
+
+        $this->denyAccessUnlessGranted(AlbumVoter::VIEW, $album);
+
+        /** @var User $user */
+        $user  = $this->getUser();
+        $files = $request->files->all('files');
+
+        $this->albumImportService->import($album, $files, $user);
 
         return $this->redirectToRoute('app_album_detail', ['id' => $album->getId()->toRfc4122()]);
     }

--- a/src/Handler/MediaProcessHandler.php
+++ b/src/Handler/MediaProcessHandler.php
@@ -4,41 +4,26 @@ declare(strict_types=1);
 
 namespace App\Handler;
 
-use App\Entity\Media;
+use App\Interface\MediaProcessorInterface;
 use App\Message\MediaProcessMessage;
 use App\Repository\FileRepository;
-use App\Repository\MediaRepository;
-use App\Service\ExifService;
-use App\Service\ThumbnailService;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
  * Handler Messenger qui traite le message MediaProcessMessage.
  *
- * Rôle : créer l'entité Media en extrayant les EXIF et en générant le thumbnail
- * de manière asynchrone, après que le File a été uploadé.
- *
- * Choix :
- * - Asynchrone (transport doctrine) : ne bloque pas la réponse HTTP de l'upload.
- * - Idempotent : si un Media existe déjà pour ce File, le handler s'arrête sans erreur.
- * - Dégradation gracieuse : EXIF manquant ou GD absent → Media créé sans ces données.
- * - Types supportés : image/* → "photo", video/* → "video", sinon ignoré.
+ * Rôle : point d'entrée asynchrone (transport doctrine) du traitement média —
+ * ne bloque pas la réponse HTTP de l'upload. La logique métier (EXIF,
+ * thumbnail, idempotence) est déléguée à MediaProcessor, réutilisé aussi en
+ * synchrone par les flux qui ont besoin du Media immédiatement (ex: import
+ * direct dans un album).
  */
 #[AsMessageHandler]
 final class MediaProcessHandler
 {
-    private const MEDIA_MIME_TYPES = [
-        'image/' => 'photo',
-        'video/' => 'video',
-    ];
-
     public function __construct(
         private readonly FileRepository $fileRepository,
-        private readonly MediaRepository $mediaRepository,
-        private readonly EntityManagerInterface $em,
-        private readonly ExifService $exifService,
-        private readonly ThumbnailService $thumbnailService,
+        private readonly MediaProcessorInterface $mediaProcessor,
     ) {}
 
     public function __invoke(MediaProcessMessage $message): void
@@ -48,43 +33,6 @@ final class MediaProcessHandler
             return;
         }
 
-        $mediaType = $this->resolveMediaType($file->getMimeType());
-        if ($mediaType === null) {
-            return;
-        }
-
-        // Idempotence : Media déjà créé pour ce File
-        if ($this->mediaRepository->findOneBy(['file' => $file]) !== null) {
-            return;
-        }
-
-        $media = new Media($file, $mediaType);
-
-        if ($mediaType === 'photo') {
-            $exif = $this->exifService->extract($file->getPath());
-            $media->setWidth($exif['width']);
-            $media->setHeight($exif['height']);
-            $media->setTakenAt($exif['takenAt']);
-            $media->setCameraModel($exif['cameraModel']);
-            $media->setGpsLat($exif['gpsLat']);
-            $media->setGpsLon($exif['gpsLon']);
-
-            $thumb = $this->thumbnailService->generate($file->getPath());
-            $media->setThumbnailPath($thumb);
-        }
-
-        $this->em->persist($media);
-        $this->em->flush();
-    }
-
-    private function resolveMediaType(string $mimeType): ?string
-    {
-        foreach (self::MEDIA_MIME_TYPES as $prefix => $type) {
-            if (str_starts_with($mimeType, $prefix)) {
-                return $type;
-            }
-        }
-
-        return null;
+        $this->mediaProcessor->process($file);
     }
 }

--- a/src/Interface/AlbumImportServiceInterface.php
+++ b/src/Interface/AlbumImportServiceInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\Album;
+use App\Entity\User;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+interface AlbumImportServiceInterface
+{
+    /**
+     * Upload une sélection de fichiers depuis le disque et les ajoute
+     * immédiatement à l'album (traitement média synchrone, contrairement
+     * au flux d'upload normal qui traite en asynchrone).
+     *
+     * Les fichiers dont le type MIME n'est pas une image/vidéo sont uploadés
+     * mais ignorés silencieusement pour l'ajout à l'album (pas de Media
+     * possible pour eux).
+     *
+     * @param UploadedFile[] $files
+     */
+    public function import(Album $album, array $files, User $owner): void;
+}

--- a/src/Interface/AlbumServiceInterface.php
+++ b/src/Interface/AlbumServiceInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\Album;
+use App\Entity\Media;
+use App\Entity\User;
+
+interface AlbumServiceInterface
+{
+    /**
+     * @param string[] $mediaIds
+     * @throws \InvalidArgumentException si le nom est vide ou uniquement des espaces
+     */
+    public function create(string $name, User $owner, array $mediaIds = []): Album;
+
+    /**
+     * @param string[] $mediaIds
+     */
+    public function addMedias(Album $album, array $mediaIds, User $owner): void;
+
+    public function removeMedia(Album $album, Media $media): void;
+
+    /**
+     * @param string[] $mediaIds
+     */
+    public function reorder(Album $album, array $mediaIds): void;
+
+    public function delete(Album $album): void;
+}

--- a/src/Interface/CreateFileServiceInterface.php
+++ b/src/Interface/CreateFileServiceInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\File;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+interface CreateFileServiceInterface
+{
+    /**
+     * @throws BadRequestHttpException si validation fails
+     * @throws NotFoundHttpException si user/folder not found
+     */
+    public function createFromUpload(
+        UploadedFile $uploadedFile,
+        string $ownerId,
+        ?string $folderId = null,
+        ?string $newFolderName = null,
+    ): File;
+}

--- a/src/Interface/MediaProcessorInterface.php
+++ b/src/Interface/MediaProcessorInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\File;
+use App\Entity\Media;
+
+interface MediaProcessorInterface
+{
+    /**
+     * Crée (ou retourne, si déjà traité) le Media associé à un File.
+     * Retourne null si le type MIME du fichier n'est pas un média supporté.
+     */
+    public function process(File $file): ?Media;
+}

--- a/src/Service/AlbumImportService.php
+++ b/src/Service/AlbumImportService.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Album;
+use App\Entity\User;
+use App\Interface\AlbumImportServiceInterface;
+use App\Interface\AlbumServiceInterface;
+use App\Interface\CreateFileServiceInterface;
+use App\Interface\MediaProcessorInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+/**
+ * Orchestre l'import de photos depuis le disque directement dans un album
+ * (SRP : compose CreateFileService, MediaProcessor et AlbumService sans
+ * dupliquer leur logique).
+ *
+ * Différence avec le flux d'upload normal (FileUploadController) : le
+ * traitement média (EXIF, thumbnail) est fait en synchrone ici, car
+ * l'utilisateur attend déjà la fin de l'upload — le Media doit exister
+ * immédiatement pour pouvoir l'ajouter à l'album dans la même requête.
+ */
+final class AlbumImportService implements AlbumImportServiceInterface
+{
+    public function __construct(
+        private readonly CreateFileServiceInterface $createFileService,
+        private readonly MediaProcessorInterface $mediaProcessor,
+        private readonly AlbumServiceInterface $albumService,
+    ) {}
+
+    public function import(Album $album, array $files, User $owner): void
+    {
+        if ($files === []) {
+            return;
+        }
+
+        $mediaIds = [];
+        foreach ($files as $uploadedFile) {
+            $file = $this->createFileService->createFromUpload($uploadedFile, (string) $owner->getId());
+
+            $media = $this->mediaProcessor->process($file);
+            if ($media !== null) {
+                $mediaIds[] = $media->getId()->toRfc4122();
+            }
+        }
+
+        $this->albumService->addMedias($album, $mediaIds, $owner);
+    }
+}

--- a/src/Service/AlbumService.php
+++ b/src/Service/AlbumService.php
@@ -8,6 +8,7 @@ use App\Entity\Album;
 use App\Entity\Media;
 use App\Entity\User;
 use App\Interface\AlbumRepositoryInterface;
+use App\Interface\AlbumServiceInterface;
 use App\Interface\MediaRepositoryInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Uid\Uuid;
@@ -19,7 +20,7 @@ use Symfony\Component\Uid\Uuid;
  * avec validation des règles métier (nom non vide).
  * La persistence est déléguée à AlbumRepositoryInterface (DIP).
  */
-final class AlbumService
+final class AlbumService implements AlbumServiceInterface
 {
     public function __construct(
         private readonly AlbumRepositoryInterface $repository,

--- a/src/Service/CreateFileService.php
+++ b/src/Service/CreateFileService.php
@@ -5,6 +5,7 @@ namespace App\Service;
 
 use App\Entity\File;
 use App\Entity\User;
+use App\Interface\CreateFileServiceInterface;
 use App\Interface\DefaultFolderServiceInterface;
 use App\Interface\StorageServiceInterface;
 use App\Repository\UserRepository;
@@ -25,7 +26,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  * - EntityManager (persistence)
  * - UserRepository (user lookup)
  */
-final class CreateFileService
+final class CreateFileService implements CreateFileServiceInterface
 {
     // Blocked MIME types (executables, scripts)
     private const BLOCKED_MIMES = [

--- a/src/Service/MediaProcessor.php
+++ b/src/Service/MediaProcessor.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\File;
+use App\Entity\Media;
+use App\Interface\MediaProcessorInterface;
+use App\Repository\MediaRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Crée l'entité Media d'un File en extrayant les EXIF et en générant le
+ * thumbnail (SRP : logique métier pure, indépendante du canal d'appel).
+ *
+ * Appelé par MediaProcessHandler (async, transport Messenger) pour le flux
+ * d'upload normal, et directement en synchrone par les flux qui ont besoin
+ * du Media immédiatement après l'upload (ex: import direct dans un album).
+ *
+ * Choix :
+ * - Idempotent : si un Media existe déjà pour ce File, le retourne tel quel.
+ * - Dégradation gracieuse : EXIF manquant ou GD absent → Media créé sans ces données.
+ * - Types supportés : image/* → "photo", video/* → "video", sinon retourne null.
+ */
+final class MediaProcessor implements MediaProcessorInterface
+{
+    private const MEDIA_MIME_TYPES = [
+        'image/' => 'photo',
+        'video/' => 'video',
+    ];
+
+    public function __construct(
+        private readonly MediaRepository $mediaRepository,
+        private readonly EntityManagerInterface $em,
+        private readonly ExifService $exifService,
+        private readonly ThumbnailService $thumbnailService,
+    ) {}
+
+    public function process(File $file): ?Media
+    {
+        $mediaType = $this->resolveMediaType($file->getMimeType());
+        if ($mediaType === null) {
+            return null;
+        }
+
+        $existing = $this->mediaRepository->findOneBy(['file' => $file]);
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        $media = new Media($file, $mediaType);
+
+        if ($mediaType === 'photo') {
+            $exif = $this->exifService->extract($file->getPath());
+            $media->setWidth($exif['width']);
+            $media->setHeight($exif['height']);
+            $media->setTakenAt($exif['takenAt']);
+            $media->setCameraModel($exif['cameraModel']);
+            $media->setGpsLat($exif['gpsLat']);
+            $media->setGpsLon($exif['gpsLon']);
+
+            $thumb = $this->thumbnailService->generate($file->getPath());
+            $media->setThumbnailPath($thumb);
+        }
+
+        $this->em->persist($media);
+        $this->em->flush();
+
+        return $media;
+    }
+
+    private function resolveMediaType(string $mimeType): ?string
+    {
+        foreach (self::MEDIA_MIME_TYPES as $prefix => $type) {
+            if (str_starts_with($mimeType, $prefix)) {
+                return $type;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Service/MediaProcessor.php
+++ b/src/Service/MediaProcessor.php
@@ -7,6 +7,7 @@ namespace App\Service;
 use App\Entity\File;
 use App\Entity\Media;
 use App\Interface\MediaProcessorInterface;
+use App\Interface\StorageServiceInterface;
 use App\Repository\MediaRepository;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -35,6 +36,7 @@ final class MediaProcessor implements MediaProcessorInterface
         private readonly EntityManagerInterface $em,
         private readonly ExifService $exifService,
         private readonly ThumbnailService $thumbnailService,
+        private readonly StorageServiceInterface $storageService,
     ) {}
 
     public function process(File $file): ?Media
@@ -52,7 +54,9 @@ final class MediaProcessor implements MediaProcessorInterface
         $media = new Media($file, $mediaType);
 
         if ($mediaType === 'photo') {
-            $exif = $this->exifService->extract($file->getPath());
+            $absolutePath = $this->storageService->getAbsolutePath($file->getPath());
+
+            $exif = $this->exifService->extract($absolutePath);
             $media->setWidth($exif['width']);
             $media->setHeight($exif['height']);
             $media->setTakenAt($exif['takenAt']);
@@ -60,7 +64,7 @@ final class MediaProcessor implements MediaProcessorInterface
             $media->setGpsLat($exif['gpsLat']);
             $media->setGpsLon($exif['gpsLon']);
 
-            $thumb = $this->thumbnailService->generate($file->getPath());
+            $thumb = $this->thumbnailService->generate($absolutePath);
             $media->setThumbnailPath($thumb);
         }
 

--- a/templates/web/album_detail.html.twig
+++ b/templates/web/album_detail.html.twig
@@ -28,6 +28,18 @@
         {{ icons.icon('images', 16) }}
         Ajouter des photos
       </a>
+      <form method="post" action="{{ path('app_album_import', {id: album.id}) }}"
+            enctype="multipart/form-data" data-controller="album-import">
+        <input type="file" name="files[]" multiple accept="image/*,video/*"
+               class="hidden" data-album-import-target="input"
+               data-action="change->album-import#submit">
+        <button type="button" data-action="click->album-import#pick"
+                class="hc-btn-soft flex items-center gap-2 px-4 py-2 rounded-md font-semibold text-sm"
+                style="background: var(--hc-accent-soft); color: var(--hc-accent);">
+          {{ icons.icon('upload', 16) }}
+          Importer depuis mon ordinateur
+        </button>
+      </form>
       <form method="post" action="{{ path('app_album_delete', {id: album.id}) }}"
             onsubmit="return confirm('Supprimer l\'album « {{ album.name|e('js') }} » ?')">
         <button type="submit" class="hc-item-action hc-item-action--danger flex items-center gap-2 px-4 py-2 rounded-md font-semibold text-sm"

--- a/templates/web/album_detail.html.twig
+++ b/templates/web/album_detail.html.twig
@@ -73,7 +73,8 @@
                 class="hc-media-thumb-remove-form" data-controller="confirm-submit"
                 data-confirm-submit-message-value="Retirer « {{ media.file.originalName }} » de l'album ?">
             <button type="submit" class="hc-media-thumb-remove" data-testid="remove-media-from-album"
-                    title="Retirer de l'album" aria-label="Retirer de l'album">×</button>
+                    title="Retirer de l'album" aria-label="Retirer de l'album"
+                    draggable="true" data-action="dragstart->album-reorder#preventDrag">×</button>
           </form>
           <a href="{{ path('app_media_view', {id: media.id}) }}"
              data-lightbox

--- a/tests/Handler/MediaProcessHandlerTest.php
+++ b/tests/Handler/MediaProcessHandlerTest.php
@@ -5,94 +5,37 @@ declare(strict_types=1);
 namespace App\Tests\Handler;
 
 use App\Entity\File;
-use App\Entity\Folder;
-use App\Entity\User;
 use App\Handler\MediaProcessHandler;
 use App\Message\MediaProcessMessage;
+use App\Interface\MediaProcessorInterface;
 use App\Repository\FileRepository;
-use App\Repository\MediaRepository;
-use App\Service\ExifService;
-use App\Service\ThumbnailService;
-use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 
 final class MediaProcessHandlerTest extends TestCase
 {
-    public function testHandlerCreatesMediaForImage(): void
+    public function testHandlerDelegatesToMediaProcessorWhenFileExists(): void
     {
         $file = $this->createMock(File::class);
-        $file->method('getId')->willReturn(\Symfony\Component\Uid\Uuid::v7());
-        $file->method('getMimeType')->willReturn('image/jpeg');
-        $file->method('getPath')->willReturn('2026/02/test.jpg');
 
         $fileRepo = $this->createMock(FileRepository::class);
         $fileRepo->method('find')->willReturn($file);
 
-        $mediaRepo = $this->createMock(MediaRepository::class);
-        $mediaRepo->method('findOneBy')->willReturn(null);
+        $processor = $this->createMock(MediaProcessorInterface::class);
+        $processor->expects($this->once())->method('process')->with($file);
 
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->once())->method('persist');
-        $em->expects($this->once())->method('flush');
-
-        $exifService = $this->createMock(ExifService::class);
-        $exifService->method('extract')->willReturn([
-            'width' => 1920,
-            'height' => 1080,
-            'takenAt' => new \DateTimeImmutable('2024-06-15 12:00:00'),
-            'cameraModel' => 'Apple iPhone 15',
-            'gpsLat' => '48.8566000',
-            'gpsLon' => '2.3522000',
-        ]);
-
-        $thumbnailService = $this->createMock(ThumbnailService::class);
-        $thumbnailService->method('generate')->willReturn('thumbs/test.jpg');
-
-        $handler = new MediaProcessHandler($fileRepo, $mediaRepo, $em, $exifService, $thumbnailService);
+        $handler = new MediaProcessHandler($fileRepo, $processor);
         $handler(new MediaProcessMessage('some-uuid'));
     }
 
-    public function testHandlerIgnoresNonMediaFile(): void
+    public function testHandlerDoesNothingWhenFileNotFound(): void
     {
-        $file = $this->createMock(File::class);
-        $file->method('getMimeType')->willReturn('application/pdf');
-
         $fileRepo = $this->createMock(FileRepository::class);
-        $fileRepo->method('find')->willReturn($file);
+        $fileRepo->method('find')->willReturn(null);
 
-        $mediaRepo = $this->createMock(MediaRepository::class);
-        $mediaRepo->method('findOneBy')->willReturn(null);
+        $processor = $this->createMock(MediaProcessorInterface::class);
+        $processor->expects($this->never())->method('process');
 
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->never())->method('persist');
-
-        $exifService = $this->createMock(ExifService::class);
-        $thumbnailService = $this->createMock(ThumbnailService::class);
-
-        $handler = new MediaProcessHandler($fileRepo, $mediaRepo, $em, $exifService, $thumbnailService);
-        $handler(new MediaProcessMessage('some-uuid'));
-    }
-
-    public function testHandlerSkipsAlreadyProcessedFile(): void
-    {
-        $file = $this->createMock(File::class);
-        $file->method('getMimeType')->willReturn('image/jpeg');
-
-        $existingMedia = $this->createMock(\App\Entity\Media::class);
-
-        $fileRepo = $this->createMock(FileRepository::class);
-        $fileRepo->method('find')->willReturn($file);
-
-        $mediaRepo = $this->createMock(MediaRepository::class);
-        $mediaRepo->method('findOneBy')->willReturn($existingMedia);
-
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->never())->method('persist');
-
-        $exifService = $this->createMock(ExifService::class);
-        $thumbnailService = $this->createMock(ThumbnailService::class);
-
-        $handler = new MediaProcessHandler($fileRepo, $mediaRepo, $em, $exifService, $thumbnailService);
+        $handler = new MediaProcessHandler($fileRepo, $processor);
         $handler(new MediaProcessMessage('some-uuid'));
     }
 }

--- a/tests/Service/AlbumImportServiceTest.php
+++ b/tests/Service/AlbumImportServiceTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Media;
+use App\Entity\User;
+use App\Interface\AlbumServiceInterface;
+use App\Interface\CreateFileServiceInterface;
+use App\Interface\MediaProcessorInterface;
+use App\Service\AlbumImportService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+final class AlbumImportServiceTest extends TestCase
+{
+    private AlbumImportService $service;
+    /** @var CreateFileServiceInterface&MockObject */
+    private CreateFileServiceInterface $createFileService;
+    /** @var MediaProcessorInterface&MockObject */
+    private MediaProcessorInterface $mediaProcessor;
+    /** @var AlbumServiceInterface&MockObject */
+    private AlbumServiceInterface $albumService;
+
+    protected function setUp(): void
+    {
+        $this->createFileService = $this->createMock(CreateFileServiceInterface::class);
+        $this->mediaProcessor    = $this->createMock(MediaProcessorInterface::class);
+        $this->albumService      = $this->createMock(AlbumServiceInterface::class);
+
+        $this->service = new AlbumImportService(
+            $this->createFileService,
+            $this->mediaProcessor,
+            $this->albumService,
+        );
+    }
+
+    private function makeUploadedFile(string $name = 'photo.jpg'): UploadedFile
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'import_test_');
+        file_put_contents($tmp, 'fake-jpeg-bytes');
+
+        return new UploadedFile($tmp, $name, 'image/jpeg', null, true);
+    }
+
+    public function testImportUploadsEachFileAndAddsResultingMediaToAlbum(): void
+    {
+        $owner = new User('test@example.com', 'Test');
+        $album = new Album('Vacances', $owner);
+
+        $file1 = $this->createMock(File::class);
+        $file2 = $this->createMock(File::class);
+
+        $folder = new \App\Entity\Folder('Photos', $owner);
+        $mediaFile1 = new File('a.jpg', 'image/jpeg', 1, 'a.jpg', $folder, $owner);
+        $mediaFile2 = new File('b.jpg', 'image/jpeg', 1, 'b.jpg', $folder, $owner);
+        $media1 = new Media($mediaFile1, 'photo');
+        $media2 = new Media($mediaFile2, 'photo');
+
+        $this->createFileService
+            ->method('createFromUpload')
+            ->willReturnOnConsecutiveCalls($file1, $file2);
+
+        $this->mediaProcessor
+            ->method('process')
+            ->willReturnOnConsecutiveCalls($media1, $media2);
+
+        $this->albumService
+            ->expects($this->once())
+            ->method('addMedias')
+            ->with($album, [$media1->getId()->toRfc4122(), $media2->getId()->toRfc4122()], $owner);
+
+        $this->service->import($album, [$this->makeUploadedFile(), $this->makeUploadedFile()], $owner);
+    }
+
+    public function testImportSkipsFilesThatDoNotProduceAMedia(): void
+    {
+        $owner = new User('test@example.com', 'Test');
+        $album = new Album('Vacances', $owner);
+
+        $file = $this->createMock(File::class);
+        $this->createFileService->method('createFromUpload')->willReturn($file);
+        $this->mediaProcessor->method('process')->willReturn(null);
+
+        $this->albumService
+            ->expects($this->once())
+            ->method('addMedias')
+            ->with($album, [], $owner);
+
+        $this->service->import($album, [$this->makeUploadedFile()], $owner);
+    }
+
+    public function testImportWithNoFilesDoesNotCallAddMedias(): void
+    {
+        $owner = new User('test@example.com', 'Test');
+        $album = new Album('Vacances', $owner);
+
+        $this->createFileService->expects($this->never())->method('createFromUpload');
+        $this->albumService->expects($this->never())->method('addMedias');
+
+        $this->service->import($album, [], $owner);
+    }
+}

--- a/tests/Service/MediaProcessorTest.php
+++ b/tests/Service/MediaProcessorTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Service;
 
 use App\Entity\File;
 use App\Entity\Media;
+use App\Interface\StorageServiceInterface;
 use App\Repository\MediaRepository;
 use App\Service\ExifService;
 use App\Service\MediaProcessor;
@@ -33,8 +34,11 @@ final class MediaProcessorTest extends TestCase
         $em->expects($this->once())->method('persist');
         $em->expects($this->once())->method('flush');
 
+        $storageService = $this->createMock(StorageServiceInterface::class);
+        $storageService->expects($this->once())->method('getAbsolutePath')->with('2026/02/test.jpg')->willReturn('/var/storage/2026/02/test.jpg');
+
         $exifService = $this->createMock(ExifService::class);
-        $exifService->method('extract')->willReturn([
+        $exifService->expects($this->once())->method('extract')->with('/var/storage/2026/02/test.jpg')->willReturn([
             'width' => 1920,
             'height' => 1080,
             'takenAt' => new \DateTimeImmutable('2024-06-15 12:00:00'),
@@ -44,9 +48,9 @@ final class MediaProcessorTest extends TestCase
         ]);
 
         $thumbnailService = $this->createMock(ThumbnailService::class);
-        $thumbnailService->method('generate')->willReturn('thumbs/test.jpg');
+        $thumbnailService->expects($this->once())->method('generate')->with('/var/storage/2026/02/test.jpg')->willReturn('thumbs/test.jpg');
 
-        $processor = new MediaProcessor($mediaRepo, $em, $exifService, $thumbnailService);
+        $processor = new MediaProcessor($mediaRepo, $em, $exifService, $thumbnailService, $storageService);
         $media = $processor->process($file);
 
         $this->assertInstanceOf(Media::class, $media);
@@ -64,8 +68,9 @@ final class MediaProcessorTest extends TestCase
 
         $exifService = $this->createMock(ExifService::class);
         $thumbnailService = $this->createMock(ThumbnailService::class);
+        $storageService = $this->createMock(StorageServiceInterface::class);
 
-        $processor = new MediaProcessor($mediaRepo, $em, $exifService, $thumbnailService);
+        $processor = new MediaProcessor($mediaRepo, $em, $exifService, $thumbnailService, $storageService);
         $media = $processor->process($file);
 
         $this->assertNull($media);
@@ -86,8 +91,9 @@ final class MediaProcessorTest extends TestCase
 
         $exifService = $this->createMock(ExifService::class);
         $thumbnailService = $this->createMock(ThumbnailService::class);
+        $storageService = $this->createMock(StorageServiceInterface::class);
 
-        $processor = new MediaProcessor($mediaRepo, $em, $exifService, $thumbnailService);
+        $processor = new MediaProcessor($mediaRepo, $em, $exifService, $thumbnailService, $storageService);
         $media = $processor->process($file);
 
         $this->assertSame($existingMedia, $media);
@@ -110,8 +116,9 @@ final class MediaProcessorTest extends TestCase
         $exifService->expects($this->never())->method('extract');
         $thumbnailService = $this->createMock(ThumbnailService::class);
         $thumbnailService->expects($this->never())->method('generate');
+        $storageService = $this->createMock(StorageServiceInterface::class);
 
-        $processor = new MediaProcessor($mediaRepo, $em, $exifService, $thumbnailService);
+        $processor = new MediaProcessor($mediaRepo, $em, $exifService, $thumbnailService, $storageService);
         $media = $processor->process($file);
 
         $this->assertInstanceOf(Media::class, $media);

--- a/tests/Service/MediaProcessorTest.php
+++ b/tests/Service/MediaProcessorTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Entity\File;
+use App\Entity\Media;
+use App\Repository\MediaRepository;
+use App\Service\ExifService;
+use App\Service\MediaProcessor;
+use App\Service\ThumbnailService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires MediaProcessor — logique de création de Media (EXIF +
+ * thumbnail) extraite de MediaProcessHandler pour être appelable aussi bien
+ * en asynchrone (handler Messenger) qu'en synchrone (import direct).
+ */
+final class MediaProcessorTest extends TestCase
+{
+    public function testProcessCreatesMediaForImage(): void
+    {
+        $file = $this->createMock(File::class);
+        $file->method('getMimeType')->willReturn('image/jpeg');
+        $file->method('getPath')->willReturn('2026/02/test.jpg');
+
+        $mediaRepo = $this->createMock(MediaRepository::class);
+        $mediaRepo->method('findOneBy')->willReturn(null);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('persist');
+        $em->expects($this->once())->method('flush');
+
+        $exifService = $this->createMock(ExifService::class);
+        $exifService->method('extract')->willReturn([
+            'width' => 1920,
+            'height' => 1080,
+            'takenAt' => new \DateTimeImmutable('2024-06-15 12:00:00'),
+            'cameraModel' => 'Apple iPhone 15',
+            'gpsLat' => '48.8566000',
+            'gpsLon' => '2.3522000',
+        ]);
+
+        $thumbnailService = $this->createMock(ThumbnailService::class);
+        $thumbnailService->method('generate')->willReturn('thumbs/test.jpg');
+
+        $processor = new MediaProcessor($mediaRepo, $em, $exifService, $thumbnailService);
+        $media = $processor->process($file);
+
+        $this->assertInstanceOf(Media::class, $media);
+        $this->assertSame('photo', $media->getMediaType());
+    }
+
+    public function testProcessReturnsNullForNonMediaFile(): void
+    {
+        $file = $this->createMock(File::class);
+        $file->method('getMimeType')->willReturn('application/pdf');
+
+        $mediaRepo = $this->createMock(MediaRepository::class);
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('persist');
+
+        $exifService = $this->createMock(ExifService::class);
+        $thumbnailService = $this->createMock(ThumbnailService::class);
+
+        $processor = new MediaProcessor($mediaRepo, $em, $exifService, $thumbnailService);
+        $media = $processor->process($file);
+
+        $this->assertNull($media);
+    }
+
+    public function testProcessReturnsExistingMediaIfAlreadyProcessed(): void
+    {
+        $file = $this->createMock(File::class);
+        $file->method('getMimeType')->willReturn('image/jpeg');
+
+        $existingMedia = $this->createMock(Media::class);
+
+        $mediaRepo = $this->createMock(MediaRepository::class);
+        $mediaRepo->method('findOneBy')->willReturn($existingMedia);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('persist');
+
+        $exifService = $this->createMock(ExifService::class);
+        $thumbnailService = $this->createMock(ThumbnailService::class);
+
+        $processor = new MediaProcessor($mediaRepo, $em, $exifService, $thumbnailService);
+        $media = $processor->process($file);
+
+        $this->assertSame($existingMedia, $media);
+    }
+
+    public function testProcessCreatesVideoMediaWithoutExifOrThumbnail(): void
+    {
+        $file = $this->createMock(File::class);
+        $file->method('getMimeType')->willReturn('video/mp4');
+        $file->method('getPath')->willReturn('2026/02/clip.mp4');
+
+        $mediaRepo = $this->createMock(MediaRepository::class);
+        $mediaRepo->method('findOneBy')->willReturn(null);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('persist');
+        $em->expects($this->once())->method('flush');
+
+        $exifService = $this->createMock(ExifService::class);
+        $exifService->expects($this->never())->method('extract');
+        $thumbnailService = $this->createMock(ThumbnailService::class);
+        $thumbnailService->expects($this->never())->method('generate');
+
+        $processor = new MediaProcessor($mediaRepo, $em, $exifService, $thumbnailService);
+        $media = $processor->process($file);
+
+        $this->assertInstanceOf(Media::class, $media);
+        $this->assertSame('video', $media->getMediaType());
+    }
+}

--- a/tests/Web/AlbumWebTest.php
+++ b/tests/Web/AlbumWebTest.php
@@ -367,6 +367,63 @@ final class AlbumWebTest extends WebTestCase
         $this->assertResponseStatusCodeSame(403);
     }
 
+    // --- Import direct depuis le disque ---
+
+    /**
+     * Copie temporaire de la fixture — UploadedFile en mode "test" (dernier
+     * argument true) ne déplace pas le fichier physiquement, mais on copie
+     * quand même par prudence pour ne jamais risquer d'altérer la fixture
+     * source versionnée dans le repo.
+     */
+    private function sampleUploadedPhoto(string $clientFilename = 'sunset.jpg'): \Symfony\Component\HttpFoundation\File\UploadedFile
+    {
+        $source = dirname(__DIR__, 2) . '/fixtures/demo-photos/kanenori-sunset-7133867_1920.jpg';
+        $tmp    = tempnam(sys_get_temp_dir(), 'album_import_test_') . '.jpg';
+        copy($source, $tmp);
+
+        return new \Symfony\Component\HttpFoundation\File\UploadedFile($tmp, $clientFilename, 'image/jpeg', null, true);
+    }
+
+    public function testImportPhotoToAlbumCreatesMediaAndAddsItImmediately(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $this->login();
+
+        $uploadedFile = $this->sampleUploadedPhoto();
+
+        $this->client->request(
+            'POST',
+            '/albums/' . $album->getId()->toRfc4122() . '/import',
+            [],
+            ['files' => [$uploadedFile]],
+        );
+
+        $this->assertResponseRedirects('/albums/' . $album->getId()->toRfc4122());
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('[data-testid="album-media-count"]', '1');
+    }
+
+    public function testImportPhotoToAlbumForbiddenForOtherUser(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob   = $this->createUser('bob@example.com');
+        $album = $this->createAlbum($alice, 'Album Alice');
+
+        $this->login('bob@example.com');
+
+        $uploadedFile = $this->sampleUploadedPhoto();
+
+        $this->client->request(
+            'POST',
+            '/albums/' . $album->getId()->toRfc4122() . '/import',
+            [],
+            ['files' => [$uploadedFile]],
+        );
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
     // --- Suppression ---
 
     public function testDeleteAlbumRedirectsToList(): void


### PR DESCRIPTION
## Résumé
- **Import direct** : bouton « Importer depuis mon ordinateur » dans un album — upload + ajout à l'album en une seule action, traitement média synchrone (contrairement au flux normal, asynchrone).
- **Refactor SRP** : `MediaProcessor` extrait de `MediaProcessHandler` (réutilisable en sync et async). `CreateFileServiceInterface`/`AlbumServiceInterface` ajoutées pour respecter DIP (classes `final` sans interface, impossibles à mocker en isolation).
- **Fix critique** : `MediaProcessor` n'utilisait pas `StorageServiceInterface::getAbsolutePath()` avant d'appeler EXIF/thumbnail — bug préexistant dans le pipeline normal, masqué par la dégradation gracieuse (thumbnail silencieusement absent). Corrige tous les uploads, pas seulement l'import.
- **Fix UI** : le bouton de suppression d'un média était imbriqué dans une vignette `draggable`, causant un conflit intermittent avec le drag natif du navigateur.

## Test plan
- [x] TDD complet sur chaque commit — RED → GREEN
- [x] Suite complète verte : PHPUnit 422/422, Jest 53/53
- [x] Vérifié visuellement en local (import, vignette générée, suppression sans blocage)