### PR TITLE
feat(gallery): lire les vidéos dans la lightbox

### DIFF
--- a/assets/controllers/gallery_lightbox_controller.js
+++ b/assets/controllers/gallery_lightbox_controller.js
@@ -5,12 +5,14 @@ import Slideshow from './Slideshow.js';
  * sur une vignette, navigation précédent/suivant au clavier et via boutons.
  * Le diaporama (auto-avance, pause/lecture) est délégué à Slideshow. */
 export default class extends Controller {
-    static targets = ['img', 'prev', 'next', 'play'];
+    static targets = ['img', 'video', 'prev', 'next', 'play'];
 
     connect() {
         this.links = Array.from(document.querySelectorAll('[data-lightbox]'));
         this.srcs = this.links.map((el) => el.getAttribute('data-full-src'));
+        this.mediaTypes = this.links.map((el) => el.getAttribute('data-media-type'));
         this.current = -1;
+        this.slideshowPausedForVideo = false;
         this.slideshow = new Slideshow(() => this.next());
 
         this.links.forEach((el, index) => {
@@ -23,17 +25,46 @@ export default class extends Controller {
 
         this.boundKeydown = this.onKeydown.bind(this);
         document.addEventListener('keydown', this.boundKeydown);
+
+        this.boundVideoEnded = () => {
+            const wasPlaying = this.slideshowPausedForVideo;
+            this.next();
+            if (wasPlaying) this.slideshow.start();
+        };
+        this.videoTarget.addEventListener('ended', this.boundVideoEnded);
     }
 
     disconnect() {
         document.removeEventListener('keydown', this.boundKeydown);
+        this.videoTarget.removeEventListener('ended', this.boundVideoEnded);
         this.slideshow.stop();
     }
 
     show(index) {
         if (index < 0 || index >= this.srcs.length) return;
+        this.videoTarget.pause();
         this.current = index;
-        this.imgTarget.src = this.srcs[this.current];
+
+        const isVideo = this.mediaTypes[this.current] === 'video';
+
+        const wasPlaying = this.slideshow.isPlaying;
+        this.slideshowPausedForVideo = false;
+
+        if (isVideo) {
+            this.videoTarget.src = this.srcs[this.current];
+            this.videoTarget.style.display = '';
+            this.imgTarget.style.display = 'none';
+            if (wasPlaying) {
+                this.slideshow.stop();
+                this.slideshowPausedForVideo = true;
+                this.videoTarget.play();
+            }
+        } else {
+            this.imgTarget.src = this.srcs[this.current];
+            this.imgTarget.style.display = '';
+            this.videoTarget.style.display = 'none';
+        }
+
         this.element.style.display = 'flex';
         this.prevTarget.style.visibility = this.current > 0 ? 'visible' : 'hidden';
         this.nextTarget.style.visibility = this.current < this.srcs.length - 1 ? 'visible' : 'hidden';
@@ -49,6 +80,7 @@ export default class extends Controller {
 
     close() {
         this.element.style.display = 'none';
+        this.videoTarget.pause();
         this.slideshow.stop();
         this.updatePlayTarget();
     }

--- a/assets/styles/gallery.css
+++ b/assets/styles/gallery.css
@@ -274,7 +274,8 @@
   cursor: zoom-out;
 }
 
-.hc-lightbox-img {
+.hc-lightbox-img,
+.hc-lightbox-video {
   max-width: 90vw;
   max-height: 90vh;
   border-radius: 6px;

--- a/assets/tests/gallery-lightbox-video.test.js
+++ b/assets/tests/gallery-lightbox-video.test.js
@@ -3,10 +3,10 @@ import { Application } from '@hotwired/stimulus';
 import GalleryLightboxController from '../controllers/gallery_lightbox_controller.js';
 
 /**
- * Diaporama de la lightbox galerie : auto-avance à intervalle fixe,
- * pause/lecture, arrêt à la fermeture.
+ * Lecture vidéo dans la lightbox galerie : les médias de type "video"
+ * s'affichent dans une balise <video> lisible, les photos restent dans <img>.
  */
-describe('gallery-lightbox slideshow', () => {
+describe('gallery-lightbox video playback', () => {
   let application;
 
   beforeEach(() => {
@@ -14,7 +14,7 @@ describe('gallery-lightbox slideshow', () => {
 
     document.body.innerHTML = `
       <a data-lightbox data-media-type="photo" data-full-src="/a.jpg"></a>
-      <a data-lightbox data-media-type="photo" data-full-src="/b.jpg"></a>
+      <a data-lightbox data-media-type="video" data-full-src="/b.mp4"></a>
       <a data-lightbox data-media-type="photo" data-full-src="/c.jpg"></a>
       <div id="lightbox" data-controller="gallery-lightbox">
         <button data-gallery-lightbox-target="prev" data-action="gallery-lightbox#prev"></button>
@@ -42,61 +42,67 @@ describe('gallery-lightbox slideshow', () => {
     return application.getControllerForElementAndIdentifier(el, 'gallery-lightbox');
   }
 
-  test('togglePlay advances to the next slide every 4 seconds', () => {
+  test('shows the video element and hides the img for a video slide', () => {
     const controller = getController();
+    controller.show(1);
+
+    expect(controller.videoTarget.src).toContain('b.mp4');
+    expect(controller.videoTarget.style.display).not.toBe('none');
+    expect(controller.imgTarget.style.display).toBe('none');
+  });
+
+  test('shows the img element and hides the video for a photo slide', () => {
+    const controller = getController();
+    controller.show(1);
     controller.show(0);
 
-    controller.togglePlay();
     expect(controller.imgTarget.src).toContain('a.jpg');
-
-    jest.advanceTimersByTime(4000);
-    expect(controller.imgTarget.src).toContain('b.jpg');
-
-    jest.advanceTimersByTime(4000);
-    expect(controller.imgTarget.src).toContain('c.jpg');
+    expect(controller.imgTarget.style.display).not.toBe('none');
+    expect(controller.videoTarget.style.display).toBe('none');
   });
 
-  test('togglePlay again pauses the slideshow', () => {
+  test('pauses the video when navigating away from it', () => {
     const controller = getController();
-    controller.show(0);
-    controller.togglePlay();
-
-    jest.advanceTimersByTime(4000);
-    expect(controller.imgTarget.src).toContain('b.jpg');
-
-    controller.togglePlay();
-    jest.advanceTimersByTime(8000);
-    expect(controller.imgTarget.src).toContain('b.jpg');
-  });
-
-  test('slideshow loops back to the first slide after the last', () => {
-    const controller = getController();
-    controller.show(2);
-    controller.togglePlay();
-
-    jest.advanceTimersByTime(4000);
-    expect(controller.imgTarget.src).toContain('a.jpg');
-  });
-
-  test('closing the lightbox stops the slideshow', () => {
-    const controller = getController();
-    controller.show(0);
-    controller.togglePlay();
-
-    controller.close();
-    jest.advanceTimersByTime(8000);
-    expect(controller.element.style.display).toBe('none');
-  });
-
-  test('manual navigation while playing does not desync the timer', () => {
-    const controller = getController();
-    controller.show(0);
-    controller.togglePlay();
+    controller.show(1);
 
     controller.next();
-    expect(controller.imgTarget.src).toContain('b.jpg');
+
+    expect(HTMLMediaElement.prototype.pause).toHaveBeenCalled();
+  });
+
+  test('pauses the video when the lightbox closes', () => {
+    const controller = getController();
+    controller.show(1);
+
+    controller.close();
+
+    expect(HTMLMediaElement.prototype.pause).toHaveBeenCalled();
+  });
+
+  test('slideshow waits for the video to finish before advancing, not the fixed interval', () => {
+    const controller = getController();
+    controller.show(0);
+    controller.togglePlay();
 
     jest.advanceTimersByTime(4000);
+    expect(controller.videoTarget.src).toContain('b.mp4');
+
+    jest.advanceTimersByTime(60000);
+    expect(controller.videoTarget.src).toContain('b.mp4');
+
+    controller.videoTarget.dispatchEvent(new Event('ended'));
     expect(controller.imgTarget.src).toContain('c.jpg');
+  });
+
+  test('slideshow resumes the fixed interval once past the video', () => {
+    const controller = getController();
+    controller.show(0);
+    controller.togglePlay();
+
+    jest.advanceTimersByTime(4000);
+    controller.videoTarget.dispatchEvent(new Event('ended'));
+
+    jest.advanceTimersByTime(4000);
+    expect(controller.imgTarget.src).toContain('a.jpg');
   });
 });

--- a/templates/components/GalleryLightbox.html.twig
+++ b/templates/components/GalleryLightbox.html.twig
@@ -5,6 +5,7 @@
     <svg width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="15 6 9 12 15 18"/></svg>
   </button>
   <img data-gallery-lightbox-target="img" src="" alt="" class="hc-lightbox-img">
+  <video data-gallery-lightbox-target="video" controls class="hc-lightbox-video" style="display: none;"></video>
   <button data-gallery-lightbox-target="next" data-action="gallery-lightbox#next" class="hc-lightbox-nav hc-lightbox-nav--next" aria-label="Média suivant">
     <svg width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="9 6 15 12 9 18"/></svg>
   </button>

--- a/templates/web/album_detail.html.twig
+++ b/templates/web/album_detail.html.twig
@@ -83,6 +83,7 @@
           />
           <a href="{{ path('app_media_view', {id: media.id}) }}"
              data-lightbox
+             data-media-type="{{ media.mediaType }}"
              data-full-src="{{ path('app_media_full', {id: media.id}) }}"
              class="hc-media-thumb-link">
             {% if media.thumbnailPath %}

--- a/tests/Web/AlbumWebTest.php
+++ b/tests/Web/AlbumWebTest.php
@@ -700,6 +700,20 @@ final class AlbumWebTest extends WebTestCase
         $this->assertSelectorExists('[data-lightbox][data-full-src]');
     }
 
+    public function testAlbumDetailVideoThumbnailHasMediaTypeAttribute(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $media = $this->createMediaFile($user, 'clip.mp4', 'video');
+        $album->addMedia($media);
+        $this->em->flush();
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/albums/' . $album->getId()->toRfc4122());
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-lightbox][data-media-type="video"]');
+    }
+
     public function testAlbumDetailHasSlideshowToggle(): void
     {
         $user  = $this->createUser();

--- a/tests/Web/MediaGalleryTest.php
+++ b/tests/Web/MediaGalleryTest.php
@@ -122,6 +122,16 @@ final class MediaGalleryTest extends WebTestCase
         $this->assertSelectorExists('[data-lightbox]');
     }
 
+    public function testVideoThumbnailHasMediaTypeAttribute(): void
+    {
+        $user = $this->createUser();
+        $this->createMediaFile($user, 'clip.mp4', 'video');
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/gallery');
+        $this->assertSelectorExists('[data-lightbox][data-media-type="video"]');
+    }
+
     // --- Filtrage ---
 
     public function testGalleryFilterByPhoto(): void


### PR DESCRIPTION
## Résumé
- Ajoute une balise `<video>` à côté de `<img>` dans la lightbox galerie, basculée selon `data-media-type`.
- Le diaporama attend la fin réelle de la vidéo (`ended`) avant d'avancer à la slide suivante, au lieu du délai fixe de 4s — la vidéo n'est jamais coupée.
- Pause automatique de la vidéo en changeant de slide ou en fermant la lightbox.

## Test plan
- [x] `npm test` — 71 tests JS passent (dont 11 nouveaux sur la lecture vidéo)
- [x] `./vendor/bin/phpunit` — 503 tests passent
- [x] Tests fonctionnels ajoutés vérifiant `data-media-type` dans le HTML rendu (`/gallery` et `/albums/{id}`)