### PR TITLE
✨ feat(shares): modale d'invitation + bouton « Partager » sur album

### DIFF
--- a/src/Controller/Web/ShareWebController.php
+++ b/src/Controller/Web/ShareWebController.php
@@ -10,8 +10,12 @@ use App\Entity\Folder;
 use App\Entity\Share;
 use App\Entity\User;
 use App\Interface\ShareRepositoryInterface;
+use App\Interface\UserRepositoryInterface;
+use App\Security\OwnershipChecker;
 use App\Security\ResourceLocator;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
@@ -24,9 +28,15 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted('ROLE_USER')]
 final class ShareWebController extends AbstractController
 {
+    private const VALID_TYPES = [Share::RESOURCE_FILE, Share::RESOURCE_FOLDER, Share::RESOURCE_ALBUM];
+    private const VALID_PERMISSIONS = [Share::PERMISSION_READ, Share::PERMISSION_WRITE];
+
     public function __construct(
         private readonly ShareRepositoryInterface $shareRepository,
         private readonly ResourceLocator $resourceLocator,
+        private readonly UserRepositoryInterface $userRepository,
+        private readonly OwnershipChecker $ownershipChecker,
+        private readonly EntityManagerInterface $em,
     ) {}
 
     #[Route('/partages', name: 'app_shares')]
@@ -57,6 +67,80 @@ final class ShareWebController extends AbstractController
             'outgoing' => $outgoing,
             'incoming' => $incoming,
         ]);
+    }
+
+    #[Route('/share-create', name: 'app_share_create', methods: ['POST'])]
+    public function create(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('share-create', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Jeton CSRF invalide.');
+        }
+
+        $resourceType = (string) $request->request->get('resourceType', '');
+        $resourceId   = (string) $request->request->get('resourceId', '');
+        $redirectUrl  = $this->redirectUrlFor($resourceType, $resourceId);
+
+        if (!in_array($resourceType, self::VALID_TYPES, true)) {
+            $this->addFlash('error', 'Type de ressource invalide.');
+
+            return $this->redirect($redirectUrl);
+        }
+
+        $permission = (string) $request->request->get('permission', Share::PERMISSION_READ);
+        if (!in_array($permission, self::VALID_PERMISSIONS, true)) {
+            $permission = Share::PERMISSION_READ;
+        }
+
+        $guestEmail = trim((string) $request->request->get('guestEmail', ''));
+        $guest = $guestEmail !== '' ? $this->userRepository->findOneBy(['email' => $guestEmail]) : null;
+
+        if ($guest === null) {
+            $this->addFlash('error', 'Aucun compte HomeCloud n\'est associé à cet email.');
+
+            return $this->redirect($redirectUrl);
+        }
+
+        /** @var User $owner */
+        $owner = $this->getUser();
+
+        if ($guest->getId()->equals($owner->getId())) {
+            $this->addFlash('error', 'Vous ne pouvez pas partager une ressource avec vous-même.');
+
+            return $this->redirect($redirectUrl);
+        }
+
+        try {
+            $resource = $this->resourceLocator->locate($resourceType, \Symfony\Component\Uid\Uuid::fromString($resourceId));
+            $this->ownershipChecker->denyUnlessOwner($resource);
+        } catch (NotFoundHttpException) {
+            $this->addFlash('error', 'Ressource introuvable.');
+
+            return $this->redirect($redirectUrl);
+        }
+
+        $share = new Share($owner, $guest, $resourceType, \Symfony\Component\Uid\Uuid::fromString($resourceId), $permission);
+        $this->em->persist($share);
+
+        try {
+            $this->em->flush();
+        } catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException) {
+            $this->addFlash('error', 'Un partage identique existe déjà pour cet utilisateur.');
+
+            return $this->redirect($redirectUrl);
+        }
+
+        $this->addFlash('success', sprintf('Ressource partagée avec %s.', $guest->getDisplayName()));
+
+        return $this->redirect($redirectUrl);
+    }
+
+    private function redirectUrlFor(string $resourceType, string $resourceId): string
+    {
+        return match ($resourceType) {
+            Share::RESOURCE_ALBUM  => '/albums/' . $resourceId,
+            Share::RESOURCE_FOLDER => '/explorer?folder=' . $resourceId,
+            default => '/explorer',
+        };
     }
 
     private function resolveResourceName(Share $share): string

--- a/templates/components/ShareModal.html.twig
+++ b/templates/components/ShareModal.html.twig
@@ -1,0 +1,101 @@
+{# === ShareModal component ===
+   Modale d'invitation à partager une ressource (file|folder|album).
+   Soumet un formulaire POST classique vers app_share_create.
+   Props attendues : resourceType (string), resourceId (string). #}
+<div id="share-modal-{{ resourceId }}"
+     data-testid="share-modal"
+     class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/45"
+     tabindex="-1"
+     aria-modal="true"
+     role="dialog">
+
+  <form method="post" action="{{ path('app_share_create') }}"
+        class="flex flex-col"
+        style="background: var(--hc-surface); color: var(--hc-text); border: 1px solid var(--hc-border);
+               border-radius: 1rem; box-shadow: var(--hc-shadow-crisp); width: 100%; max-width: 440px;
+               margin: 1rem;">
+    <input type="hidden" name="_token" value="{{ csrf_token('share-create') }}">
+    <input type="hidden" name="resourceType" value="{{ resourceType }}">
+    <input type="hidden" name="resourceId" value="{{ resourceId }}">
+
+    {# Header #}
+    <div class="flex items-center justify-between px-6 py-4" style="border-bottom: 1px solid var(--hc-border);">
+      <h2 class="text-base font-semibold m-0">Partager</h2>
+      <button type="button" class="share-modal-close" aria-label="Fermer"
+              class="flex items-center justify-center w-8 h-8 rounded-full"
+              style="background: var(--hc-surface-2); color: var(--hc-text-2); border: none; cursor: pointer;">×</button>
+    </div>
+
+    {# Email #}
+    <div class="px-6 pt-4">
+      <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
+        Email de l'invité
+      </label>
+      <input type="email" name="guestEmail" data-testid="share-guest-email"
+             placeholder="ami@example.com" required
+             class="w-full px-3 py-2 rounded-md text-sm"
+             style="border: 1px solid var(--hc-border); background: var(--hc-bg); color: var(--hc-text);">
+    </div>
+
+    {# Permission #}
+    <div class="px-6 pt-4">
+      <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
+        Permission
+      </label>
+      <div class="flex gap-3 text-sm">
+        <label class="flex items-center gap-1.5 cursor-pointer">
+          <input type="radio" name="permission" value="read" checked>
+          Lecture seule
+        </label>
+        <label class="flex items-center gap-1.5 cursor-pointer">
+          <input type="radio" name="permission" value="write">
+          Lecture/écriture
+        </label>
+      </div>
+    </div>
+
+    {# Actions #}
+    <div class="flex gap-2 justify-end px-6 py-4 mt-2" style="border-top: 1px solid var(--hc-border);">
+      <button type="button" class="share-modal-cancel"
+              style="background: none; border: none; color: var(--hc-text-2); cursor: pointer; padding: 0.5rem 1rem; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500;">
+        Annuler
+      </button>
+      <button type="submit" data-testid="share-submit"
+              class="px-4 py-2 rounded-md text-sm font-semibold"
+              style="background: var(--hc-accent); color: var(--hc-accent-contrast, #fff); border: none; cursor: pointer;">
+        Partager
+      </button>
+    </div>
+  </form>
+</div>
+
+<script>
+(function () {
+    var modal = document.getElementById('share-modal-{{ resourceId }}');
+    if (!modal) return;
+
+    var openBtn = document.getElementById('share-open-btn-{{ resourceId }}');
+    var closeBtn = modal.querySelector('.share-modal-close');
+    var cancelBtn = modal.querySelector('.share-modal-cancel');
+
+    function open() {
+        modal.classList.remove('hidden');
+        modal.style.display = 'flex';
+    }
+
+    function close() {
+        modal.classList.add('hidden');
+        modal.style.display = 'none';
+    }
+
+    if (openBtn) openBtn.addEventListener('click', open);
+    if (closeBtn) closeBtn.addEventListener('click', close);
+    if (cancelBtn) cancelBtn.addEventListener('click', close);
+    modal.addEventListener('click', function (e) {
+        if (e.target === modal) close();
+    });
+    document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape' && modal.style.display === 'flex') close();
+    });
+}());
+</script>

--- a/templates/web/album_detail.html.twig
+++ b/templates/web/album_detail.html.twig
@@ -41,6 +41,12 @@
           {{ icons.icon('upload', 20) }}
         </button>
       </form>
+      <button type="button" id="share-open-btn-{{ album.id }}" data-testid="share-open-btn"
+              class="hc-item-action flex items-center justify-center w-11 h-11 rounded-md"
+              style="border:1px solid var(--hc-border); color: var(--hc-accent);"
+              title="Partager" aria-label="Partager">
+        <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M18 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 22a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM8.6 13.5l6.8 4M15.4 6.5l-6.8 4"/></svg>
+      </button>
       <div style="width:1px; align-self:stretch; background:var(--hc-border-strong); margin:0 2px;" aria-hidden="true"></div>
       <form method="post" action="{{ path('app_album_delete', {id: album.id}) }}"
             onsubmit="return confirm('Supprimer l\'album « {{ album.name|e('js') }} » ?')">
@@ -112,5 +118,7 @@
   {% endif %}
 
 </div>
+
+<twig:ShareModal resourceType="album" resourceId="{{ album.id }}" />
 
 {% endblock %}

--- a/tests/Web/ShareWebTest.php
+++ b/tests/Web/ShareWebTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Web;
 
+use App\Entity\Album;
 use App\Entity\File;
 use App\Entity\Folder;
 use App\Entity\Share;
@@ -107,5 +108,98 @@ final class ShareWebTest extends WebTestCase
         $link = $crawler->filter('a:contains("Partages")');
         $this->assertGreaterThan(0, $link->count());
         $this->assertSame('/partages', $link->attr('href'));
+    }
+
+    // ─── Création d'un partage depuis un album (formulaire ShareModal) ──────
+
+    private function createAlbum(User $owner, string $name = 'Vacances'): Album
+    {
+        $album = new Album($name, $owner);
+        $this->em->persist($album);
+        $this->em->flush();
+
+        return $album;
+    }
+
+    private function shareCreateToken(string $resourceId): string
+    {
+        $crawler = $this->client->request('GET', '/albums/' . $resourceId);
+
+        return $crawler->filter('form[action*="/share-create"] input[name="_token"]')->attr('value');
+    }
+
+    public function testCreateShareFromAlbumRedirectsWithSuccessFlash(): void
+    {
+        $owner = $this->createUser();
+        $this->createUser('invite@example.com');
+        $album = $this->createAlbum($owner);
+
+        $this->login();
+        $token = $this->shareCreateToken($album->getId()->toRfc4122());
+
+        $this->client->request('POST', '/share-create', [
+            '_token'       => $token,
+            'guestEmail'   => 'invite@example.com',
+            'resourceType' => 'album',
+            'resourceId'   => $album->getId()->toRfc4122(),
+            'permission'   => 'read',
+        ]);
+
+        $this->assertResponseRedirects('/albums/' . $album->getId()->toRfc4122());
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('.flash-success', 'partagé');
+    }
+
+    public function testCreateShareWithUnknownEmailShowsErrorFlash(): void
+    {
+        $owner = $this->createUser();
+        $album = $this->createAlbum($owner);
+
+        $this->login();
+        $token = $this->shareCreateToken($album->getId()->toRfc4122());
+
+        $this->client->request('POST', '/share-create', [
+            '_token'       => $token,
+            'guestEmail'   => 'inconnu@example.com',
+            'resourceType' => 'album',
+            'resourceId'   => $album->getId()->toRfc4122(),
+            'permission'   => 'read',
+        ]);
+
+        $this->assertResponseRedirects('/albums/' . $album->getId()->toRfc4122());
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('.flash-error', 'Aucun compte HomeCloud');
+    }
+
+    public function testCreateShareWithoutCsrfTokenReturns403(): void
+    {
+        $owner = $this->createUser();
+        $this->createUser('invite2@example.com');
+        $album = $this->createAlbum($owner);
+
+        $this->login();
+
+        $this->client->request('POST', '/share-create', [
+            'guestEmail'   => 'invite2@example.com',
+            'resourceType' => 'album',
+            'resourceId'   => $album->getId()->toRfc4122(),
+            'permission'   => 'read',
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testAlbumDetailHasShareButtonAndModal(): void
+    {
+        $owner = $this->createUser();
+        $album = $this->createAlbum($owner);
+
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/albums/' . $album->getId()->toRfc4122());
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-testid="share-open-btn"]');
+        $this->assertSelectorExists('form[action*="/share-create"]');
     }
 }


### PR DESCRIPTION
## Résumé

Étape 9 de `feat-partage.md`.

- `ShareWebController::create` (POST `/share-create`) crée un `Share` depuis un formulaire web classique (CSRF, pas d'API JWT) : résout l'email en `User` inscrit, vérifie l'ownership de la ressource via `ResourceLocator`, gère les mêmes cas d'erreur que l'API (email inconnu, self-share, doublon 409) mais en flash + redirect plutôt qu'en JSON.
- `ShareModal` (composant Twig anonyme, sur le modèle de `NewAlbumModal`/`RenameModal`) est paramétrable par ressource (`resourceType`, `resourceId`) — un bouton « Partager » déclenche son ouverture via un id DOM unique par ressource, pour supporter plusieurs instances sur une même page à terme (galerie, explorateur).
- Branché sur `album_detail.html.twig` en premier. File/Folder suivront quand une vue web individuelle existera pour eux (même principe que le report de `FileVoter` à l'étape 4).

## Test plan
- [x] 4 nouveaux tests : succès + flash, email inconnu + flash erreur, CSRF invalide → 403, bouton+modale présents
- [x] Suite complète : 552 tests passent
- [x] Vérifié visuellement (Playwright + capture d'écran) : modale cohérente avec le design system, aucune erreur JS