### PR TITLE
🔒 fix(security): nettoyer les shares orphelins à la suppression

### DIFF
--- a/src/Controller/Web/FileWebController.php
+++ b/src/Controller/Web/FileWebController.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Controller\Web;
 
 use App\Entity\File;
+use App\Entity\Share;
 use App\Interface\StorageServiceInterface;
+use App\Interface\ShareRepositoryInterface;
 use App\Repository\FileRepository;
 use App\Interface\DefaultFolderServiceInterface;
 use Doctrine\ORM\EntityManagerInterface;
@@ -40,6 +42,7 @@ final class FileWebController extends AbstractController
         private readonly DefaultFolderServiceInterface $folderService,
         private readonly FileRepository $fileRepository,
         private readonly EntityManagerInterface $em,
+        private readonly ShareRepositoryInterface $shareRepository,
     ) {}
 
     #[Route('/files/{id}/download', name: 'app_file_download', methods: ['GET'])]
@@ -158,6 +161,7 @@ final class FileWebController extends AbstractController
             return $this->redirect($folderId ? '/explorer?folder=' . $folderId : '/explorer');
         }
 
+        $this->shareRepository->deleteByResource(Share::RESOURCE_FILE, $file->getId());
         $this->em->remove($file);
         $this->em->flush();
 

--- a/src/Interface/ShareRepositoryInterface.php
+++ b/src/Interface/ShareRepositoryInterface.php
@@ -23,4 +23,7 @@ interface ShareRepositoryInterface
     public function countByUser(User $user): int;
 
     public function findActiveShare(User $guest, string $resourceType, Uuid $resourceId, string $permission): ?Share;
+
+    /** Supprime tous les shares pointant vers cette ressource (nettoyage à la suppression). */
+    public function deleteByResource(string $resourceType, Uuid $resourceId): void;
 }

--- a/src/Repository/ShareRepository.php
+++ b/src/Repository/ShareRepository.php
@@ -75,6 +75,19 @@ class ShareRepository extends ServiceEntityRepository implements ShareRepository
         return $qb->getQuery()->getOneOrNullResult();
     }
 
+    /** Supprime tous les shares pointant vers cette ressource (nettoyage à la suppression). */
+    public function deleteByResource(string $resourceType, Uuid $resourceId): void
+    {
+        $this->createQueryBuilder('s')
+            ->delete()
+            ->where('s.resourceType = :type')
+            ->andWhere('s.resourceId = :rid')
+            ->setParameter('type', $resourceType)
+            ->setParameter('rid', $resourceId, 'uuid')
+            ->getQuery()
+            ->execute();
+    }
+
     /** Compte les shares actifs (non expirés) d'un owner. */
     public function countActiveByOwner(User $owner): int
     {

--- a/src/Service/AlbumService.php
+++ b/src/Service/AlbumService.php
@@ -6,10 +6,12 @@ namespace App\Service;
 
 use App\Entity\Album;
 use App\Entity\Media;
+use App\Entity\Share;
 use App\Entity\User;
 use App\Interface\AlbumRepositoryInterface;
 use App\Interface\AlbumServiceInterface;
 use App\Interface\MediaRepositoryInterface;
+use App\Interface\ShareRepositoryInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Uid\Uuid;
 
@@ -25,6 +27,7 @@ final class AlbumService implements AlbumServiceInterface
     public function __construct(
         private readonly AlbumRepositoryInterface $repository,
         private readonly MediaRepositoryInterface $mediaRepository,
+        private readonly ShareRepositoryInterface $shareRepository,
     ) {}
 
     /**
@@ -96,6 +99,7 @@ final class AlbumService implements AlbumServiceInterface
      */
     public function delete(Album $album): void
     {
+        $this->shareRepository->deleteByResource(Share::RESOURCE_ALBUM, $album->getId());
         $this->repository->remove($album);
     }
 

--- a/src/Service/FolderService.php
+++ b/src/Service/FolderService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service;
 
 use App\Entity\Folder;
+use App\Entity\Share;
 use App\Entity\User;
 use App\Enum\FolderMediaType;
 use App\Interface\AuthenticationResolverInterface;
@@ -12,6 +13,7 @@ use App\Interface\DefaultFolderServiceInterface;
 use App\Interface\FilenameValidatorInterface;
 use App\Interface\FolderRepositoryInterface;
 use App\Interface\OwnershipCheckerInterface;
+use App\Interface\ShareRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -42,6 +44,7 @@ final class FolderService
         private readonly EntityManagerInterface $em,
         private readonly LoggerInterface $logger,
         private readonly Stopwatch $stopwatch,
+        private readonly ShareRepositoryInterface $shareRepository,
     ) {}
 
     /**
@@ -191,13 +194,16 @@ final class FolderService
                 $desc = $this->folderRepository->find($descId);
                 if ($desc !== null) {
                     $this->em->refresh($desc);
+                    $this->shareRepository->deleteByResource(Share::RESOURCE_FOLDER, $desc->getId());
                     $this->em->remove($desc);
                 }
             }
             $this->em->refresh($folder);
+            $this->shareRepository->deleteByResource(Share::RESOURCE_FOLDER, $folder->getId());
             $this->em->remove($folder);
             $this->em->flush();
         } else {
+            $this->shareRepository->deleteByResource(Share::RESOURCE_FOLDER, $folder->getId());
             $this->em->remove($folder);
             $this->em->flush();
         }

--- a/src/State/AlbumProcessor.php
+++ b/src/State/AlbumProcessor.php
@@ -91,8 +91,7 @@ final class AlbumProcessor implements ProcessorInterface
         $album = $this->albumRepository->findById(Uuid::fromString((string) $uriVariables['id']))
             ?? throw new NotFoundHttpException('Album not found');
         $this->ownershipChecker->denyUnlessOwner($album);
-        $this->em->remove($album);
-        $this->em->flush();
+        $this->albumService->delete($album);
         return null;
     }
 }

--- a/src/State/FileProcessor.php
+++ b/src/State/FileProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\FileOutput;
 use App\Entity\Share;
 use App\Interface\DefaultFolderServiceInterface;
+use App\Interface\ShareRepositoryInterface;
 use App\Repository\FileRepository;
 use App\Repository\MediaRepository;
 use App\Security\AuthenticationResolver;
@@ -49,6 +50,7 @@ final class FileProcessor implements ProcessorInterface
         private readonly FileActionService $fileActionService,
         private readonly RequestStack $requestStack,
         private readonly IriExtractor $iriExtractor,
+        private readonly ShareRepositoryInterface $shareRepository,
     ) {}
 
     /**
@@ -83,6 +85,7 @@ final class FileProcessor implements ProcessorInterface
         }
 
         $this->storageService->delete($file->getPath());
+        $this->shareRepository->deleteByResource(Share::RESOURCE_FILE, $file->getId());
         $this->em->remove($file);
         $this->em->flush();
 

--- a/tests/Api/ShareTest.php
+++ b/tests/Api/ShareTest.php
@@ -615,4 +615,59 @@ final class ShareTest extends AuthenticatedApiTestCase
 
         $this->assertResponseStatusCodeSame(403);
     }
+
+    // ─── Nettoyage des shares orphelins à la suppression ────────────────────
+
+    public function testDeletingFileRemovesItsShares(): void
+    {
+        $owner = $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
+        $guest = $this->createGuest();
+        $file  = $this->createFile($owner);
+        $share = new Share($owner, $guest, 'file', $file->getId(), 'read');
+        $this->em->persist($share);
+        $this->em->flush();
+        $shareId = $share->getId();
+
+        $this->createAuthenticatedClient()->request('DELETE', '/api/v1/files/' . $file->getId()->toRfc4122());
+        $this->assertResponseStatusCodeSame(204);
+
+        $this->em->clear();
+        $this->assertNull($this->em->getRepository(Share::class)->find($shareId));
+    }
+
+    public function testDeletingAlbumRemovesItsShares(): void
+    {
+        $owner = $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
+        $guest = $this->createGuest();
+        $album = $this->createAlbum($owner);
+        $share = new Share($owner, $guest, 'album', $album->getId(), 'read');
+        $this->em->persist($share);
+        $this->em->flush();
+        $shareId = $share->getId();
+
+        $this->createAuthenticatedClient()->request('DELETE', '/api/v1/albums/' . $album->getId()->toRfc4122());
+        $this->assertResponseStatusCodeSame(204);
+
+        $this->em->clear();
+        $this->assertNull($this->em->getRepository(Share::class)->find($shareId));
+    }
+
+    public function testDeletingFolderRemovesItsShares(): void
+    {
+        $owner  = $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
+        $guest  = $this->createGuest();
+        $folder = $this->createFolder('To Delete', $owner, null, $this->em);
+        $share  = new Share($owner, $guest, 'folder', $folder->getId(), 'read');
+        $this->em->persist($share);
+        $this->em->flush();
+        $shareId = $share->getId();
+
+        $this->createAuthenticatedClient()->request('DELETE', '/api/v1/folders/' . $folder->getId()->toRfc4122(), [
+            'json' => ['deleteContents' => true],
+        ]);
+        $this->assertResponseStatusCodeSame(204);
+
+        $this->em->clear();
+        $this->assertNull($this->em->getRepository(Share::class)->find($shareId));
+    }
 }

--- a/tests/Repository/ShareRepositoryTest.php
+++ b/tests/Repository/ShareRepositoryTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Repository;
+
+use App\Entity\Share;
+use App\Entity\User;
+use App\Repository\ShareRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class ShareRepositoryTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private ShareRepository $repository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $this->repository = static::getContainer()->get(ShareRepository::class);
+
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM shares');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createUser(string $email): User
+    {
+        $user = new User($email, 'Test User');
+        $user->setPassword('irrelevant-hash');
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+
+    public function testDeleteByResourceRemovesMatchingShares(): void
+    {
+        $owner = $this->createUser('owner-share-repo@example.com');
+        $guest = $this->createUser('guest-share-repo@example.com');
+        $resourceId = Uuid::v7();
+
+        $share = new Share($owner, $guest, Share::RESOURCE_FOLDER, $resourceId, Share::PERMISSION_READ);
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $this->repository->deleteByResource(Share::RESOURCE_FOLDER, $resourceId);
+        $this->em->clear();
+
+        $this->assertNull($this->repository->find($share->getId()));
+    }
+
+    public function testDeleteByResourceLeavesOtherSharesIntact(): void
+    {
+        $owner = $this->createUser('owner-share-repo2@example.com');
+        $guest = $this->createUser('guest-share-repo2@example.com');
+        $targetResourceId = Uuid::v7();
+        $otherResourceId  = Uuid::v7();
+
+        $targetShare = new Share($owner, $guest, Share::RESOURCE_FOLDER, $targetResourceId, Share::PERMISSION_READ);
+        $otherShare  = new Share($owner, $guest, Share::RESOURCE_FOLDER, $otherResourceId, Share::PERMISSION_READ);
+        $this->em->persist($targetShare);
+        $this->em->persist($otherShare);
+        $this->em->flush();
+
+        $this->repository->deleteByResource(Share::RESOURCE_FOLDER, $targetResourceId);
+        $this->em->clear();
+
+        $this->assertNull($this->repository->find($targetShare->getId()));
+        $this->assertNotNull($this->repository->find($otherShare->getId()));
+    }
+}

--- a/tests/Service/AlbumServiceTest.php
+++ b/tests/Service/AlbumServiceTest.php
@@ -11,6 +11,7 @@ use App\Entity\Media;
 use App\Entity\User;
 use App\Interface\AlbumRepositoryInterface;
 use App\Interface\MediaRepositoryInterface;
+use App\Interface\ShareRepositoryInterface;
 use App\Service\AlbumService;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -26,12 +27,15 @@ final class AlbumServiceTest extends TestCase
     private AlbumRepositoryInterface $repository;
     /** @var MediaRepositoryInterface&MockObject */
     private MediaRepositoryInterface $mediaRepository;
+    /** @var ShareRepositoryInterface&MockObject */
+    private ShareRepositoryInterface $shareRepository;
 
     protected function setUp(): void
     {
         $this->repository = $this->createMock(AlbumRepositoryInterface::class);
         $this->mediaRepository = $this->createMock(MediaRepositoryInterface::class);
-        $this->service = new AlbumService($this->repository, $this->mediaRepository);
+        $this->shareRepository = $this->createMock(ShareRepositoryInterface::class);
+        $this->service = new AlbumService($this->repository, $this->mediaRepository, $this->shareRepository);
     }
 
     private function makeUser(): User

--- a/tests/Unit/Service/FolderServiceTest.php
+++ b/tests/Unit/Service/FolderServiceTest.php
@@ -13,6 +13,7 @@ use App\Interface\DefaultFolderServiceInterface;
 use App\Interface\FilenameValidatorInterface;
 use App\Interface\FolderRepositoryInterface;
 use App\Interface\OwnershipCheckerInterface;
+use App\Interface\ShareRepositoryInterface;
 use App\Service\FolderService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -41,6 +42,9 @@ final class FolderServiceTest extends TestCase
     /** @var EntityManagerInterface&MockObject */
     private EntityManagerInterface $em;
 
+    /** @var ShareRepositoryInterface&MockObject */
+    private ShareRepositoryInterface $shareRepository;
+
     private FolderService $service;
 
     protected function setUp(): void
@@ -51,6 +55,7 @@ final class FolderServiceTest extends TestCase
         $this->authResolver        = $this->createMock(AuthenticationResolverInterface::class);
         $this->defaultFolderService = $this->createMock(DefaultFolderServiceInterface::class);
         $this->em                  = $this->createMock(EntityManagerInterface::class);
+        $this->shareRepository     = $this->createMock(ShareRepositoryInterface::class);
 
         $this->service = new FolderService(
             folderRepository:     $this->folderRepository,
@@ -61,6 +66,7 @@ final class FolderServiceTest extends TestCase
             em:                   $this->em,
             logger:               $this->createMock(LoggerInterface::class),
             stopwatch:            new Stopwatch(),
+            shareRepository:      $this->shareRepository,
         );
     }
 


### PR DESCRIPTION
## Résumé
- Étape 6 de `feat-partage.md`.
- `Share` référence ses ressources par `(resourceType, resourceId)` sans FK (choix assumé du modèle, pas de dépendance Doctrine sur une union polymorphe) — supprimer un fichier/dossier/album laissait son `Share` pointer vers une ressource inexistante, jamais nettoyé.
- `ShareRepository::deleteByResource()` (nouveau) est appelé à chaque point de suppression réel : `FileProcessor::handleDelete` (API), `FileWebController::delete` (web), `AlbumService::delete` (partagé API+web), `FolderService::deleteFolder` (les deux branches `deleteContents`, y compris descendants).
- **Bug latent découvert en cours de route** : `AlbumProcessor::handleDelete` (API) supprimait l'album directement via `$em->remove()` sans passer par `AlbumService::delete()` — corrigé, sinon le nettoyage n'y aurait jamais été appliqué.

## Test plan
- [x] `ShareRepositoryTest` : `deleteByResource` supprime le bon share, laisse les autres intacts
- [x] `testDeletingFileRemovesItsShares` / `AlbumRemovesItsShares` / `FolderRemovesItsShares`
- [x] Suite complète : 536 tests passent