### PR TITLE
🔒 fix(security): exiger l'ownership réel à la création d'un Share

### DIFF
--- a/src/Security/ResourceLocator.php
+++ b/src/Security/ResourceLocator.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Share;
+use App\Interface\AlbumRepositoryInterface;
+use App\Interface\FileRepositoryInterface;
+use App\Interface\FolderRepositoryInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Résout une ressource polymorphe (resourceType + resourceId) vers son entité réelle.
+ *
+ * Point d'entrée unique pour traduire la paire (type, id) stockée sur `Share`
+ * en File|Folder|Album, sans dupliquer un `match` dans chaque appelant.
+ */
+final readonly class ResourceLocator
+{
+    public function __construct(
+        private FileRepositoryInterface $fileRepository,
+        private FolderRepositoryInterface $folderRepository,
+        private AlbumRepositoryInterface $albumRepository,
+    ) {}
+
+    public function locate(string $resourceType, Uuid $resourceId): File|Folder|Album
+    {
+        $resource = match ($resourceType) {
+            Share::RESOURCE_FILE   => $this->fileRepository->find($resourceId),
+            Share::RESOURCE_FOLDER => $this->folderRepository->find($resourceId),
+            Share::RESOURCE_ALBUM  => $this->albumRepository->findById($resourceId),
+            default => throw new NotFoundHttpException('Type de ressource inconnu.'),
+        };
+
+        return $resource ?? throw new NotFoundHttpException('Ressource introuvable.');
+    }
+}

--- a/src/State/ShareProcessor.php
+++ b/src/State/ShareProcessor.php
@@ -11,9 +11,11 @@ use ApiPlatform\Metadata\Post;
 use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\ShareOutput;
 use App\Entity\Share;
+use App\Entity\User;
 use App\Interface\ShareRepositoryInterface;
 use App\Interface\UserRepositoryInterface;
 use App\Security\OwnershipChecker;
+use App\Security\ResourceLocator;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -41,6 +43,7 @@ final class ShareProcessor implements ProcessorInterface
         private readonly ShareProvider $provider,
         private readonly Security $security,
         private readonly OwnershipChecker $ownershipChecker,
+        private readonly ResourceLocator $resourceLocator,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
@@ -81,6 +84,13 @@ final class ShareProcessor implements ProcessorInterface
         if (!in_array($permission, self::VALID_PERMISSIONS, true)) {
             throw new BadRequestHttpException('permission invalide. Valeurs acceptées : read, write.');
         }
+
+        if ($guest->getId()->equals($owner->getId())) {
+            throw new BadRequestHttpException('Vous ne pouvez pas partager une ressource avec vous-même.');
+        }
+
+        $resource = $this->resourceLocator->locate($resourceType, Uuid::fromString($resourceId));
+        $this->ownershipChecker->denyUnlessOwner($resource);
 
         $expiresAt = null;
         if (!empty($data->expiresAt)) {

--- a/tests/Api/ShareTest.php
+++ b/tests/Api/ShareTest.php
@@ -202,6 +202,93 @@ final class ShareTest extends AuthenticatedApiTestCase
         $this->assertResponseStatusCodeSame(400);
     }
 
+    public function testCreateShareFailsIfNotResourceOwner(): void
+    {
+        // Alice (JWT courant) tente de partager un fichier qui appartient à Bob.
+        $bob  = $this->createGuest();
+        $file = $this->createFile($bob);
+        $stranger = $this->createUser('stranger@example.com', 'password123', 'Stranger');
+        $this->em->flush();
+
+        $this->createAuthenticatedClient()->request('POST', '/api/v1/shares', [
+            'json' => [
+                'guestId'      => $stranger->getId()->toRfc4122(),
+                'resourceType' => 'file',
+                'resourceId'   => $file->getId()->toRfc4122(),
+                'permission'   => 'read',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testCreateShareFailsIfNotFolderOwner(): void
+    {
+        $bob    = $this->createGuest();
+        $folder = $this->createFolder('Bob Folder', $bob, null, $this->em);
+
+        $this->createAuthenticatedClient()->request('POST', '/api/v1/shares', [
+            'json' => [
+                'guestId'      => $bob->getId()->toRfc4122(),
+                'resourceType' => 'folder',
+                'resourceId'   => $folder->getId()->toRfc4122(),
+                'permission'   => 'read',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testCreateShareFailsIfNotAlbumOwner(): void
+    {
+        $bob   = $this->createGuest();
+        $album = $this->createAlbum($bob);
+
+        $this->createAuthenticatedClient()->request('POST', '/api/v1/shares', [
+            'json' => [
+                'guestId'      => $bob->getId()->toRfc4122(),
+                'resourceType' => 'album',
+                'resourceId'   => $album->getId()->toRfc4122(),
+                'permission'   => 'read',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testCreateShareFailsIfResourceNotFound(): void
+    {
+        $guest = $this->createGuest();
+
+        $this->createAuthenticatedClient()->request('POST', '/api/v1/shares', [
+            'json' => [
+                'guestId'      => $guest->getId()->toRfc4122(),
+                'resourceType' => 'file',
+                'resourceId'   => Uuid::v7()->toRfc4122(),
+                'permission'   => 'read',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testCreateShareFailsIfGuestIsSelf(): void
+    {
+        $owner = $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
+        $file  = $this->createFile($owner);
+
+        $this->createAuthenticatedClient()->request('POST', '/api/v1/shares', [
+            'json' => [
+                'guestId'      => $owner->getId()->toRfc4122(),
+                'resourceType' => 'file',
+                'resourceId'   => $file->getId()->toRfc4122(),
+                'permission'   => 'read',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
     // ─── GET /api/v1/shares ─────────────────────────────────────────────────
 
     public function testGetCollectionAsOwner(): void


### PR DESCRIPTION
## Résumé
- **Faille critique corrigée** : `ShareProcessor::handlePost()` validait le format de `resourceId` mais ne vérifiait ni son existence ni sa propriété réelle. N'importe quel compte authentifié pouvait créer un `Share` (lecture *ou écriture*) sur un fichier/dossier/album appartenant à un autre utilisateur, et se l'auto-attribuer.
- Ajoute `ResourceLocator` (résout `resourceType` + `resourceId` polymorphe vers l'entité réelle, 404 si absente) et appelle `OwnershipChecker::denyUnlessOwner()` avant toute création de partage (403 si non-owner).
- Rejette également le partage à soi-même (`owner === guest`, 400).
- Étape 1 de `feat-partage.md` — isolée, mergeable indépendamment du reste du chantier partage.

## Test plan
- [x] 5 nouveaux tests RED→GREEN : `testCreateShareFailsIfNotResourceOwner` (file/folder/album), `testCreateShareFailsIfResourceNotFound`, `testCreateShareFailsIfGuestIsSelf`
- [x] Les 18 tests `ShareTest.php` existants restent verts (alice partage bien ses propres ressources, comportement inchangé)
- [x] Suite complète : 508 tests PHP passent