### PR TITLE
🔒 fix(security): protéger la lecture d'un dossier par ownership/partage

### DIFF
--- a/src/State/FolderProvider.php
+++ b/src/State/FolderProvider.php
@@ -10,8 +10,11 @@ use ApiPlatform\State\Pagination\TraversablePaginator;
 use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\FolderOutput;
 use App\Entity\Folder;
+use App\Entity\Share;
 use App\Repository\FolderRepository;
 use App\Security\AuthenticationResolver;
+use App\Security\ResourceAccessChecker;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
  * Fournit les données lues pour les opérations GET sur la ressource Folder.
@@ -31,6 +34,7 @@ final class FolderProvider implements ProviderInterface
         private readonly FolderRepository $repository,
         private readonly Pagination $pagination,
         private readonly AuthenticationResolver $authResolver,
+        private readonly ResourceAccessChecker $resourceAccessChecker,
     ) {}
 
     /**
@@ -41,9 +45,18 @@ final class FolderProvider implements ProviderInterface
     {
         if (isset($uriVariables['id'])) {
             $folder = $this->repository->find($uriVariables['id']);
+            if ($folder === null) {
+                // null → API Platform répond automatiquement 404
+                return null;
+            }
 
-            // null → API Platform répond automatiquement 404
-            return $folder ? $this->toOutput($folder) : null;
+            $currentUser = $this->authResolver->getAuthenticatedUser();
+            if ($currentUser === null
+                || !$this->resourceAccessChecker->canRead($currentUser, Share::RESOURCE_FOLDER, $folder->getId(), $folder->getOwner())) {
+                throw new AccessDeniedHttpException();
+            }
+
+            return $this->toOutput($folder);
         }
 
         [$page, $offset, $limit] = $this->pagination->getPagination($operation, $context);

--- a/tests/Api/ShareTest.php
+++ b/tests/Api/ShareTest.php
@@ -483,4 +483,51 @@ final class ShareTest extends AuthenticatedApiTestCase
 
         $this->assertResponseStatusCodeSame(403);
     }
+
+    // ─── Accès guest sur Folder ──────────────────────────────────────────────
+
+    public function testGuestCanAccessSharedFolder(): void
+    {
+        $owner  = $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
+        $guest  = $this->createGuest();
+        $folder = $this->createFolder('Shared Folder', $owner, null, $this->em);
+        $share  = new Share($owner, $guest, 'folder', $folder->getId(), 'read');
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $response = $this->createAuthenticatedClient('bob@example.com')->request('GET', '/api/v1/folders/' . $folder->getId()->toRfc4122(), [
+            'headers' => ['Accept' => 'application/json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(200);
+    }
+
+    public function testGuestCannotAccessFolderWithoutShare(): void
+    {
+        $owner  = $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
+        $this->createGuest();
+        $folder = $this->createFolder('Private Folder', $owner, null, $this->em);
+
+        $response = $this->createAuthenticatedClient('bob@example.com')->request('GET', '/api/v1/folders/' . $folder->getId()->toRfc4122(), [
+            'headers' => ['Accept' => 'application/json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testExpiredFolderShareDeniesAccess(): void
+    {
+        $owner  = $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
+        $guest  = $this->createGuest();
+        $folder = $this->createFolder('Shared Folder', $owner, null, $this->em);
+        $share  = new Share($owner, $guest, 'folder', $folder->getId(), 'read', new \DateTimeImmutable('-1 day'));
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $response = $this->createAuthenticatedClient('bob@example.com')->request('GET', '/api/v1/folders/' . $folder->getId()->toRfc4122(), [
+            'headers' => ['Accept' => 'application/json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
 }


### PR DESCRIPTION
## Résumé
- Étape 3 de `feat-partage.md`.
- **Trou de sécurité découvert en cours de route** (plus large que prévu) : `FolderProvider::provide()` ne vérifiait aucune ownership sur `GET /folders/{id}` — seule la collection était filtrée par propriétaire. N'importe quel utilisateur authentifié pouvait lire les métadonnées de n'importe quel dossier d'un autre utilisateur, partage ou non.
- Ajoute la vérification via `ResourceAccessChecker::canRead` (owner ou partage `folder` actif) — dernier des 4 providers (File/Folder/Album/Media) à en être dépourvu.

## Test plan
- [x] `testGuestCanAccessSharedFolder`, `testGuestCannotAccessFolderWithoutShare`, `testExpiredFolderShareDeniesAccess`
- [x] Suite complète : 516 tests passent