### PR TITLE
✨ feat(security): invitation par email + index/unicité + rate-limiting

### DIFF
--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -1,0 +1,6 @@
+framework:
+    rate_limiter:
+        share_creation:
+            policy: 'sliding_window'
+            limit: 20
+            interval: '15 minutes'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -121,6 +121,10 @@ services:
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_authentication_success, method: onAuthenticationSuccess }
 
+    App\State\ShareProcessor:
+        arguments:
+            $shareCreationLimiter: '@limiter.share_creation'
+
 when@test:
     services:
         Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface:

--- a/migrations/Version20260714181028.php
+++ b/migrations/Version20260714181028.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260714181028 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE INDEX idx_share_lookup ON shares (guest_id, resource_type, resource_id)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_share ON shares (owner_id, guest_id, resource_type, resource_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX idx_share_lookup ON shares');
+        $this->addSql('DROP INDEX uniq_share ON shares');
+    }
+}

--- a/src/ApiResource/ShareOutput.php
+++ b/src/ApiResource/ShareOutput.php
@@ -73,6 +73,7 @@ final class ShareOutput
     public string $id = '';
     public string $ownerId = '';
     public string $guestId = '';
+    public ?string $guestEmail = null;
     public string $resourceType = '';
     public string $resourceId = '';
     public string $permission = '';

--- a/src/Entity/Share.php
+++ b/src/Entity/Share.php
@@ -23,6 +23,8 @@ use Symfony\Component\Uid\Uuid;
  */
 #[ORM\Entity(repositoryClass: ShareRepository::class)]
 #[ORM\Table(name: 'shares')]
+#[ORM\Index(name: 'idx_share_lookup', columns: ['guest_id', 'resource_type', 'resource_id'])]
+#[ORM\UniqueConstraint(name: 'uniq_share', columns: ['owner_id', 'guest_id', 'resource_type', 'resource_id'])]
 class Share
 {
     public const PERMISSION_READ = 'read';

--- a/src/State/ShareProcessor.php
+++ b/src/State/ShareProcessor.php
@@ -16,10 +16,14 @@ use App\Interface\ShareRepositoryInterface;
 use App\Interface\UserRepositoryInterface;
 use App\Security\OwnershipChecker;
 use App\Security\ResourceLocator;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -44,6 +48,7 @@ final class ShareProcessor implements ProcessorInterface
         private readonly Security $security,
         private readonly OwnershipChecker $ownershipChecker,
         private readonly ResourceLocator $resourceLocator,
+        private readonly RateLimiterFactory $shareCreationLimiter,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
@@ -61,14 +66,12 @@ final class ShareProcessor implements ProcessorInterface
         /** @var User $owner */
         $owner = $this->security->getUser();
 
-        $guestId = $data->guestId ?? '';
-        if (!Uuid::isValid($guestId)) {
-            throw new BadRequestHttpException('guestId invalide.');
+        $limiter = $this->shareCreationLimiter->create((string) $owner->getId());
+        if (!$limiter->consume(1)->isAccepted()) {
+            throw new TooManyRequestsHttpException(null, 'Trop de partages créés récemment. Réessayez plus tard.');
         }
-        $guest = $this->userRepository->find(Uuid::fromString($guestId));
-        if ($guest === null) {
-            throw new NotFoundHttpException('Utilisateur invité introuvable.');
-        }
+
+        $guest = $this->resolveGuest($data);
 
         $resourceType = $data->resourceType ?? '';
         if (!in_array($resourceType, self::VALID_TYPES, true)) {
@@ -107,9 +110,41 @@ final class ShareProcessor implements ProcessorInterface
         );
 
         $this->em->persist($share);
-        $this->em->flush();
+        try {
+            $this->em->flush();
+        } catch (UniqueConstraintViolationException) {
+            throw new ConflictHttpException('Un partage identique existe déjà pour cet utilisateur et cette ressource.');
+        }
 
         return $this->provider->toOutput($share);
+    }
+
+    private function resolveGuest(ShareOutput $data): User
+    {
+        $guestId = $data->guestId ?? '';
+        if ($guestId !== '') {
+            if (!Uuid::isValid($guestId)) {
+                throw new BadRequestHttpException('guestId invalide.');
+            }
+            $guest = $this->userRepository->find(Uuid::fromString($guestId));
+            if ($guest === null) {
+                throw new NotFoundHttpException('Utilisateur invité introuvable.');
+            }
+
+            return $guest;
+        }
+
+        $guestEmail = $data->guestEmail ?? '';
+        if ($guestEmail !== '') {
+            $guest = $this->userRepository->findOneBy(['email' => $guestEmail]);
+            if ($guest === null) {
+                throw new NotFoundHttpException('Aucun compte HomeCloud n\'est associé à cet email.');
+            }
+
+            return $guest;
+        }
+
+        throw new BadRequestHttpException('guestId ou guestEmail requis.');
     }
 
     private function handlePatch(ShareOutput $data, array $uriVariables): ShareOutput

--- a/src/State/ShareProvider.php
+++ b/src/State/ShareProvider.php
@@ -60,6 +60,7 @@ final class ShareProvider implements ProviderInterface
         $output->id = $share->getId()->toRfc4122();
         $output->ownerId = $share->getOwner()->getId()->toRfc4122();
         $output->guestId = $share->getGuest()->getId()->toRfc4122();
+        $output->guestEmail = $share->getGuest()->getEmail();
         $output->resourceType = $share->getResourceType();
         $output->resourceId = $share->getResourceId()->toRfc4122();
         $output->permission = $share->getPermission();

--- a/tests/Api/ShareTest.php
+++ b/tests/Api/ShareTest.php
@@ -670,4 +670,128 @@ final class ShareTest extends AuthenticatedApiTestCase
         $this->em->clear();
         $this->assertNull($this->em->getRepository(Share::class)->find($shareId));
     }
+
+    // ─── Invitation par email ────────────────────────────────────────────────
+
+    public function testCreateShareWithGuestEmailOfRegisteredUser(): void
+    {
+        $owner = $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
+        $guest = $this->createGuest(); // bob@example.com
+        $file  = $this->createFile($owner);
+
+        $response = $this->createAuthenticatedClient()->request('POST', '/api/v1/shares', [
+            'json' => [
+                'guestEmail'   => 'bob@example.com',
+                'resourceType' => 'file',
+                'resourceId'   => $file->getId()->toRfc4122(),
+                'permission'   => 'read',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $data = $response->toArray();
+        $this->assertSame($guest->getId()->toRfc4122(), $data['guestId']);
+    }
+
+    public function testCreateShareWithGuestEmailNotFoundReturns404WithClearMessage(): void
+    {
+        $owner = $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
+        $file  = $this->createFile($owner);
+
+        $response = $this->createAuthenticatedClient()->request('POST', '/api/v1/shares', [
+            'json' => [
+                'guestEmail'   => 'inconnu@example.com',
+                'resourceType' => 'file',
+                'resourceId'   => $file->getId()->toRfc4122(),
+                'permission'   => 'read',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(404);
+        $this->assertStringContainsString(
+            'Aucun compte HomeCloud',
+            $response->getContent(false)
+        );
+    }
+
+    public function testCreateShareStillWorksWithGuestIdForBackwardCompatibility(): void
+    {
+        $owner = $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
+        $guest = $this->createGuest();
+        $file  = $this->createFile($owner);
+
+        $response = $this->createAuthenticatedClient()->request('POST', '/api/v1/shares', [
+            'json' => [
+                'guestId'      => $guest->getId()->toRfc4122(),
+                'resourceType' => 'file',
+                'resourceId'   => $file->getId()->toRfc4122(),
+                'permission'   => 'read',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+    }
+
+    public function testCreateShareFailsIfNeitherGuestIdNorGuestEmailProvided(): void
+    {
+        $owner = $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
+        $file  = $this->createFile($owner);
+
+        $this->createAuthenticatedClient()->request('POST', '/api/v1/shares', [
+            'json' => [
+                'resourceType' => 'file',
+                'resourceId'   => $file->getId()->toRfc4122(),
+                'permission'   => 'read',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    // ─── Doublon → 409 ───────────────────────────────────────────────────────
+
+    public function testDuplicateShareReturns409(): void
+    {
+        $owner = $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
+        $guest = $this->createGuest();
+        $file  = $this->createFile($owner);
+
+        $payload = [
+            'guestId'      => $guest->getId()->toRfc4122(),
+            'resourceType' => 'file',
+            'resourceId'   => $file->getId()->toRfc4122(),
+            'permission'   => 'read',
+        ];
+
+        $this->createAuthenticatedClient()->request('POST', '/api/v1/shares', ['json' => $payload]);
+        $this->assertResponseStatusCodeSame(201);
+
+        $this->createAuthenticatedClient()->request('POST', '/api/v1/shares', ['json' => $payload]);
+        $this->assertResponseStatusCodeSame(409);
+    }
+
+    // ─── Rate limiting ───────────────────────────────────────────────────────
+
+    public function testCreateShareIsRateLimitedAfterTooManyAttempts(): void
+    {
+        $lastStatus = null;
+        for ($i = 0; $i < 25; $i++) {
+            $this->em->clear();
+            $owner = $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
+            $guest = $this->createUser("guest{$i}@example.com", 'password123', "Guest {$i}");
+            $file  = $this->createFile($owner);
+
+            $response = $this->createAuthenticatedClient()->request('POST', '/api/v1/shares', [
+                'json' => [
+                    'guestId'      => $guest->getId()->toRfc4122(),
+                    'resourceType' => 'file',
+                    'resourceId'   => $file->getId()->toRfc4122(),
+                    'permission'   => 'read',
+                ],
+            ]);
+            $lastStatus = $response->getStatusCode();
+        }
+
+        $this->assertSame(429, $lastStatus);
+    }
 }

--- a/tests/Web/DashboardTest.php
+++ b/tests/Web/DashboardTest.php
@@ -134,12 +134,14 @@ final class DashboardTest extends WebTestCase
 
         $folder = new Folder('Shared Folder', $user, null);
         $this->em->persist($folder);
+        $expiredFolder = new Folder('Expired Shared Folder', $user, null);
+        $this->em->persist($expiredFolder);
         $this->em->flush();
 
         $activeShare = new Share($user, $guest, Share::RESOURCE_FOLDER, $folder->getId(), Share::PERMISSION_READ);
         $this->em->persist($activeShare);
 
-        $expiredShare = new Share($user, $guest, Share::RESOURCE_FOLDER, $folder->getId(), Share::PERMISSION_READ, new \DateTimeImmutable('-1 day'));
+        $expiredShare = new Share($user, $guest, Share::RESOURCE_FOLDER, $expiredFolder->getId(), Share::PERMISSION_READ, new \DateTimeImmutable('-1 day'));
         $this->em->persist($expiredShare);
 
         $this->em->flush();


### PR DESCRIPTION
## Résumé

Étape 7 de `feat-partage.md`, trois points regroupés car ils touchent tous `ShareProcessor`/`Share`, et l'UI à venir (page « Partages ») a besoin de l'email pour être utilisable :

**Invitation par email**
- `POST /shares` accepte désormais `guestEmail` en plus de `guestId` (rétrocompatible — les tests existants avec `guestId` restent verts).
- Email inconnu → 404 avec message clair (« Aucun compte HomeCloud n'est associé à cet email »).
- Ni `guestId` ni `guestEmail` fourni → 400.

**Index + contrainte d'unicité**
- `idx_share_lookup (guest_id, resource_type, resource_id)` — accélère `findActiveShare`, appelé à *chaque* accès à une ressource partagée (pas de cache par choix de sécurité, donc cet index est ce qui rend cette politique tenable en perf).
- `uniq_share (owner_id, guest_id, resource_type, resource_id)` — empêche les doublons, gérés en **409 Conflict** plutôt qu'un upsert silencieux.
- Migration `Version20260714181028`.

**Rate limiting**
- 20 créations de partage / 15 min par owner (`config/packages/rate_limiter.yaml`) — anti énumération d'emails et anti spam d'invitations.

**Effet de bord corrigé** : `DashboardTest::testDashboardShowsActiveSharesCount` créait deux `Share` identiques (même owner/guest/resource, distingués seulement par `expiresAt`) pour tester actif/expiré — rejeté par `uniq_share`. Adapté pour utiliser deux dossiers distincts, préserve l'intention du test.

## Test plan
- [x] 6 nouveaux tests : invitation email (succès/échec), rétrocompat guestId, validation ni-ni, doublon 409, rate-limiting
- [x] Migration appliquée sur dev + test (`doctrine:migrations:migrate`)
- [x] Suite complète : 544 tests passent