### PR TITLE
✨ feat(media): renommer un média en place + actions de vignette plus soignées

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ php.ini
 # Deploy info (généré par les scripts de déploiement)
 /templates/deploy-info.html.twig
 /.deploy-targets
+
+# import pour test
+/import/*

--- a/assets/controllers/rename_media_controller.js
+++ b/assets/controllers/rename_media_controller.js
@@ -1,0 +1,35 @@
+import { Controller } from '@hotwired/stimulus';
+
+/* Renommer un média en place, sans navigation : demande le nouveau nom via
+ * prompt() natif (cohérent avec confirm() déjà utilisé pour la suppression),
+ * envoie la requête en arrière-plan et met à jour le nom affiché au succès. */
+export default class extends Controller {
+    static targets = ['caption'];
+    static values = { url: String, currentName: String };
+
+    async prompt() {
+        const name = window.prompt('Nouveau nom du fichier', this.currentNameValue);
+        if (!name || name === this.currentNameValue) return;
+
+        const body = new URLSearchParams({ name });
+        const response = await fetch(this.urlValue, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'Accept': 'application/json',
+            },
+            body: body.toString(),
+        });
+
+        if (!response.ok) {
+            window.alert('Le renommage a échoué. Vérifiez que le nom est valide.');
+            return;
+        }
+
+        const data = await response.json();
+        this.currentNameValue = data.name;
+        if (this.hasCaptionTarget) {
+            this.captionTarget.textContent = data.name;
+        }
+    }
+}

--- a/assets/styles/gallery.css
+++ b/assets/styles/gallery.css
@@ -105,35 +105,48 @@
   text-overflow: ellipsis;
 }
 
-/* ── Retrait d'un média d'un album ── */
-.hc-media-thumb-remove-form {
+/* ── Actions flottantes sur une vignette (renommer, retirer) ── */
+.hc-media-thumb-actions {
   position: absolute;
   top: 6px;
   right: 6px;
   z-index: 2;
+  display: flex;
+  gap: 4px;
 }
 
-.hc-media-thumb-remove {
+.hc-media-thumb-action-form {
+  display: contents;
+}
+
+.hc-media-thumb-action {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: 26px;
+  height: 26px;
   border-radius: 50%;
   border: none;
-  background: rgba(0, 0, 0, 0.55);
+  background: rgba(17, 17, 17, 0.65);
+  backdrop-filter: blur(2px);
   color: #fff;
-  font-size: 1rem;
-  line-height: 1;
   cursor: pointer;
   opacity: 0;
-  transition: opacity .15s ease, background .15s ease;
+  transform: translateY(-2px);
+  transition: opacity .15s ease, transform .15s ease, background .15s ease;
 }
-.hc-media-thumb:hover .hc-media-thumb-remove {
+.hc-media-thumb:hover .hc-media-thumb-action {
   opacity: 1;
+  transform: translateY(0);
 }
-.hc-media-thumb-remove:hover {
+.hc-media-thumb-action:hover {
+  background: rgba(17, 17, 17, 0.85);
+}
+.hc-media-thumb-action--remove:hover {
   background: var(--hc-err);
+}
+.hc-media-thumb-action--rename:hover {
+  background: var(--hc-accent);
 }
 
 /* ── Sélection multiple (toujours visible, pour ajout à un album) ── */

--- a/assets/tests/rename-media.test.js
+++ b/assets/tests/rename-media.test.js
@@ -1,0 +1,81 @@
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { Application } from '@hotwired/stimulus';
+import RenameMediaController from '../controllers/rename_media_controller.js';
+
+describe('rename-media controller', () => {
+  let application;
+  let promptSpy;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="thumb" data-controller="rename-media"
+           data-rename-media-url-value="/gallery/abc/rename"
+           data-rename-media-current-name-value="ancien-nom.jpg">
+        <button data-action="click->rename-media#prompt"></button>
+        <div data-rename-media-target="caption">ancien-nom.jpg</div>
+      </div>
+    `;
+
+    application = Application.start();
+    application.register('rename-media', RenameMediaController);
+
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    application.stop();
+    jest.restoreAllMocks();
+  });
+
+  function clickRenameButton() {
+    document.querySelector('button').click();
+  }
+
+  test('does nothing when prompt is cancelled', async () => {
+    promptSpy = jest.spyOn(window, 'prompt').mockReturnValue(null);
+
+    clickRenameButton();
+    await Promise.resolve();
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when the name is unchanged', async () => {
+    promptSpy = jest.spyOn(window, 'prompt').mockReturnValue('ancien-nom.jpg');
+
+    clickRenameButton();
+    await Promise.resolve();
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('sends a POST request and updates the caption on success', async () => {
+    promptSpy = jest.spyOn(window, 'prompt').mockReturnValue('nouveau-nom.jpg');
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: 'nouveau-nom.jpg' }),
+    });
+
+    clickRenameButton();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(global.fetch).toHaveBeenCalledWith('/gallery/abc/rename', expect.objectContaining({ method: 'POST' }));
+    expect(document.querySelector('[data-rename-media-target="caption"]').textContent).toBe('nouveau-nom.jpg');
+  });
+
+  test('alerts and does not update the caption on failure', async () => {
+    promptSpy = jest.spyOn(window, 'prompt').mockReturnValue('inva/lid.jpg');
+    const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+    global.fetch.mockResolvedValue({ ok: false });
+
+    clickRenameButton();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(alertSpy).toHaveBeenCalled();
+    expect(document.querySelector('[data-rename-media-target="caption"]').textContent).toBe('ancien-nom.jpg');
+  });
+});

--- a/src/Controller/Web/MediaRenameController.php
+++ b/src/Controller/Web/MediaRenameController.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Web;
+
+use App\Interface\FileActionServiceInterface;
+use App\Interface\MediaRepositoryInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Renomme un média en place, sans navigation — la page appelante (galerie
+ * ou album) reste affichée, le nom est mis à jour côté client via fetch().
+ *
+ * Contrôleur dédié (SRP) plutôt qu'une méthode de plus sur
+ * MediaGalleryController, qui gère déjà listing/vue/service de fichiers.
+ */
+#[IsGranted('ROLE_USER')]
+final class MediaRenameController extends AbstractController
+{
+    public function __construct(
+        private readonly MediaRepositoryInterface $mediaRepository,
+        private readonly FileActionServiceInterface $fileActionService,
+    ) {}
+
+    #[Route('/gallery/{id}/rename', name: 'app_media_rename', requirements: ['id' => '[0-9a-f\-]+'], methods: ['POST'])]
+    public function __invoke(string $id, Request $request): JsonResponse
+    {
+        $media = $this->mediaRepository->findById(Uuid::fromString($id));
+
+        if ($media === null || !$media->isOwnedBy($this->getUser())) {
+            throw $this->createNotFoundException('Média introuvable.');
+        }
+
+        $newName = (string) $request->request->get('name', '');
+        $this->fileActionService->rename($media->getFile(), $newName);
+
+        return $this->json(['name' => $media->getFile()->getOriginalName()]);
+    }
+}

--- a/src/Interface/FileActionServiceInterface.php
+++ b/src/Interface/FileActionServiceInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\User;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+interface FileActionServiceInterface
+{
+    /**
+     * @throws BadRequestHttpException si le nom est invalide ou déjà pris dans le dossier
+     */
+    public function rename(File $file, string $newName): void;
+
+    /**
+     * @throws BadRequestHttpException si déplacement créerait un cycle ou nom déjà pris
+     */
+    public function move(File $file, Folder $targetFolder, User $requester): void;
+
+    public function delete(File $file): void;
+}

--- a/src/Service/FileActionService.php
+++ b/src/Service/FileActionService.php
@@ -7,6 +7,7 @@ use App\Entity\File;
 use App\Entity\Folder;
 use App\Entity\User;
 use App\Interface\AuthorizationCheckerInterface;
+use App\Interface\FileActionServiceInterface;
 use App\Interface\FileRepositoryInterface;
 use App\Interface\StorageServiceInterface;
 use App\Service\FilenameValidator;
@@ -25,7 +26,7 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  * - EntityManager (persistence)
  * - FileRepositoryInterface (data access)
  */
-final class FileActionService
+final class FileActionService implements FileActionServiceInterface
 {
     public function __construct(
         private readonly FileRepositoryInterface $fileRepository,

--- a/templates/components/MediaThumbActions.html.twig
+++ b/templates/components/MediaThumbActions.html.twig
@@ -1,0 +1,27 @@
+{# Actions flottantes sur une vignette média (visibles au survol) : renommer
+   et retirer. Réutilisé par gallery.html.twig et album_detail.html.twig.
+   Props attendues : media, renameUrl, removeUrl (null pour masquer le
+   bouton de retrait — ex. dans la galerie, "retirer" n'a pas de sens hors
+   contexte d'un album). Le renommage se fait en place (fetch), sans
+   navigation — voir rename_media_controller.js. Le contrôleur est posé sur
+   le conteneur de la vignette (data-rename-media-*) par le template
+   appelant, ce composant ne fournit que le bouton déclencheur. #}
+<div class="hc-media-thumb-actions">
+  <button type="button" data-action="click->rename-media#prompt"
+          class="hc-media-thumb-action hc-media-thumb-action--rename"
+          title="Renommer" aria-label="Renommer">
+    <svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+  </button>
+
+  {% if removeUrl is defined and removeUrl %}
+    <form method="post" action="{{ removeUrl }}"
+          class="hc-media-thumb-action-form" data-controller="confirm-submit"
+          data-confirm-submit-message-value="Retirer « {{ media.file.originalName }} » de l'album ?">
+      <button type="submit" class="hc-media-thumb-action hc-media-thumb-action--remove"
+              data-testid="remove-media-from-album" title="Retirer de l'album" aria-label="Retirer de l'album"
+              draggable="true" data-action="dragstart->album-reorder#preventDrag">
+        <svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
+      </button>
+    </form>
+  {% endif %}
+</div>

--- a/templates/web/album_detail.html.twig
+++ b/templates/web/album_detail.html.twig
@@ -68,14 +68,14 @@
         <div class="hc-media-thumb" draggable="true"
              data-album-reorder-target="item"
              data-media-id="{{ media.id }}"
-             data-action="dragstart->album-reorder#dragStart dragover->album-reorder#dragOver drop->album-reorder#drop dragend->album-reorder#dragEnd">
-          <form method="post" action="{{ path('app_album_remove_media', {id: album.id, mediaId: media.id}) }}"
-                class="hc-media-thumb-remove-form" data-controller="confirm-submit"
-                data-confirm-submit-message-value="Retirer « {{ media.file.originalName }} » de l'album ?">
-            <button type="submit" class="hc-media-thumb-remove" data-testid="remove-media-from-album"
-                    title="Retirer de l'album" aria-label="Retirer de l'album"
-                    draggable="true" data-action="dragstart->album-reorder#preventDrag">×</button>
-          </form>
+             data-action="dragstart->album-reorder#dragStart dragover->album-reorder#dragOver drop->album-reorder#drop dragend->album-reorder#dragEnd"
+             data-controller="rename-media"
+             data-rename-media-url-value="{{ path('app_media_rename', {id: media.id}) }}"
+             data-rename-media-current-name-value="{{ media.file.originalName }}">
+          <twig:MediaThumbActions
+            :media="media"
+            removeUrl="{{ path('app_album_remove_media', {id: album.id, mediaId: media.id}) }}"
+          />
           <a href="{{ path('app_media_view', {id: media.id}) }}"
              data-lightbox
              data-full-src="{{ path('app_media_full', {id: media.id}) }}"
@@ -95,7 +95,7 @@
               </div>
             {% endif %}
           </a>
-          <div class="hc-media-thumb-caption">
+          <div class="hc-media-thumb-caption" data-rename-media-target="caption">
             {{ media.file.originalName }}
           </div>
         </div>

--- a/templates/web/gallery.html.twig
+++ b/templates/web/gallery.html.twig
@@ -67,7 +67,11 @@
 
     <div data-testid="media-gallery" class="hc-media-grid" data-controller="gallery-selection">
       {% for media in medias %}
-        <div data-testid="media-thumbnail" class="hc-media-thumb" data-gallery-selection-target="thumb">
+        <div data-testid="media-thumbnail" class="hc-media-thumb" data-gallery-selection-target="thumb"
+             data-controller="rename-media"
+             data-rename-media-url-value="{{ path('app_media_rename', {id: media.id}) }}"
+             data-rename-media-current-name-value="{{ media.file.originalName }}">
+          <twig:MediaThumbActions :media="media" />
           {% if targetAlbum %}
             <label class="hc-media-thumb-select">
               <input type="checkbox" name="mediaIds[]" value="{{ media.id }}" form="gallery-add-to-album-form"
@@ -95,7 +99,7 @@
               </div>
             {% endif %}
           </a>
-          <div class="hc-media-thumb-caption">
+          <div class="hc-media-thumb-caption" data-rename-media-target="caption">
             {{ media.file.originalName }}
           </div>
         </div>

--- a/tests/Web/MediaGalleryTest.php
+++ b/tests/Web/MediaGalleryTest.php
@@ -420,4 +420,5 @@ final class MediaGalleryTest extends WebTestCase
         $this->client->request('GET', '/gallery?album=' . $album->getId()->toRfc4122());
         $this->assertResponseStatusCodeSame(403);
     }
+
 }

--- a/tests/Web/MediaRenameTest.php
+++ b/tests/Web/MediaRenameTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Tests fonctionnels du renommage d'un média (POST /gallery/{id}/rename).
+ * Réponse JSON — le renommage se fait en place, sans navigation.
+ */
+final class MediaRenameTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM album_media');
+        $conn->executeStatement('DELETE FROM albums');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createUser(string $email = 'gallery@example.com'): \App\Entity\User
+    {
+        return $this->createWebUser($email);
+    }
+
+    private function login(string $email = 'gallery@example.com'): void
+    {
+        $this->loginAs($email);
+    }
+
+    public function testRenameMediaReturnsJsonWithNewName(): void
+    {
+        $user  = $this->createUser();
+        $media = $this->createMediaFile($user, 'ancien-nom.jpg', 'photo');
+        $this->login();
+
+        $this->client->request(
+            'POST',
+            '/gallery/' . $media->getId()->toRfc4122() . '/rename',
+            ['name' => 'nouveau-nom.jpg'],
+            [],
+            ['HTTP_ACCEPT' => 'application/json'],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $data = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertSame('nouveau-nom.jpg', $data['name']);
+    }
+
+    public function testRenameMediaPersistsTheNewName(): void
+    {
+        $user  = $this->createUser();
+        $media = $this->createMediaFile($user, 'ancien-nom.jpg', 'photo');
+        $this->login();
+
+        $this->client->request(
+            'POST',
+            '/gallery/' . $media->getId()->toRfc4122() . '/rename',
+            ['name' => 'nouveau-nom.jpg'],
+            [],
+            ['HTTP_ACCEPT' => 'application/json'],
+        );
+
+        $this->client->request('GET', '/gallery');
+        $this->assertStringContainsString('nouveau-nom.jpg', $this->client->getResponse()->getContent());
+    }
+
+    public function testRenameMediaNotFoundForOtherUser(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob   = $this->createUser('bob@example.com');
+        $media = $this->createMediaFile($alice, 'photo.jpg', 'photo');
+
+        $this->login('bob@example.com');
+        $this->client->request(
+            'POST',
+            '/gallery/' . $media->getId()->toRfc4122() . '/rename',
+            ['name' => 'hack.jpg'],
+            [],
+            ['HTTP_ACCEPT' => 'application/json'],
+        );
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testRenameMediaWithEmptyNameReturns400(): void
+    {
+        $user  = $this->createUser();
+        $media = $this->createMediaFile($user, 'photo.jpg', 'photo');
+        $this->login();
+
+        $this->client->request(
+            'POST',
+            '/gallery/' . $media->getId()->toRfc4122() . '/rename',
+            ['name' => ''],
+            [],
+            ['HTTP_ACCEPT' => 'application/json'],
+        );
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testRenameMediaWithForbiddenCharsReturns400(): void
+    {
+        $user  = $this->createUser();
+        $media = $this->createMediaFile($user, 'photo.jpg', 'photo');
+        $this->login();
+
+        $this->client->request(
+            'POST',
+            '/gallery/' . $media->getId()->toRfc4122() . '/rename',
+            ['name' => 'inva/lid.jpg'],
+            [],
+            ['HTTP_ACCEPT' => 'application/json'],
+        );
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+}


### PR DESCRIPTION
## Résumé
- Renommage d'un média en place (galerie + album) : icône crayon au survol, `prompt()` natif, `fetch()` async — reste sur la page courante, aucune navigation.
- Contrôleur dédié `MediaRenameController` (SRP) plutôt qu'une méthode de plus sur `MediaGalleryController`.
- `FileActionServiceInterface` ajoutée (classe `final` sans interface, impossible à mocker en isolation).
- Boutons retirer/renommer factorisés en composant Twig `MediaThumbActions`, avec une vraie icône SVG (trash) remplaçant le `×` texte.

## Test plan
- [x] TDD complet : `MediaRenameTest` (JSON, ownership, validation) + `rename-media.test.js` (Jest, contrôleur Stimulus réel) — RED → GREEN
- [x] Suite complète verte : PHPUnit 427/427, Jest 57/57
- [x] Vérifié visuellement en local