### PR TITLE
✨ feat(shares): bouton « Partager » sur les dossiers + durée affichée

### DIFF
--- a/templates/components/FolderCard.html.twig
+++ b/templates/components/FolderCard.html.twig
@@ -20,6 +20,11 @@
 			<span class="hidden group-hover:inline text-xs font-medium whitespace-nowrap">Déplacer {{ item.name|e('html') }}</span>
 		</button>
 		<button type="button"
+		        id="share-open-btn-{{ item.id }}"
+		        data-testid="share-folder-btn-{{ item.id }}"
+		        class="share-btn hc-item-action"
+		        title="Partager {{ item.name|e('html') }}"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon"><path d="M18 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 22a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM8.6 13.5l6.8 4M15.4 6.5l-6.8 4"/></svg></button>
+		<button type="button"
 		        data-testid="delete-folder-btn-{{ item.id }}"
 		        data-empty="{{ ((item.children|length) == 0 and (item.files|length) == 0) ? '1' : '0' }}"
 		        class="delete-folder-btn hc-item-action hc-item-action--danger"
@@ -27,4 +32,6 @@
 		        onclick="openDeleteFolderModal('{{ item.id }}', '{{ item.name|e('js') }}', '{{ item.parentId ?? '' }}', '{{ ((item.children|length) == 0 and (item.files|length) == 0) ? '1' : '0' }}')"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-trash"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg></button>
 	</div>
 </div>
+
+<twig:ShareModal resourceType="folder" resourceId="{{ item.id }}" />
 {# Props attendues : item (entité Folder) #}

--- a/templates/web/shares.html.twig
+++ b/templates/web/shares.html.twig
@@ -39,9 +39,11 @@
               <div class="hc-item-name">{{ row.resourceName }}</div>
               <div class="hc-item-meta">
                 Partagé par {{ row.share.owner.displayName }} ·
-                {{ row.share.permission == 'write' ? 'lecture/écriture' : 'lecture seule' }}
+                {{ row.share.permission == 'write' ? 'lecture/écriture' : 'lecture seule' }} ·
                 {% if row.share.expiresAt %}
-                  · {{ row.share.isActive ? 'expire le ' ~ row.share.expiresAt|date('d/m/Y') : 'expiré' }}
+                  {{ row.share.isActive ? 'expire le ' ~ row.share.expiresAt|date('d/m/Y') : 'expiré le ' ~ row.share.expiresAt|date('d/m/Y') }}
+                {% else %}
+                  permanent
                 {% endif %}
               </div>
             </div>
@@ -70,9 +72,11 @@
               <div class="hc-item-name">{{ row.resourceName }}</div>
               <div class="hc-item-meta">
                 Partagé avec {{ row.share.guest.displayName }} ·
-                {{ row.share.permission == 'write' ? 'lecture/écriture' : 'lecture seule' }}
+                {{ row.share.permission == 'write' ? 'lecture/écriture' : 'lecture seule' }} ·
                 {% if row.share.expiresAt %}
-                  · {{ row.share.isActive ? 'expire le ' ~ row.share.expiresAt|date('d/m/Y') : 'expiré' }}
+                  {{ row.share.isActive ? 'expire le ' ~ row.share.expiresAt|date('d/m/Y') : 'expiré le ' ~ row.share.expiresAt|date('d/m/Y') }}
+                {% else %}
+                  permanent
                 {% endif %}
               </div>
             </div>

--- a/tests/Web/ExplorerPageTest.php
+++ b/tests/Web/ExplorerPageTest.php
@@ -359,4 +359,23 @@ final class ExplorerPageTest extends WebTestCase
             );
         }
     }
+
+    // --- Partage de dossier ---
+
+    public function testFolderCardHasShareButtonAndModal(): void
+    {
+        $user = $this->createUser();
+
+        $folder = new Folder('Documents partagés', $user);
+        $this->em->persist($folder);
+        $this->em->flush();
+
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/explorer');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-testid="share-folder-btn-' . $folder->getId()->toRfc4122() . '"]');
+        $this->assertSelectorExists('form[action*="/share-create"] input[value="' . $folder->getId()->toRfc4122() . '"]');
+    }
 }

--- a/tests/Web/ShareWebTest.php
+++ b/tests/Web/ShareWebTest.php
@@ -80,6 +80,52 @@ final class ShareWebTest extends WebTestCase
         $this->assertStringContainsString('partage-sortant.jpg', $crawler->filter('body')->text());
     }
 
+    public function testSharesPageListsOutgoingFolderShareWithNameGuestAndPermission(): void
+    {
+        $owner  = $this->createUser();
+        $guest  = $this->createUser('guest-folder@example.com');
+        $folder = new Folder('Documents partagés', $owner);
+        $this->em->persist($folder);
+        $this->em->flush();
+
+        $share = new Share($owner, $guest, Share::RESOURCE_FOLDER, $folder->getId(), Share::PERMISSION_WRITE);
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/partages');
+        $this->assertResponseIsSuccessful();
+
+        $row = $crawler->filter('[data-testid="share-row-outgoing"]')->text();
+        $this->assertStringContainsString('Documents partagés', $row);
+        $this->assertStringContainsString($guest->getDisplayName(), $row);
+        $this->assertStringContainsString('lecture/écriture', $row);
+        $this->assertStringContainsString('permanent', $row);
+    }
+
+    public function testSharesPageShowsExpirationDateWhenSet(): void
+    {
+        $owner  = $this->createUser();
+        $guest  = $this->createUser('guest-expiry@example.com');
+        $folder = new Folder('Dossier temporaire', $owner);
+        $this->em->persist($folder);
+        $this->em->flush();
+
+        $expiresAt = new \DateTimeImmutable('+7 days');
+        $share = new Share($owner, $guest, Share::RESOURCE_FOLDER, $folder->getId(), Share::PERMISSION_READ, $expiresAt);
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/partages');
+        $this->assertResponseIsSuccessful();
+
+        $row = $crawler->filter('[data-testid="share-row-outgoing"]')->text();
+        $this->assertStringContainsString($expiresAt->format('d/m/Y'), $row);
+    }
+
     public function testSharesPageListsIncomingShares(): void
     {
         $owner = $this->createUser('owner-in@example.com');


### PR DESCRIPTION
## Résumé

Discussion avec l'utilisateur : les documents/PDF sans visionneuse n'ont pas de mécanisme de consultation individuelle dans HomeCloud, contrairement aux photos/vidéos (album). Le partage pertinent pour ce cas est donc celui du **dossier** qui contient ces fichiers (`Share::RESOURCE_FOLDER`, déjà fonctionnel depuis les étapes 3/5/7) plutôt qu'un partage multi-fichiers direct ou un export zip.

Le zip a été écarté : en plus de perdre la consultation vivante (mise à jour si on ajoute du contenu après coup), générer un zip à la volée pour plusieurs gros fichiers présenterait un vrai risque de lenteur/timeout côté serveur — contrairement au téléchargement individuel déjà en place (`FileDownloadController`, `StreamedResponse`), qui reste fluide quelle que soit la taille du fichier.

## Changements
- `FolderCard` réutilise `ShareModal` tel quel (`resourceType="folder"`) — même pattern que le bouton album de l'étape 9, aucune duplication.
- `shares.html.twig` affiche désormais systématiquement la durée du partage : date d'expiration si définie, « permanent » sinon (avant, rien ne s'affichait pour un partage permanent).

## Test plan
- [x] `testFolderCardHasShareButtonAndModal` : bouton + modale présents sur chaque dossier
- [x] `testSharesPageListsOutgoingFolderShareWithNameGuestAndPermission` : nom du dossier + invité + permission affichés
- [x] `testSharesPageShowsExpirationDateWhenSet` : date d'expiration affichée
- [x] Suite complète : 555 tests passent
- [x] Vérifié visuellement (Playwright + capture) : modale cohérente, aucune erreur JS