### PR TITLE
✨ feat(security): rendre la permission write effective sur File

### DIFF
--- a/src/State/FileProcessor.php
+++ b/src/State/FileProcessor.php
@@ -9,16 +9,18 @@ use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\FileOutput;
+use App\Entity\Share;
 use App\Interface\DefaultFolderServiceInterface;
-use App\Interface\OwnershipCheckerInterface;
 use App\Repository\FileRepository;
 use App\Repository\MediaRepository;
 use App\Security\AuthenticationResolver;
+use App\Security\ResourceAccessChecker;
 use App\Service\FileActionService;
 use App\Service\IriExtractor;
 use App\Interface\StorageServiceInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -42,7 +44,7 @@ final class FileProcessor implements ProcessorInterface
         private readonly MediaRepository $mediaRepository,
         private readonly StorageServiceInterface $storageService,
         private readonly AuthenticationResolver $authResolver,
-        private readonly OwnershipCheckerInterface $ownershipChecker,
+        private readonly ResourceAccessChecker $resourceAccessChecker,
         private readonly DefaultFolderServiceInterface $defaultFolderService,
         private readonly FileActionService $fileActionService,
         private readonly RequestStack $requestStack,
@@ -69,7 +71,10 @@ final class FileProcessor implements ProcessorInterface
         $file = $this->fileRepository->find($uriVariables['id'])
             ?? throw new NotFoundHttpException('File not found');
 
-        $this->ownershipChecker->denyUnlessOwner($file);
+        $user = $this->authResolver->requireUser();
+        if (!$this->resourceAccessChecker->canWrite($user, Share::RESOURCE_FILE, $file->getId(), $file->getOwner())) {
+            throw new AccessDeniedHttpException('You are not allowed to delete this File');
+        }
 
         // Supprimer le thumbnail du disque AVANT le cascade DB (onDelete: CASCADE supprime la ligne Media)
         $media = $this->mediaRepository->findOneBy(['file' => $file]);
@@ -93,6 +98,9 @@ final class FileProcessor implements ProcessorInterface
             ?? throw new NotFoundHttpException('File not found');
 
         $user = $this->authResolver->requireUser();
+        if (!$this->resourceAccessChecker->canWrite($user, Share::RESOURCE_FILE, $file->getId(), $file->getOwner())) {
+            throw new AccessDeniedHttpException('You are not allowed to modify this File');
+        }
 
         // Déléguez le renommage à FileActionService (validation)
         if ($data->originalName !== '') {

--- a/tests/Api/ShareTest.php
+++ b/tests/Api/ShareTest.php
@@ -530,4 +530,89 @@ final class ShareTest extends AuthenticatedApiTestCase
 
         $this->assertResponseStatusCodeSame(403);
     }
+
+    // ─── Permission write effective sur File ────────────────────────────────
+
+    public function testGuestWithWriteShareCanRenameFile(): void
+    {
+        $owner = $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
+        $guest = $this->createGuest();
+        $file  = $this->createFile($owner);
+        $share = new Share($owner, $guest, 'file', $file->getId(), 'write');
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $response = $this->createAuthenticatedClient('bob@example.com')->request('PATCH', '/api/v1/files/' . $file->getId()->toRfc4122(), [
+            'json'    => ['originalName' => 'renamed.jpg'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(200);
+    }
+
+    public function testGuestWithReadShareCannotRenameFile(): void
+    {
+        $owner = $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
+        $guest = $this->createGuest();
+        $file  = $this->createFile($owner);
+        $share = new Share($owner, $guest, 'file', $file->getId(), 'read');
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $response = $this->createAuthenticatedClient('bob@example.com')->request('PATCH', '/api/v1/files/' . $file->getId()->toRfc4122(), [
+            'json'    => ['originalName' => 'renamed.jpg'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testGuestWithWriteShareCanDeleteFile(): void
+    {
+        $owner = $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
+        $guest = $this->createGuest();
+        $file  = $this->createFile($owner);
+        $share = new Share($owner, $guest, 'file', $file->getId(), 'write');
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $this->createAuthenticatedClient('bob@example.com')->request('DELETE', '/api/v1/files/' . $file->getId()->toRfc4122());
+
+        $this->assertResponseStatusCodeSame(204);
+    }
+
+    public function testGuestWithReadShareCannotDeleteFile(): void
+    {
+        $owner = $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
+        $guest = $this->createGuest();
+        $file  = $this->createFile($owner);
+        $share = new Share($owner, $guest, 'file', $file->getId(), 'read');
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $this->createAuthenticatedClient('bob@example.com')->request('DELETE', '/api/v1/files/' . $file->getId()->toRfc4122());
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testGuestWithWriteShareCannotMoveFileOutOfScope(): void
+    {
+        // Anti-exfiltration (arbitrage §3.2 de feat-partage.md) : le move reste
+        // owner-only, même avec un partage write — déjà garanti par
+        // FileActionService::move() -> AuthorizationChecker::assertOwns().
+        $owner   = $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
+        $guest   = $this->createGuest();
+        $file    = $this->createFile($owner);
+        $share   = new Share($owner, $guest, 'file', $file->getId(), 'write');
+        $this->em->persist($share);
+        $guestFolder = $this->createFolder('Guest Folder', $guest, null, $this->em);
+        $this->em->flush();
+
+        $this->createAuthenticatedClient('bob@example.com')->request('PATCH', '/api/v1/files/' . $file->getId()->toRfc4122(), [
+            'json'    => ['targetFolderId' => $guestFolder->getId()->toRfc4122()],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
 }


### PR DESCRIPTION
## Résumé
- Étape 5 de `feat-partage.md`.
- `FileProcessor::handleDelete/handlePatch` appelaient `denyUnlessOwner()` en dur — un guest avec permission `write` sur un fichier partagé ne pouvait ni le renommer ni le supprimer. La permission `write` était donc totalement inerte.
- Remplacé par `ResourceAccessChecker::canWrite` (owner ou partage write actif).
- Le move reste owner-only **sans changement de code nécessaire** : `FileActionService::move()` → `AuthorizationChecker::assertOwns()` l'interdisait déjà à tout non-owner (anti-exfiltration déjà garantie, arbitrage §3.2).
- `AlbumProcessor` inchangé : aucune action API « ajout/retrait de média » n'existe côté API REST (gérée côté web, déjà couverte par `ALBUM_VIEW` du voter) — seuls rename/delete d'album existent et restent légitimement owner-only.

## Test plan
- [x] `testGuestWithWriteShareCanRenameFile` / `CanDeleteFile` → 200/204
- [x] `testGuestWithReadShareCannotRenameFile` / `CannotDeleteFile` → 403
- [x] `testGuestWithWriteShareCannotMoveFileOutOfScope` → 403 (anti-exfiltration)
- [x] Suite complète : 531 tests passent