### PR TITLE
✨ feat(security): unifier owner/share sous ResourceAccessChecker

### DIFF
--- a/src/Controller/FileDownloadController.php
+++ b/src/Controller/FileDownloadController.php
@@ -8,7 +8,7 @@ use App\Entity\Share;
 use App\Entity\User;
 use App\Repository\FileRepository;
 use App\Interface\StorageServiceInterface;
-use App\Security\ShareAccessChecker;
+use App\Security\ResourceAccessChecker;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
@@ -25,9 +25,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
  *
  * Sécurité :
  * - Le propriétaire du fichier peut toujours le télécharger ; un autre utilisateur
- *   ne le peut que s'il bénéficie d'un partage actif (ShareAccessChecker), sur le
- *   même modèle que FileProvider (item GET) — même logique, même contrôleur qui
- *   n'y était pas encore aligné.
+ *   ne le peut que s'il bénéficie d'un partage actif (ResourceAccessChecker), sur le
+ *   même modèle que FileProvider (item GET).
  * - Les fichiers ordinaires sont stockés en clair ; les fichiers neutralisés sont stockés
  *   en .bin avec leur contenu d'origine intact. Dans les deux cas, le fichier est streamé
  *   directement — aucun déchiffrement nécessaire.
@@ -43,7 +42,7 @@ final class FileDownloadController extends AbstractController
     public function __construct(
         private readonly FileRepository $fileRepository,
         private readonly StorageServiceInterface $storageService,
-        private readonly ShareAccessChecker $shareAccessChecker,
+        private readonly ResourceAccessChecker $resourceAccessChecker,
     ) {}
 
     #[Route('/api/v1/files/{id}/download', name: 'file_download', methods: ['GET'])]
@@ -54,8 +53,7 @@ final class FileDownloadController extends AbstractController
 
         /** @var User $user */
         $user = $this->getUser();
-        if (!$file->getOwner()->getId()->equals($user->getId())
-            && !$this->shareAccessChecker->canAccess($user, Share::RESOURCE_FILE, $file->getId())) {
+        if (!$this->resourceAccessChecker->canRead($user, Share::RESOURCE_FILE, $file->getId(), $file->getOwner())) {
             throw $this->createAccessDeniedException('Vous ne pouvez pas télécharger ce fichier.');
         }
 

--- a/src/Controller/MediaThumbnailController.php
+++ b/src/Controller/MediaThumbnailController.php
@@ -8,7 +8,7 @@ use App\Entity\Share;
 use App\Entity\User;
 use App\Repository\MediaRepository;
 use App\Interface\StorageServiceInterface;
-use App\Security\ShareAccessChecker;
+use App\Security\ResourceAccessChecker;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -43,7 +43,7 @@ final class MediaThumbnailController extends AbstractController
     public function __construct(
         private readonly MediaRepository $mediaRepository,
         private readonly StorageServiceInterface $storageService,
-        private readonly ShareAccessChecker $shareAccessChecker,
+        private readonly ResourceAccessChecker $resourceAccessChecker,
     ) {}
 
     #[Route('/api/v1/medias/{id}/thumbnail', name: 'media_thumbnail', methods: ['GET'])]
@@ -54,8 +54,7 @@ final class MediaThumbnailController extends AbstractController
 
         /** @var User $user */
         $user = $this->getUser();
-        if (!$media->isOwnedBy($user)
-            && !$this->shareAccessChecker->canAccess($user, Share::RESOURCE_FILE, $media->getFile()->getId())) {
+        if (!$this->resourceAccessChecker->canRead($user, Share::RESOURCE_FILE, $media->getFile()->getId(), $media->getFile()->getOwner())) {
             throw $this->createAccessDeniedException('Vous ne pouvez pas voir ce média.');
         }
 

--- a/src/Interface/ResourceAccessCheckerInterface.php
+++ b/src/Interface/ResourceAccessCheckerInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\User;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Contrat unifiant ownership et partage pour l'accès à une ressource.
+ * Respecte le Dependency Inversion Principle (SOLID D).
+ */
+interface ResourceAccessCheckerInterface
+{
+    public function canRead(User $user, string $resourceType, Uuid $resourceId, User $owner): bool;
+
+    public function canWrite(User $user, string $resourceType, Uuid $resourceId, User $owner): bool;
+}

--- a/src/Interface/ShareAccessCheckerInterface.php
+++ b/src/Interface/ShareAccessCheckerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\User;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Contrat de vérification d'accès via partage (Share) actif.
+ * Respecte le Dependency Inversion Principle (SOLID D).
+ */
+interface ShareAccessCheckerInterface
+{
+    public function canAccess(User $user, string $resourceType, Uuid $resourceId, string $permission = 'read'): bool;
+}

--- a/src/Security/ResourceAccessChecker.php
+++ b/src/Security/ResourceAccessChecker.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Entity\Share;
+use App\Entity\User;
+use App\Interface\ResourceAccessCheckerInterface;
+use App\Interface\ShareAccessCheckerInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Source de vérité unique pour l'accès à une ressource : owner OU partage actif.
+ *
+ * Centralise la logique auparavant dupliquée dans FileProvider, AlbumProvider,
+ * MediaProvider, FileDownloadController et MediaThumbnailController.
+ *
+ * Pas de cache : ShareAccessChecker::canAccess() rejoue la requête à chaque
+ * appel, donc révocation et expiration d'un Share sont effectives immédiatement.
+ */
+final readonly class ResourceAccessChecker implements ResourceAccessCheckerInterface
+{
+    public function __construct(
+        private ShareAccessCheckerInterface $shareAccessChecker,
+    ) {}
+
+    public function canRead(User $user, string $resourceType, Uuid $resourceId, User $owner): bool
+    {
+        return $owner->getId()->equals($user->getId())
+            || $this->shareAccessChecker->canAccess($user, $resourceType, $resourceId, Share::PERMISSION_READ);
+    }
+
+    public function canWrite(User $user, string $resourceType, Uuid $resourceId, User $owner): bool
+    {
+        return $owner->getId()->equals($user->getId())
+            || $this->shareAccessChecker->canAccess($user, $resourceType, $resourceId, Share::PERMISSION_WRITE);
+    }
+}

--- a/src/Security/ShareAccessChecker.php
+++ b/src/Security/ShareAccessChecker.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace App\Security;
 
 use App\Entity\User;
+use App\Interface\ShareAccessCheckerInterface;
 use App\Repository\ShareRepository;
 use Symfony\Component\Uid\Uuid;
 
 /**
  * Vérifie si un utilisateur a accès à une ressource via un partage actif.
  */
-final class ShareAccessChecker
+final class ShareAccessChecker implements ShareAccessCheckerInterface
 {
     public function __construct(
         private readonly ShareRepository $shareRepository,

--- a/src/State/AlbumProvider.php
+++ b/src/State/AlbumProvider.php
@@ -13,7 +13,7 @@ use App\Entity\Album;
 use App\Entity\Share;
 use App\Entity\User;
 use App\Repository\AlbumRepository;
-use App\Security\ShareAccessChecker;
+use App\Security\ResourceAccessChecker;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
@@ -30,7 +30,7 @@ final class AlbumProvider implements ProviderInterface
         private readonly AlbumRepository $repository,
         private readonly Pagination $pagination,
         private readonly Security $security,
-        private readonly ShareAccessChecker $shareAccessChecker,
+        private readonly ResourceAccessChecker $resourceAccessChecker,
     ) {}
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
@@ -47,8 +47,7 @@ final class AlbumProvider implements ProviderInterface
                 return null;
             }
 
-            if (!$album->isOwnedBy($currentUser)
-                && !$this->shareAccessChecker->canAccess($currentUser, Share::RESOURCE_ALBUM, $album->getId())) {
+            if (!$this->resourceAccessChecker->canRead($currentUser, Share::RESOURCE_ALBUM, $album->getId(), $album->getOwner())) {
                 throw new AccessDeniedHttpException();
             }
 

--- a/src/State/FileProvider.php
+++ b/src/State/FileProvider.php
@@ -14,7 +14,7 @@ use App\Entity\File;
 use App\Entity\User;
 use App\Repository\FileRepository;
 use App\Repository\FolderRepository;
-use App\Security\ShareAccessChecker;
+use App\Security\ResourceAccessChecker;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -39,7 +39,7 @@ final class FileProvider implements ProviderInterface
         private readonly RequestStack $requestStack,
         private readonly Pagination $pagination,
         private readonly Security $security,
-        private readonly ShareAccessChecker $shareAccessChecker,
+        private readonly ResourceAccessChecker $resourceAccessChecker,
     ) {}
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
@@ -52,10 +52,9 @@ final class FileProvider implements ProviderInterface
 
             /** @var User|null $currentUser */
             $currentUser = $this->security->getUser();
-            if ($operation instanceof Get && $currentUser !== null && $currentUser->getId() != $file->getOwner()->getId()) {
-                if (!$this->shareAccessChecker->canAccess($currentUser, 'file', $file->getId())) {
-                    throw new AccessDeniedHttpException();
-                }
+            if ($operation instanceof Get && $currentUser !== null
+                && !$this->resourceAccessChecker->canRead($currentUser, 'file', $file->getId(), $file->getOwner())) {
+                throw new AccessDeniedHttpException();
             }
 
             return $this->toOutput($file);

--- a/src/State/MediaProvider.php
+++ b/src/State/MediaProvider.php
@@ -11,7 +11,7 @@ use App\Entity\Media;
 use App\Entity\Share;
 use App\Entity\User;
 use App\Repository\MediaRepository;
-use App\Security\ShareAccessChecker;
+use App\Security\ResourceAccessChecker;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -35,7 +35,7 @@ final class MediaProvider implements ProviderInterface
         private readonly MediaRepository $repository,
         private readonly RequestStack $requestStack,
         private readonly Security $security,
-        private readonly ShareAccessChecker $shareAccessChecker,
+        private readonly ResourceAccessChecker $resourceAccessChecker,
     ) {}
 
     /** @return MediaOutput|MediaOutput[]|null */
@@ -51,8 +51,7 @@ final class MediaProvider implements ProviderInterface
             $media = $this->repository->find(Uuid::fromString($uriVariables['id']))
                 ?? throw new NotFoundHttpException('Media not found');
 
-            if (!$media->isOwnedBy($currentUser)
-                && !$this->shareAccessChecker->canAccess($currentUser, Share::RESOURCE_FILE, $media->getFile()->getId())) {
+            if (!$this->resourceAccessChecker->canRead($currentUser, Share::RESOURCE_FILE, $media->getFile()->getId(), $media->getFile()->getOwner())) {
                 throw new AccessDeniedHttpException();
             }
 

--- a/tests/Unit/Security/ResourceAccessCheckerTest.php
+++ b/tests/Unit/Security/ResourceAccessCheckerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Entity\Share;
+use App\Entity\User;
+use App\Interface\ShareAccessCheckerInterface;
+use App\Security\ResourceAccessChecker;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class ResourceAccessCheckerTest extends TestCase
+{
+    private function makeUser(): User
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(Uuid::v7());
+
+        return $user;
+    }
+
+    public function testOwnerCanReadAndWrite(): void
+    {
+        $owner = $this->makeUser();
+        $shareAccessChecker = $this->createMock(ShareAccessCheckerInterface::class);
+        $shareAccessChecker->expects($this->never())->method('canAccess');
+
+        $checker = new ResourceAccessChecker($shareAccessChecker);
+
+        $this->assertTrue($checker->canRead($owner, Share::RESOURCE_FILE, Uuid::v7(), $owner));
+        $this->assertTrue($checker->canWrite($owner, Share::RESOURCE_FILE, Uuid::v7(), $owner));
+    }
+
+    public function testGuestWithReadShareCanReadButNotWrite(): void
+    {
+        $owner = $this->makeUser();
+        $guest = $this->makeUser();
+        $resourceId = Uuid::v7();
+
+        $shareAccessChecker = $this->createMock(ShareAccessCheckerInterface::class);
+        $shareAccessChecker->method('canAccess')
+            ->willReturnCallback(fn (User $u, string $type, Uuid $id, string $perm) => $perm === Share::PERMISSION_READ);
+
+        $checker = new ResourceAccessChecker($shareAccessChecker);
+
+        $this->assertTrue($checker->canRead($guest, Share::RESOURCE_FILE, $resourceId, $owner));
+        $this->assertFalse($checker->canWrite($guest, Share::RESOURCE_FILE, $resourceId, $owner));
+    }
+
+    public function testGuestWithWriteShareCanReadAndWrite(): void
+    {
+        $owner = $this->makeUser();
+        $guest = $this->makeUser();
+        $resourceId = Uuid::v7();
+
+        $shareAccessChecker = $this->createMock(ShareAccessCheckerInterface::class);
+        $shareAccessChecker->method('canAccess')->willReturn(true);
+
+        $checker = new ResourceAccessChecker($shareAccessChecker);
+
+        $this->assertTrue($checker->canRead($guest, Share::RESOURCE_FILE, $resourceId, $owner));
+        $this->assertTrue($checker->canWrite($guest, Share::RESOURCE_FILE, $resourceId, $owner));
+    }
+
+    public function testGuestWithoutShareCannotReadOrWrite(): void
+    {
+        $owner = $this->makeUser();
+        $guest = $this->makeUser();
+        $resourceId = Uuid::v7();
+
+        $shareAccessChecker = $this->createMock(ShareAccessCheckerInterface::class);
+        $shareAccessChecker->method('canAccess')->willReturn(false);
+
+        $checker = new ResourceAccessChecker($shareAccessChecker);
+
+        $this->assertFalse($checker->canRead($guest, Share::RESOURCE_FILE, $resourceId, $owner));
+        $this->assertFalse($checker->canWrite($guest, Share::RESOURCE_FILE, $resourceId, $owner));
+    }
+
+    public function testExpiredShareDeniesReadAndWrite(): void
+    {
+        // ShareAccessChecker::canAccess encapsule déjà le filtre d'expiration
+        // (findActiveShare) : un share expiré doit se comporter comme "aucun share".
+        $owner = $this->makeUser();
+        $guest = $this->makeUser();
+        $resourceId = Uuid::v7();
+
+        $shareAccessChecker = $this->createMock(ShareAccessCheckerInterface::class);
+        $shareAccessChecker->method('canAccess')->willReturn(false);
+
+        $checker = new ResourceAccessChecker($shareAccessChecker);
+
+        $this->assertFalse($checker->canRead($guest, Share::RESOURCE_FILE, $resourceId, $owner));
+        $this->assertFalse($checker->canWrite($guest, Share::RESOURCE_FILE, $resourceId, $owner));
+    }
+}


### PR DESCRIPTION
## Résumé
- Étape 2 de `feat-partage.md` — socle technique, zéro changement fonctionnel.
- La logique « owner OR share actif » était dupliquée avec des variantes légèrement différentes dans 5 fichiers (`FileProvider`, `AlbumProvider`, `MediaProvider`, `FileDownloadController`, `MediaThumbnailController`).
- `ResourceAccessChecker::canRead/canWrite` centralise désormais cette décision. Pas de cache : la révocation/expiration d'un partage reste effective immédiatement.
- `ShareAccessCheckerInterface` introduite (la classe concrète est `final`, non mockable directement) pour permettre les tests unitaires.

## Test plan
- [x] 5 nouveaux tests unitaires `ResourceAccessCheckerTest` (owner, guest read, guest write, sans share, share expiré)
- [x] Suite complète : 513 tests passent — comportement strictement identique aux 5 appelants migrés (aucune régression)