### PR TITLE
🐛 fix(csp): autoriser data: dans script-src pour les modules AssetMapper

### DIFF
--- a/src/EventListener/SecurityHeadersListener.php
+++ b/src/EventListener/SecurityHeadersListener.php
@@ -22,6 +22,13 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * - Sur le front HTML : policy permissive (scripts/styles inline autorisés,
  *   faute de nonces sur chaque <script> existant) mais qui bloque les
  *   sources EXTERNES, l'embedding en iframe et les plugins (object-src)
+ * - script-src autorise `data:` : AssetMapper mappe les imports CSS des
+ *   modules JS (`import './styles/app.css'`) vers un faux module
+ *   `data:application/javascript,` — sans ce `data:`, la CSP bloque ce
+ *   faux module et interrompt toute la chaîne d'imports du module JS
+ *   principal (app.js et tout ce qu'il importe). Risque limité : `data:`
+ *   n'autorise que du contenu inline déjà rendu par le serveur, comme
+ *   `'unsafe-inline'` déjà présent.
  */
 #[AsEventListener(event: KernelEvents::RESPONSE)]
 final class SecurityHeadersListener
@@ -65,7 +72,7 @@ final class SecurityHeadersListener
         // les scripts/styles inline existants faute de nonces sur chacun.
         $headers->set(
             'Content-Security-Policy',
-            "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'",
+            "default-src 'self'; script-src 'self' 'unsafe-inline' data:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'",
         );
     }
 }

--- a/tests/Unit/EventListener/SecurityHeadersListenerTest.php
+++ b/tests/Unit/EventListener/SecurityHeadersListenerTest.php
@@ -102,8 +102,26 @@ final class SecurityHeadersListenerTest extends TestCase
         (new SecurityHeadersListener('test'))($event);
 
         $csp = $event->getResponse()->headers->get('Content-Security-Policy');
-        $this->assertStringContainsString("script-src 'self' 'unsafe-inline'", $csp);
+        $this->assertStringContainsString("script-src 'self' 'unsafe-inline' data:", $csp);
         $this->assertStringContainsString("style-src 'self' 'unsafe-inline'", $csp);
+    }
+
+    /**
+     * AssetMapper mappe les imports CSS des modules JS (import './styles/app.css')
+     * vers un faux module data:application/javascript, — sans data: dans
+     * script-src, ce faux module est bloqué par la CSP, ce qui interrompt toute
+     * la chaîne d'imports du module JS principal (app.js et tout ce qu'il importe :
+     * modal.js, move-modal.js, etc.). Régression constatée : la recherche live
+     * (dépend de openMoveElementModal, définie dans move-modal.js) ne fonctionnait
+     * plus du tout après l'introduction de la CSP stricte (commit 6b494cd).
+     */
+    public function testCspAllowsDataUriInScriptSrcForAssetMapperCssModules(): void
+    {
+        $event = $this->buildEvent('/explorer');
+        (new SecurityHeadersListener('test'))($event);
+
+        $csp = $event->getResponse()->headers->get('Content-Security-Policy');
+        $this->assertStringContainsString('data:', $csp);
     }
 
     public function testCspHeaderIsStrictOnApiRoutesNotHtmlPolicy(): void


### PR DESCRIPTION
## Résumé

La CSP stricte introduite sur le front (commit `6b494cd`, fix sécurité F7) bloquait **tout le chargement du module JS principal** de l'application, sans qu'aucune erreur explicite ne le signale clairement.

**Cause racine** : AssetMapper mappe les imports CSS des modules JS (`import './styles/app.css'`) vers un faux module `data:application/javascript,` — une technique standard pour que cet import ne casse rien côté navigateur. Mais la CSP (`script-src 'self' 'unsafe-inline'`, sans `data:`) bloquait ce faux module, ce qui interrompait toute la chaîne d'imports d'`app.js` (`modal.js`, `move-modal.js`, `toast.js`, `folder-children.js`, `rename.js`, `delete-folder-modal.js`, `upload-modal.js`).

**4 régressions signalées par l'utilisateur, toutes reproduites (Playwright) puis confirmées corrigées** :
- Recherche live cassée (`openMoveElementModal is not defined`)
- Import de photo/vidéo depuis l'ordinateur dans un album sans effet
- Renommage de média dans un album sans effet
- Drag & drop de fichier vidéo vers l'explorateur sans effet

Toutes partageaient cette même cause : leur JS dépendait, directement ou indirectement, du chargement réussi du module principal.

## Fix
Ajout de `data:` à la directive `script-src` de la CSP — périmètre minimal, les autres directives (`object-src`, `frame-ancestors`, `base-uri`) restent inchangées.

## Test plan
- [x] `testCspAllowsDataUriInScriptSrcForAssetMapperCssModules` (nouveau)
- [x] `testCspHeaderOnHtmlFrontAllowsInlineScriptsAndStyles` mis à jour
- [x] Suite complète : 537 tests passent
- [x] Vérifié en conditions réelles avec un navigateur piloté (Playwright) : les 4 interactions fonctionnent à nouveau après le fix