### PR TITLE
✨ feat(shares): ajouter la page web « Partages »

### DIFF
--- a/src/Controller/Web/ShareWebController.php
+++ b/src/Controller/Web/ShareWebController.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Web;
+
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Share;
+use App\Entity\User;
+use App\Interface\ShareRepositoryInterface;
+use App\Security\ResourceLocator;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Page web « Partages » — liste les partages sortants (créés par
+ * l'utilisateur) et entrants (dont il est l'invité).
+ */
+#[IsGranted('ROLE_USER')]
+final class ShareWebController extends AbstractController
+{
+    public function __construct(
+        private readonly ShareRepositoryInterface $shareRepository,
+        private readonly ResourceLocator $resourceLocator,
+    ) {}
+
+    #[Route('/partages', name: 'app_shares')]
+    public function index(): Response
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $shares = $this->shareRepository->findByUser($user, limit: 100);
+
+        $outgoing = [];
+        $incoming = [];
+
+        foreach ($shares as $share) {
+            $row = [
+                'share'        => $share,
+                'resourceName' => $this->resolveResourceName($share),
+            ];
+
+            if ($share->getOwner()->getId()->equals($user->getId())) {
+                $outgoing[] = $row;
+            } else {
+                $incoming[] = $row;
+            }
+        }
+
+        return $this->render('web/shares.html.twig', [
+            'outgoing' => $outgoing,
+            'incoming' => $incoming,
+        ]);
+    }
+
+    private function resolveResourceName(Share $share): string
+    {
+        try {
+            $resource = $this->resourceLocator->locate($share->getResourceType(), $share->getResourceId());
+        } catch (NotFoundHttpException) {
+            return 'Ressource supprimée';
+        }
+
+        return match (true) {
+            $resource instanceof File   => $resource->getOriginalName(),
+            $resource instanceof Folder => $resource->getName(),
+            $resource instanceof Album  => $resource->getName(),
+        };
+    }
+}

--- a/templates/web/layout.html.twig
+++ b/templates/web/layout.html.twig
@@ -71,8 +71,8 @@
                 Albums
             </a>
 
-            <a href="#"
-               class="hc-nav-item">
+            <a href="{{ path('app_shares') }}"
+               class="hc-nav-item {{ current_route == 'app_shares' ? 'active' : '' }}">
                 <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                     <path d="M18 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 22a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM8.6 13.5l6.8 4M15.4 6.5l-6.8 4"/>
                 </svg>

--- a/templates/web/shares.html.twig
+++ b/templates/web/shares.html.twig
@@ -1,0 +1,87 @@
+{% extends 'web/layout.html.twig' %}
+{% import 'macros/icon.html.twig' as icons %}
+
+{% block title %}Partages — HomeCloud{% endblock %}
+
+{% block content %}
+
+{% set shareIcon %}<svg width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M18 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 22a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM8.6 13.5l6.8 4M15.4 6.5l-6.8 4"/></svg>{% endset %}
+
+<div class="flex flex-col gap-7 max-w-[1100px] mx-auto h-full">
+
+  {# En-tête de page #}
+  <div class="flex items-center justify-between">
+    <div>
+      <h1 class="text-2xl font-black tracking-tight mb-1 flex items-center gap-2">
+        {{ shareIcon }}
+        Partages
+      </h1>
+      <p class="hc-page-sub">{{ incoming|length }} reçu{{ incoming|length != 1 ? 's' : '' }} · {{ outgoing|length }} envoyé{{ outgoing|length != 1 ? 's' : '' }}</p>
+    </div>
+  </div>
+
+  {# === Partagés avec moi (entrants) === #}
+  <div>
+    <h2 class="text-sm font-semibold uppercase tracking-wide mb-3" style="color:var(--hc-text-2);">Partagés avec moi</h2>
+    {% if incoming is empty %}
+      <div data-testid="shares-incoming-empty">
+        <twig:EmptyState
+          title="Aucun partage reçu"
+          subtitle="Les ressources qu'on partage avec vous apparaîtront ici."
+          icon="<svg width='64' height='64' fill='none' stroke='currentColor' stroke-width='1.5' viewBox='0 0 24 24' class='hc-icon'><path d='M18 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 22a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM8.6 13.5l6.8 4M15.4 6.5l-6.8 4'/></svg>"
+        />
+      </div>
+    {% else %}
+      <div class="hc-item-card" style="display:flex; flex-direction:column; gap:0; padding:0;" data-testid="shares-incoming-list">
+        {% for row in incoming %}
+          <div class="flex items-center justify-between px-4 py-3" style="border-bottom:1px solid var(--hc-border);" data-testid="share-row-incoming">
+            <div>
+              <div class="hc-item-name">{{ row.resourceName }}</div>
+              <div class="hc-item-meta">
+                Partagé par {{ row.share.owner.displayName }} ·
+                {{ row.share.permission == 'write' ? 'lecture/écriture' : 'lecture seule' }}
+                {% if row.share.expiresAt %}
+                  · {{ row.share.isActive ? 'expire le ' ~ row.share.expiresAt|date('d/m/Y') : 'expiré' }}
+                {% endif %}
+              </div>
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </div>
+
+  {# === Mes partages (sortants) === #}
+  <div>
+    <h2 class="text-sm font-semibold uppercase tracking-wide mb-3" style="color:var(--hc-text-2);">Mes partages</h2>
+    {% if outgoing is empty %}
+      <div data-testid="shares-outgoing-empty">
+        <twig:EmptyState
+          title="Vous n'avez encore rien partagé"
+          subtitle="Partagez un fichier, un dossier ou un album depuis sa page de détail."
+          icon="<svg width='64' height='64' fill='none' stroke='currentColor' stroke-width='1.5' viewBox='0 0 24 24' class='hc-icon'><path d='M18 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 22a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM8.6 13.5l6.8 4M15.4 6.5l-6.8 4'/></svg>"
+        />
+      </div>
+    {% else %}
+      <div class="hc-item-card" style="display:flex; flex-direction:column; gap:0; padding:0;" data-testid="shares-outgoing-list">
+        {% for row in outgoing %}
+          <div class="flex items-center justify-between px-4 py-3" style="border-bottom:1px solid var(--hc-border);" data-testid="share-row-outgoing">
+            <div>
+              <div class="hc-item-name">{{ row.resourceName }}</div>
+              <div class="hc-item-meta">
+                Partagé avec {{ row.share.guest.displayName }} ·
+                {{ row.share.permission == 'write' ? 'lecture/écriture' : 'lecture seule' }}
+                {% if row.share.expiresAt %}
+                  · {{ row.share.isActive ? 'expire le ' ~ row.share.expiresAt|date('d/m/Y') : 'expiré' }}
+                {% endif %}
+              </div>
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </div>
+
+</div>
+
+{% endblock %}

--- a/tests/Web/ShareWebTest.php
+++ b/tests/Web/ShareWebTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Share;
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class ShareWebTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM shares');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createUser(string $email = 'shares@example.com'): User
+    {
+        return $this->createWebUser($email, 'secret123', 'Shares User');
+    }
+
+    private function login(string $email = 'shares@example.com'): void
+    {
+        $this->loginAs($email);
+    }
+
+    private function createFile(User $owner, string $name = 'photo.jpg'): File
+    {
+        $folder = new Folder('Docs', $owner);
+        $this->em->persist($folder);
+        $file = new File($name, 'image/jpeg', 1024, "test/{$name}", $folder, $owner);
+        $this->em->persist($file);
+        $this->em->flush();
+
+        return $file;
+    }
+
+    public function testSharesPageRequiresLogin(): void
+    {
+        $this->client->request('GET', '/partages');
+
+        $this->assertResponseRedirects('/login');
+    }
+
+    public function testSharesPageListsOutgoingShares(): void
+    {
+        $owner = $this->createUser();
+        $guest = $this->createUser('guest-out@example.com');
+        $file  = $this->createFile($owner, 'partage-sortant.jpg');
+        $share = new Share($owner, $guest, Share::RESOURCE_FILE, $file->getId(), Share::PERMISSION_READ);
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/partages');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertStringContainsString('partage-sortant.jpg', $crawler->filter('body')->text());
+    }
+
+    public function testSharesPageListsIncomingShares(): void
+    {
+        $owner = $this->createUser('owner-in@example.com');
+        $guest = $this->createUser(); // shares@example.com, celui qui se connecte
+        $file  = $this->createFile($owner, 'partage-entrant.jpg');
+        $share = new Share($owner, $guest, Share::RESOURCE_FILE, $file->getId(), Share::PERMISSION_READ);
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/partages');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertStringContainsString('partage-entrant.jpg', $crawler->filter('body')->text());
+    }
+
+    public function testSidebarLinkPointsToSharesPage(): void
+    {
+        $this->createUser();
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/');
+
+        $this->assertResponseIsSuccessful();
+        $link = $crawler->filter('a:contains("Partages")');
+        $this->assertGreaterThan(0, $link->count());
+        $this->assertSame('/partages', $link->attr('href'));
+    }
+}


### PR DESCRIPTION
## Résumé

Étape 8 de `feat-partage.md`. Le lien sidebar « Partages » était mort (`href="#"`) depuis toujours — aucune vue web n'existait pour consulter les partages, alors que l'API et le dashboard (`countActiveByOwner`) les exposaient déjà.

- `ShareWebController::index` liste les partages sortants (owner) et entrants (guest) séparément, avec le nom de la ressource résolu via `ResourceLocator` (tolérant aux shares orphelins résiduels — affiche « Ressource supprimée » plutôt qu'une page qui plante).
- `shares.html.twig` réutilise `EmptyState` et le design system `--hc-*` existant.
- Le lien sidebar pointe désormais vers `app_shares` avec état actif.

## Test plan
- [x] 4 tests `ShareWebTest` : redirection login, liste sortants, liste entrants, lien sidebar
- [x] Suite complète : 548 tests passent
- [x] Vérifié visuellement (Playwright + capture d'écran) : page cohérente avec le design system, sidebar active, aucune erreur JS