### PR TITLE
✨ feat(security): rendre les albums partagés visibles côté web

### DIFF
--- a/src/Security/AlbumVoter.php
+++ b/src/Security/AlbumVoter.php
@@ -5,17 +5,19 @@ declare(strict_types=1);
 namespace App\Security;
 
 use App\Entity\Album;
+use App\Entity\Share;
 use App\Entity\User;
+use App\Interface\ResourceAccessCheckerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
 /**
- * Voter Symfony pour les droits sur les albums (SRP — ownership centralisé).
+ * Voter Symfony pour les droits sur les albums.
  *
- * Responsabilité unique : vérifier si l'utilisateur connecté est propriétaire
- * de l'album pour les attributs ALBUM_VIEW et ALBUM_DELETE.
- *
- * Remplace les doubles ownership checks inline dans AlbumWebController.
+ * ALBUM_VIEW : owner OU partage actif (read ou write) — délégué à
+ * ResourceAccessChecker, seule source de vérité owner/share.
+ * ALBUM_DELETE : owner uniquement — un guest write agit dans l'album
+ * (ajoute/retire des médias), il ne le détruit pas.
  *
  * @extends Voter<'ALBUM_VIEW'|'ALBUM_DELETE', Album>
  */
@@ -23,6 +25,10 @@ final class AlbumVoter extends Voter
 {
     public const VIEW   = 'ALBUM_VIEW';
     public const DELETE = 'ALBUM_DELETE';
+
+    public function __construct(
+        private readonly ResourceAccessCheckerInterface $resourceAccessChecker,
+    ) {}
 
     protected function supports(string $attribute, mixed $subject): bool
     {
@@ -38,6 +44,9 @@ final class AlbumVoter extends Voter
         }
 
         /** @var Album $subject */
-        return $subject->getOwner()->getId()->equals($user->getId());
+        return match ($attribute) {
+            self::VIEW   => $this->resourceAccessChecker->canRead($user, Share::RESOURCE_ALBUM, $subject->getId(), $subject->getOwner()),
+            self::DELETE => $subject->getOwner()->getId()->equals($user->getId()),
+        };
     }
 }

--- a/tests/Unit/Security/AlbumVoterTest.php
+++ b/tests/Unit/Security/AlbumVoterTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Entity\Album;
+use App\Entity\User;
+use App\Interface\ResourceAccessCheckerInterface;
+use App\Security\AlbumVoter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Uid\Uuid;
+
+final class AlbumVoterTest extends TestCase
+{
+    private function makeUser(): User
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(Uuid::v7());
+
+        return $user;
+    }
+
+    private function makeAlbum(User $owner): Album
+    {
+        $album = $this->createMock(Album::class);
+        $album->method('getId')->willReturn(Uuid::v7());
+        $album->method('getOwner')->willReturn($owner);
+
+        return $album;
+    }
+
+    private function tokenFor(User $user): TokenInterface
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUser')->willReturn($user);
+
+        return $token;
+    }
+
+    public function testOwnerCanViewAlbum(): void
+    {
+        $owner = $this->makeUser();
+        $album = $this->makeAlbum($owner);
+
+        $resourceAccessChecker = $this->createMock(ResourceAccessCheckerInterface::class);
+        $resourceAccessChecker->method('canRead')->willReturn(true);
+
+        $voter = new AlbumVoter($resourceAccessChecker);
+
+        $this->assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->tokenFor($owner), $album, [AlbumVoter::VIEW])
+        );
+    }
+
+    public function testGuestWithActiveShareCanViewAlbum(): void
+    {
+        $owner = $this->makeUser();
+        $guest = $this->makeUser();
+        $album = $this->makeAlbum($owner);
+
+        $resourceAccessChecker = $this->createMock(ResourceAccessCheckerInterface::class);
+        $resourceAccessChecker->method('canRead')->willReturn(true);
+
+        $voter = new AlbumVoter($resourceAccessChecker);
+
+        $this->assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->tokenFor($guest), $album, [AlbumVoter::VIEW])
+        );
+    }
+
+    public function testGuestWithoutShareCannotViewAlbum(): void
+    {
+        $owner = $this->makeUser();
+        $guest = $this->makeUser();
+        $album = $this->makeAlbum($owner);
+
+        $resourceAccessChecker = $this->createMock(ResourceAccessCheckerInterface::class);
+        $resourceAccessChecker->method('canRead')->willReturn(false);
+
+        $voter = new AlbumVoter($resourceAccessChecker);
+
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->tokenFor($guest), $album, [AlbumVoter::VIEW])
+        );
+    }
+
+    public function testGuestWithExpiredShareCannotViewAlbum(): void
+    {
+        // ResourceAccessChecker::canRead encapsule déjà l'expiration (ShareAccessChecker) :
+        // un share expiré doit se comporter exactement comme "aucun share".
+        $owner = $this->makeUser();
+        $guest = $this->makeUser();
+        $album = $this->makeAlbum($owner);
+
+        $resourceAccessChecker = $this->createMock(ResourceAccessCheckerInterface::class);
+        $resourceAccessChecker->method('canRead')->willReturn(false);
+
+        $voter = new AlbumVoter($resourceAccessChecker);
+
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->tokenFor($guest), $album, [AlbumVoter::VIEW])
+        );
+    }
+
+    public function testGuestWithWriteShareCannotDeleteAlbum(): void
+    {
+        // ALBUM_DELETE reste owner-only : un guest write agit dans l'album,
+        // il ne le détruit pas (arbitrage §3.3 de feat-partage.md).
+        $owner = $this->makeUser();
+        $guest = $this->makeUser();
+        $album = $this->makeAlbum($owner);
+
+        $resourceAccessChecker = $this->createMock(ResourceAccessCheckerInterface::class);
+        $resourceAccessChecker->method('canRead')->willReturn(true);
+        $resourceAccessChecker->method('canWrite')->willReturn(true);
+
+        $voter = new AlbumVoter($resourceAccessChecker);
+
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->tokenFor($guest), $album, [AlbumVoter::DELETE])
+        );
+    }
+
+    public function testOwnerCanDeleteAlbum(): void
+    {
+        $owner = $this->makeUser();
+        $album = $this->makeAlbum($owner);
+
+        $resourceAccessChecker = $this->createMock(ResourceAccessCheckerInterface::class);
+
+        $voter = new AlbumVoter($resourceAccessChecker);
+
+        $this->assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->tokenFor($owner), $album, [AlbumVoter::DELETE])
+        );
+    }
+}

--- a/tests/Web/AlbumWebTest.php
+++ b/tests/Web/AlbumWebTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Web;
 
 use App\Entity\Album;
+use App\Entity\Share;
 use App\Entity\User;
 use App\Tests\Web\Fixtures\WebFixturesTrait;
 use Doctrine\ORM\EntityManagerInterface;
@@ -725,5 +726,66 @@ final class AlbumWebTest extends WebTestCase
 
         $this->client->request('GET', '/albums/' . $album->getId()->toRfc4122());
         $this->assertSelectorExists('[data-testid="lightbox-slideshow-toggle"]');
+    }
+
+    // --- Partage ---
+
+    public function testGuestWithActiveShareCanViewAlbumDetail(): void
+    {
+        $owner = $this->createUser('owner@example.com');
+        $guest = $this->createUser('guest@example.com');
+        $album = $this->createAlbum($owner, 'Vacances partagées');
+        $share = new Share($owner, $guest, 'album', $album->getId(), 'read');
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $this->login('guest@example.com');
+
+        $this->client->request('GET', '/albums/' . $album->getId()->toRfc4122());
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testGuestWithoutShareCannotViewAlbumDetail(): void
+    {
+        $owner = $this->createUser('owner@example.com');
+        $this->createUser('guest@example.com');
+        $album = $this->createAlbum($owner, 'Album privé');
+        $this->em->flush();
+
+        $this->login('guest@example.com');
+
+        $this->client->request('GET', '/albums/' . $album->getId()->toRfc4122());
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testGuestWithExpiredShareCannotViewAlbumDetail(): void
+    {
+        $owner = $this->createUser('owner@example.com');
+        $guest = $this->createUser('guest@example.com');
+        $album = $this->createAlbum($owner, 'Album expiré');
+        $share = new Share($owner, $guest, 'album', $album->getId(), 'read', new \DateTimeImmutable('-1 day'));
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $this->login('guest@example.com');
+
+        $this->client->request('GET', '/albums/' . $album->getId()->toRfc4122());
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testGuestWithWriteShareCannotDeleteAlbum(): void
+    {
+        $owner = $this->createUser('owner@example.com');
+        $guest = $this->createUser('guest@example.com');
+        $album = $this->createAlbum($owner, 'Album protégé');
+        $share = new Share($owner, $guest, 'album', $album->getId(), 'write');
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $this->login('guest@example.com');
+        $token = $this->csrfTokenFrom('/albums/' . $album->getId()->toRfc4122(), 'form[action*="/delete"] input[name="_token"]');
+
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/delete', ['_token' => $token]);
+        $this->assertResponseStatusCodeSame(403);
     }
 }


### PR DESCRIPTION
## Résumé
- Étape 4 de `feat-partage.md` (partie Album — FileVoter reporté, voir ci-dessous).
- `AlbumVoter` ignorait totalement `Share` (ownership pur) — un guest avec un partage album actif recevait 403 sur toutes les vues web (détail, add/remove media, reorder, import). Le partage d'album était donc fonctionnel côté API mais invisible côté UI.
- `ALBUM_VIEW` délègue désormais à `ResourceAccessChecker::canRead` (owner ou partage actif read/write).
- `ALBUM_DELETE` reste owner-only (arbitrage déjà tranché dans le plan) : un guest write agit dans l'album, il ne le détruit pas.
- `FileVoter` (prévu par le plan) **non créé** : aucune vue web File individuelle n'existe encore pour le consommer — l'accès web aux fichiers passe par `/gallery/{id}`, déjà protégé. Il sera ajouté quand une vue File dédiée existera, pour éviter du code sans appelant.

## Test plan
- [x] 6 tests unitaires `AlbumVoterTest` (owner, guest share actif, sans share, share expiré, guest write ne peut pas delete, owner peut delete)
- [x] 4 tests web fonctionnels `AlbumWebTest` (accès détail avec/sans partage, partage expiré, guest write refusé sur delete)
- [x] Suite complète : 526 tests passent