### PR TITLE
🐛 fix(explorer): l'import de fichier ignorait le dossier courant

### DIFF
--- a/src/Twig/Components/ImportCard.php
+++ b/src/Twig/Components/ImportCard.php
@@ -2,11 +2,12 @@
 
 namespace App\Twig\Components;
 
+use App\Entity\Folder;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
 #[AsTwigComponent(name: 'ImportCard')]
 class ImportCard
 {
-    public ?string $currentFolder = null;
+    public ?Folder $currentFolder = null;
     // Props : dossier courant (optionnel)
 }

--- a/templates/web/explorer.html.twig
+++ b/templates/web/explorer.html.twig
@@ -19,7 +19,7 @@
   <twig:Breadcrumbs :segments="breadcrumbSegments" />
 
   {# === ImportCard component === #}
-  <twig:ImportCard :current-folder="currentFolder ?? null" />
+  <twig:ImportCard :currentFolder="currentFolder ?? null" />
 
   {# === Explorateur === #}
   <div data-testid="file-explorer" class="hc-explorer-grid">

--- a/templates/web/home.html.twig
+++ b/templates/web/home.html.twig
@@ -7,7 +7,7 @@
 {% set folderIcon %}<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/></svg>{% endset %}
 
 {# === ImportCard component === #}
-<twig:ImportCard :current-folder="currentFolder ?? null" />
+<twig:ImportCard :currentFolder="currentFolder ?? null" />
 
 {# === Explorateur === #}
 <div data-testid="file-explorer" class="flex gap-4">

--- a/tests/Web/ExplorerPageTest.php
+++ b/tests/Web/ExplorerPageTest.php
@@ -277,6 +277,31 @@ final class ExplorerPageTest extends WebTestCase
         $this->assertCount(1, $sectionTitles, 'Il ne doit avoir qu\'une seule section-title "Dossiers"');
     }
 
+    /**
+     * ImportCard::$currentFolder est typé `string` mais explorer.html.twig lui
+     * passait l'objet Folder entier (:current-folder="currentFolder") — le
+     * hidden input folder_id restait vide même en naviguant dans un sous-dossier,
+     * donc les uploads (drag & drop ou bouton Parcourir) atterrissaient toujours
+     * dans le dossier par défaut au lieu du dossier affiché à l'écran.
+     */
+    public function testImportCardFolderIdReflectsCurrentFolderWhenBrowsingSubfolder(): void
+    {
+        $user = $this->createUser();
+
+        $folder = new Folder('Sous-dossier', $user);
+        $this->em->persist($folder);
+        $this->em->flush();
+        $folderId = $folder->getId()->toRfc4122();
+
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/explorer?folder=' . $folderId);
+
+        $this->assertResponseIsSuccessful();
+        $hiddenInput = $crawler->filter('#main-upload-form input[name="folder_id"]');
+        $this->assertSame($folderId, $hiddenInput->attr('value'));
+    }
+
     public function testImportCardUsesCloudIcon(): void
     {
         $this->createUser();


### PR DESCRIPTION
## Résumé

Le hidden input `folder_id` d'`ImportCard` restait toujours vide en naviguant dans un sous-dossier — les uploads (bouton « Parcourir » ou drag & drop) atterrissaient donc systématiquement dans le dossier par défaut au lieu du dossier affiché à l'écran.

**Cause** : `explorer.html.twig` et `home.html.twig` passaient la prop en kebab-case (`:current-folder="..."`), mais Symfony UX TwigComponent ne convertit pas kebab-case → camelCase sur les props typées — la clé `"current-folder"` ne correspond à aucune propriété PHP valide (un tiret est syntaxiquement impossible dans un nom de propriété), elle était donc silencieusement ignorée et `ImportCard::$currentFolder` restait à sa valeur par défaut `null`. Confirmé en inspectant le template Twig compilé (`ComponentRuntime->render("ImportCard", ["current-folder" => ...])`).

**Fix** : `:currentFolder="..."` (camelCase, sans tiret). Au passage, `ImportCard::$currentFolder` est retypé `?Folder` (au lieu de `?string`) — le composant reçoit bien l'entité, pas un ID.

## Test plan
- [x] `testImportCardFolderIdReflectsCurrentFolderWhenBrowsingSubfolder` (nouveau)
- [x] Suite complète : 538 tests passent
- [x] Vérifié en conditions réelles (Playwright) : `folder_id` correspond désormais au dossier affiché lors de la navigation