### PR TITLE
Partage par lien public — verrou de visibilité et gestion des invités

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -69,6 +69,9 @@ when@dev: &access_control
             - { path: ^/api/request-reset-password, roles: PUBLIC_ACCESS }
             - { path: ^/api/docs, roles: PUBLIC_ACCESS }
             - { path: ^/api, roles: ROLE_USER }
+            # Partage par lien public : accessible sans compte, le secret est
+            # dans (selector, token). Doit précéder toute règle catch-all ^/.
+            - { path: ^/p/, roles: PUBLIC_ACCESS }
 
 when@prod: *access_control
 

--- a/config/packages/test/security.yaml
+++ b/config/packages/test/security.yaml
@@ -55,4 +55,7 @@ security:
         - { path: ^/api, roles: ROLE_USER }
         - { path: ^/login$, roles: PUBLIC_ACCESS }
         - { path: ^/web/token$, roles: ROLE_USER }
+        # Partage par lien public : accessible sans compte, le secret est
+        # dans (selector, token). Doit précéder la règle catch-all ^/.
+        - { path: ^/p/, roles: PUBLIC_ACCESS }
         - { path: ^/, roles: ROLE_USER }

--- a/config/routes/folder_browser.yaml
+++ b/config/routes/folder_browser.yaml
@@ -1,4 +1,4 @@
 web_folders:
     path: /web/folders
-    controller: App\Controller\FolderBrowserController::index
+    controller: App\Controller\Web\FolderBrowserController::index
     methods: [GET]

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -16,6 +16,8 @@ services:
     App\Interface\FolderRepositoryInterface:      '@App\Repository\FolderRepository'
     App\Interface\UserRepositoryInterface:        '@App\Repository\UserRepository'
     App\Interface\ShareRepositoryInterface:       '@App\Repository\ShareRepository'
+    App\Interface\ShareLinkRepositoryInterface:   '@App\Repository\ShareLinkRepository'
+    App\Interface\ShareLinkAccessCheckerInterface: '@App\Security\ShareLinkAccessChecker'
     App\Interface\FilenameValidatorInterface:     '@App\Service\FilenameValidator'
     App\Interface\OwnershipCheckerInterface:      '@App\Security\OwnershipChecker'
     App\Interface\AuthenticationResolverInterface: '@App\Security\AuthenticationResolver'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -18,6 +18,7 @@ services:
     App\Interface\ShareRepositoryInterface:       '@App\Repository\ShareRepository'
     App\Interface\ShareLinkRepositoryInterface:   '@App\Repository\ShareLinkRepository'
     App\Interface\ShareLinkAccessCheckerInterface: '@App\Security\ShareLinkAccessChecker'
+    App\Interface\ResourceLocatorInterface:       '@App\Security\ResourceLocator'
     App\Interface\FilenameValidatorInterface:     '@App\Service\FilenameValidator'
     App\Interface\OwnershipCheckerInterface:      '@App\Security\OwnershipChecker'
     App\Interface\AuthenticationResolverInterface: '@App\Security\AuthenticationResolver'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -19,6 +19,7 @@ services:
     App\Interface\ShareLinkRepositoryInterface:   '@App\Repository\ShareLinkRepository'
     App\Interface\ShareLinkAccessCheckerInterface: '@App\Security\ShareLinkAccessChecker'
     App\Interface\ResourceLocatorInterface:       '@App\Security\ResourceLocator'
+    App\Interface\SharedResourceCleanerInterface: '@App\Security\SharedResourceCleaner'
     App\Interface\FilenameValidatorInterface:     '@App\Service\FilenameValidator'
     App\Interface\OwnershipCheckerInterface:      '@App\Security\OwnershipChecker'
     App\Interface\AuthenticationResolverInterface: '@App\Security\AuthenticationResolver'

--- a/feat-partage.md
+++ b/feat-partage.md
@@ -1,0 +1,369 @@
+# Partage — état des lieux & plan « privé par défaut, public sur opt-in »
+
+> Ce document remplace `plan-partage.md` (supprimé, jamais commité).
+> Vérifié contre le code du **2026-07-14**, après les PR #204 → #215.
+
+**En une phrase** : HomeCloud n'a aujourd'hui que du privé (tout accès exige un
+compte). On ajoute l'accès public par lien — mais **verrouillé par ressource**, de
+sorte qu'un fichier marqué privé ne puisse **jamais** être exposé par un simple
+échange de lien, même en cas de bug d'interface.
+
+---
+
+## Partie A — Ce qui est FAIT (partage entre comptes)
+
+Le chantier « partage collaboratif » est **terminé et mergé** (PR #204 → #215).
+Résumé de ce qui existe réellement en prod, pour ne pas le redévelopper :
+
+| Brique                   | Où                                                          | Comportement                                                                                                                                                                                                |
+|--------------------------|-------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Entité `Share`           | `src/Entity/Share.php`                                      | Relation polymorphe `resourceType` (file/folder/album) + `resourceId`, **sans FK**. `permission` read/write. `expiresAt` nullable = permanent. Index `idx_share_lookup`, contrainte `uniq_share`.           |
+| Source de vérité d'accès | `src/Security/ResourceAccessChecker.php`                    | `canRead()` / `canWrite()` = **owner OU partage actif**. Consommé par les 4 providers API, 2 contrôleurs de download, et `AlbumVoter`. **Aucun cache** : la révocation est effective à la requête suivante. |
+| Résolution polymorphe    | `src/Security/ResourceLocator.php`                          | `(type, id)` → `File\|Folder\|Album`, 404 si absente.                                                                                                                                                       |
+| Création d'un partage    | `ShareProcessor` (API) + `ShareWebController::create` (web) | Exige l'ownership réel de la ressource, rejette le self-share, 409 sur doublon, **rate-limité** (20 / 15 min / owner). Accepte `guestId` **ou** `guestEmail`.                                               |
+| Nettoyage                | `ShareRepository::deleteByResource()`                       | Appelé aux 5 points de suppression réels (File API/web, Album, Folder récursif).                                                                                                                            |
+| UI                       | `/partages`, `ShareModal`                                   | Page entrants/sortants (nom ressource, personne, droits, durée). Bouton « Partager » sur album et dossier.                                                                                                  |
+
+**Étape non faite du chantier initial** : le bandeau « Partagé par X » sur une ressource
+consultée en tant que guest (cosmétique, non bloquant).
+
+### Le verrou actuel
+
+```php
+// src/Entity/Share.php
+#[ORM\ManyToOne(targetEntity: User::class)]
+#[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+private User $guest;   // ← non-nullable : impose un compte existant
+```
+
+Partager, aujourd'hui, c'est **relier deux comptes**. L'invité s'authentifie
+normalement (session/JWT), et à chaque requête `ShareAccessChecker` rejoue la
+question « existe-t-il une ligne `shares` où `guest = moi` ? ». Il n'y a aucun
+jeton, aucun lien : c'est ce qui rend la révocation instantanée et le modèle
+simple. Le prix : **l'invité doit avoir un compte**.
+
+---
+
+## Partie B — Plan : privé par défaut, public sur opt-in explicite
+
+### B.0 — La question préalable : veut-on de l'accès public ?
+
+Avant de parler de tokens, il faut trancher ceci, sinon on construit sur du sable.
+
+**Réponse : oui, mais jamais par défaut, et jamais sans un verrou explicite par
+ressource.** Le privé reste le mode normal ; le public est une exception que
+l'owner doit déclarer, ressource par ressource.
+
+#### Pourquoi le public est irréductiblement différent
+
+L'autorisation actuelle répond à « **qui es-tu ?** » (identité prouvée par mot de
+passe). Un lien public répond à « **que détiens-tu ?** » (un secret dans une URL).
+Ce n'est pas une variante, c'est un autre modèle, avec une propriété qu'on ne peut
+pas corriger :
+
+> **On ne peut pas empêcher la retransmission d'un lien.**
+> Un lien transféré dans un mail, collé dans un Slack, capturé dans un historique
+> de navigation ou un log de proxy → l'accès suit. Le lien ne distingue pas le
+> destinataire prévu de n'importe qui d'autre.
+
+D'où une asymétrie de révocation qu'il faut assumer :
+
+| | Privé (`Share` + compte) | Public (`ShareLink`) |
+|---|---|---|
+| Qui accède | une personne identifiée | **quiconque détient l'URL** |
+| Révocation | **réellement effective** — on coupe la ligne, l'accès s'arrête | ferme la porte, mais **ne défait pas ce qui a déjà été téléchargé** |
+| Traçabilité | on sait qui | on ne sait pas combien de personnes ont eu le lien |
+
+Un lien public est **réversible dans ses effets futurs, irréversible dans ses
+conséquences**. C'est la raison pour laquelle il ne peut pas être le défaut.
+
+#### Ce qui décide, ce n'est pas le type de fichier
+
+Tentation à écarter : « les photos en public, les documents en privé ». Le même PDF
+peut être un flyer de fête (fuite sans conséquence) ou un bulletin de salaire (fuite
+grave). Le système **ne peut pas deviner** — c'est à l'owner de le déclarer au moment
+du partage. Le rôle du code n'est pas de choisir à sa place, mais de rendre ce choix
+**explicite, réversible et jamais implicite**.
+
+#### Les trois lignes de défense (de la plus forte à la plus faible)
+
+**1. Aucune URL latente.** Une ressource sans `ShareLink` est **inatteignable** — il
+n'y a pas de « lien secret » à deviner, aucune route n'expose une ressource hors du
+firewall. C'est déjà vrai aujourd'hui, et c'est la garantie la plus forte. À préserver.
+
+**2. Le verrou `visibility` — la réponse à « comment garantir qu'un fichier ne peut
+pas être exposé par un simple échange de lien ».** Voir B.1. En une phrase : le
+serveur **refuse** de créer un lien sur une ressource marquée privée. Le refus vit
+dans le domaine, pas dans un template — donc ni un bug d'UI, ni un clic malheureux,
+ni une requête forgée ne peuvent produire un lien public sur un fichier verrouillé.
+C'est la différence entre une politique (qu'on espère respectée) et une **invariante**
+(que le système garantit).
+
+**3. Les garde-fous d'usage** — expiration obligatoire, lecture seule, `noindex`,
+rate-limit (voir B.2). Ils **limitent la casse, ils ne la préviennent pas**. Ils ne
+remplacent jamais le point 2.
+
+#### Les règles qui en découlent (non négociables)
+
+1. **Le lien EST l'autorisation** — l'email qui le transporte ne protège rien. L'UI
+   ne doit donc pas dire « partager *avec* Untel » mais « **créer un lien d'accès** ».
+2. **Lien = lecture seule.** Un `write` porté par un lien signifierait que n'importe
+   quel porteur peut renommer/supprimer. Exclu.
+3. **Expiration obligatoire** (pas de `null`), défaut 7 j, max 30 j. Un lien qui
+   n'expire jamais est une fuite qui n'expire jamais. C'est l'inverse du défaut du
+   partage entre comptes (permanent) — et c'est délibéré.
+4. **`visibility = private` par défaut** sur toute ressource, existante comme nouvelle.
+
+Ces règles définissent ce qu'on livre. Si l'une est refusée, le plan change.
+
+### B.1 — Modèle de données
+
+#### a) Le verrou de visibilité (le cœur de la garantie)
+
+Un champ `visibility` sur `File`, `Folder` et `Album` :
+
+```php
+public const VISIBILITY_PRIVATE      = 'private';       // défaut — aucun lien possible
+public const VISIBILITY_LINK_ALLOWED = 'link_allowed';  // opt-in explicite de l'owner
+
+#[ORM\Column(type: 'string', length: 12, options: ['default' => 'private'])]
+private string $visibility = self::VISIBILITY_PRIVATE;
+```
+
+La migration met **`private` sur tout l'existant** : aucune ressource déjà en base ne
+devient exposable par l'ajout de la fonctionnalité.
+
+La règle est appliquée **côté serveur, dans le domaine** — pas dans un template :
+
+```php
+// ShareLinkFactory (ou le service de création)
+if ($resource->getVisibility() !== VISIBILITY_LINK_ALLOWED) {
+    throw new ResourceNotPubliclyShareableException();  // → 403
+}
+```
+
+Conséquences concrètes, et c'est exactement ce qu'on cherchait :
+- Un fichier `private` **ne peut pas** produire de lien, quoi qu'il arrive côté UI.
+- **Un dossier `private` protège son contenu** : un dossier `Privé` (bulletins, papiers
+  d'identité, contrats) est structurellement non-exposable par lien. C'est la réponse
+  simple et robuste au besoin « certains fichiers ne doivent jamais sortir ».
+- Repasser une ressource en `private` **révoque ses liens existants** (cascade — à
+  tester explicitement, cf. B.4 étape 6).
+- **Héritage** : un fichier hérite-t-il de la visibilité de son dossier ? Recommandé :
+  la vérification remonte la chaîne des parents, et **le plus restrictif gagne** — un
+  fichier `link_allowed` dans un dossier `private` reste non-partageable. Sinon
+  déplacer un fichier dans le dossier « Privé » ne le protégerait pas, ce qui ruinerait
+  la garantie. (À confirmer, cf. B.5.)
+
+#### b) L'entité `ShareLink`
+
+Deux options pour porter le lien. **Option 2 recommandée.**
+
+**Option 1 — rendre `Share::$guest` nullable.** Un `Share` sans guest = un lien.
+Séduisant (une seule table), mais toxique : chaque appelant de `getGuest()`
+devient nullable, `uniq_share` casse (plusieurs liens sur la même ressource, tous
+avec `guest = NULL`), et surtout `findActiveShare()` — le cœur de la sécurité,
+appelé à chaque requête — mélangerait deux logiques d'autorisation
+fondamentalement différentes. On dégraderait le code déjà solide.
+
+**Option 2 (retenue) — nouvelle entité `ShareLink`, distincte.**
+
+```php
+#[ORM\Entity]
+#[ORM\Table(name: 'share_links')]
+#[ORM\Index(name: 'idx_sharelink_selector', columns: ['selector'])]
+class ShareLink
+{
+    private Uuid $id;                    // Uuid::v7() dans le constructeur (règle projet)
+    private User $owner;                 // qui a créé le lien
+    private string $resourceType;        // file | folder | album
+    private Uuid $resourceId;
+    private string $selector;            // public, indexé, sert à retrouver la ligne
+    private string $hashedToken;         // hash du secret — le secret n'est JAMAIS stocké
+    private \DateTimeImmutable $expiresAt;   // NON nullable (cf. B.0)
+    private ?string $invitedEmail;       // trace de livraison, sans valeur de sécurité
+    private \DateTimeImmutable $createdAt;
+    private ?\DateTimeImmutable $revokedAt = null;
+
+    public function isActive(): bool
+    {
+        return $this->revokedAt === null && $this->expiresAt > new \DateTimeImmutable();
+    }
+}
+```
+
+`Share` reste **strictement inchangé**. Les deux mécanismes coexistent sans se
+polluer : `ResourceAccessChecker` continue de répondre pour les comptes,
+`ShareLinkAccessChecker` répond pour les liens.
+
+**Les deux systèmes ne se recouvrent pas** — et c'est voulu :
+
+| Besoin | Mécanisme | Le destinataire a-t-il un compte ? |
+|---|---|---|
+| Partager durablement avec un proche qui utilise HomeCloud | `Share` (existant) | oui |
+| Envoyer une photo à quelqu'un qui n'aura jamais de compte | `ShareLink` | non |
+| Ne jamais exposer un document sensible | `visibility = private` (défaut) | — aucun partage possible par lien |
+
+**Pourquoi selector + hashedToken** (et non un token en clair en base) : c'est le
+pattern déjà utilisé par le projet pour la réinitialisation de mot de passe
+(`ResetPasswordRequest`, bundle SymfonyCasts). Si la base fuite, les liens ne sont
+pas exploitables. Le secret n'existe qu'une fois, dans l'URL envoyée.
+
+```
+URL :   /p/{selector}/{token}
+Base :  selector (clair, indexé)  +  hashedToken = hash('sha256', token)
+Vérif : trouver par selector, puis hash_equals(hashedToken, hash(token_fourni))
+        → comparaison à temps constant, pas de timing attack
+```
+
+### B.2 — Sécurité : la checklist non négociable
+
+| Risque | Défense |
+|---|---|
+| Token devinable | `random_bytes(32)` → `bin2hex` (256 bits). Jamais `uniqid()`, `rand()`, ni un UUID. |
+| Base compromise → liens rejouables | Seul le **hash** est stocké. |
+| Timing attack sur la comparaison | `hash_equals()`, jamais `===`. |
+| Token dans les logs serveur / Referer | Le token est dans le **path**, pas la query string (les query strings finissent dans les access logs et l'en-tête `Referer`). Ajouter `Referrer-Policy: no-referrer` — **déjà en place** (`SecurityHeadersListener`). |
+| Indexation par un moteur de recherche | `X-Robots-Tag: noindex, nofollow` sur les réponses `/p/*`. |
+| Brute-force du selector | Rate-limit sur `/p/*` (réutiliser le pattern `rate_limiter.yaml` de `share_creation`). |
+| Énumération d'emails à la création | Déjà couvert : rate-limit sur la création. |
+| Lien qui survit à la suppression de la ressource | Étendre `deleteByResource()` — **ou** un `ShareLinkRepository::deleteByResource()` appelé aux **mêmes 5 points** que `Share` (cf. Partie A). Ne pas oublier ce point : c'est exactement le trou qu'on a dû colmater à l'étape 6 du chantier précédent. |
+| Élévation vers l'écriture | Impossible par construction : le lien n'accorde que `read` (B.0). |
+| Le porteur du lien accède à **autre chose** | La ressource est liée au lien en base. Le porteur ne peut pas changer `resourceId` : il n'apparaît nulle part dans l'URL. |
+| **Exposition accidentelle d'une ressource sensible** | **`visibility = private` par défaut** : le serveur refuse de créer un lien (B.1.a). Ni un bug d'UI, ni une requête forgée ne peuvent contourner ce refus — il est dans le domaine. |
+| Contournement du verrou en déplaçant le fichier | La vérification **remonte la chaîne des parents** : le plus restrictif gagne (B.1.a). Un fichier dans un dossier `private` reste non-partageable. |
+
+**Le piège du firewall.** `config/packages/security.yaml` : le firewall `web`
+couvre `pattern: ^/`. Une route `/p/*` doit être explicitement `PUBLIC_ACCESS`.
+⚠️ Le fichier prévient lui-même que `config/packages/test/security.yaml` redéfinit
+tout l'`access_control` — **toute règle ajoutée doit être répercutée là-bas**,
+sinon les tests ne valideront pas ce qu'on croit.
+
+### B.3 — Envoi de l'email
+
+`symfony/mailer` est installé, mais `.env` est sur `MAILER_DSN=null://null` :
+**aucun email ne part aujourd'hui**. Il faut un vrai DSN (o2switch fournit du
+SMTP) dans `.env.local` / secrets de déploiement.
+
+Décision à prendre : bloquer la v1 sur la config SMTP, ou livrer d'abord le lien
+**copiable dans l'UI** (« Copier le lien ») et brancher l'email juste après ?
+La seconde option découple, permet de tester tout le mécanisme sans dépendre du
+mail, et reste utile ensuite (on veut souvent copier un lien plutôt que
+l'envoyer). **Recommandé : lien copiable d'abord, email en second temps.**
+
+### B.4 — Découpage TDD
+
+Conventions projet : une branche par étape depuis `main`, TDD RED → GREEN →
+REFACTOR, PR + CI verte avant merge. Jamais de commit sur `main`.
+
+**Étape 0 — Le verrou `visibility` (à faire EN PREMIER)**
+
+Cette étape vient avant tout le reste, et ce n'est pas un détail d'ordonnancement :
+tant qu'elle n'existe pas, toute route publique livrée ensuite est exposable sans
+garde-fou. On pose la serrure avant de percer la porte.
+
+- RED (unitaire) : une ressource neuve est `private` ; créer un lien sur une
+  ressource `private` **lève une exception** ; sur une ressource `link_allowed`,
+  ça passe ; un fichier `link_allowed` **dans un dossier `private`** est refusé
+  (héritage, le plus restrictif gagne) ; repasser en `private` **révoque les liens
+  existants**.
+- GREEN : constantes + champ `visibility` sur `File`/`Folder`/`Album`,
+  `VisibilityChecker` (SRP — répond « cette ressource est-elle exposable ? » en
+  remontant les parents), exception dédiée → 403.
+- Migration : `visibility = 'private'` sur **tout l'existant** (aucune ressource
+  déjà en base ne doit devenir exposable par le déploiement).
+
+**Étape 1 — Entité + génération du token (socle, aucune route exposée)**
+- RED (unitaire) : le token généré fait 64 caractères hex ; deux appels donnent
+  deux tokens différents ; le token en clair n'est pas stocké ; `hash_equals`
+  valide le bon token et rejette un token modifié d'un caractère ; `isActive()`
+  est faux si expiré, faux si révoqué, vrai sinon.
+- GREEN : `ShareLink` (+ `Uuid::v7()` dans le constructeur, règle projet),
+  `ShareLinkRepository`, `ShareLinkGenerator` (SRP : génère, ne persiste pas).
+- Migration via `make:migration`.
+
+**Étape 2 — `ShareLinkAccessChecker` (SRP, symétrique de `ShareAccessChecker`)**
+- RED (unitaire) : selector inconnu → null ; token invalide → null ; lien expiré
+  → null ; lien révoqué → null ; lien valide → retourne le `ShareLink`.
+- GREEN : le service + son interface (DIP, comme le reste de `src/Security/`).
+
+**Étape 3 — Route publique de consultation `/p/{selector}/{token}`**
+- RED (fonctionnel) : lien valide → 200 et le contenu s'affiche **sans être
+  connecté** ; token faux → 404 (**pas 403** : ne pas confirmer l'existence du
+  selector) ; expiré → 404 ; révoqué → 404 ; en-tête `X-Robots-Tag: noindex`
+  présent ; la page n'expose **aucune** action d'écriture.
+- GREEN : `PublicShareController`, template dédié (ne pas réutiliser le layout
+  authentifié : pas de sidebar, pas de menu — le visiteur n'a pas de compte),
+  `access_control` PUBLIC_ACCESS **dans les deux fichiers de sécurité** (B.2).
+
+⚠️ **Fait à l'issue de l'étape 3** : le verrou `VisibilityChecker` (étape 0)
+n'est **pas encore branché à la création d'un `ShareLink`**. Rien n'empêche
+aujourd'hui de créer un lien sur une ressource `private` — les tests de
+l'étape 3 positionnent `visibility` manuellement sur les fixtures pour
+simuler un lien déjà créé, ils ne passent par aucun point de création réel.
+Le verrou doit être appelé dans le service de création du lien (étape 5,
+`ShareLinkFactory` ou équivalent) via `denyUnlessPubliclyShareable()`, avec
+un test RED dédié qui vérifie le refus. Ne pas livrer l'étape 5 sans ce test.
+
+**Étape 4 — Téléchargement public**
+- RED : le porteur d'un lien valide télécharge le fichier partagé (ou un fichier
+  du dossier partagé) ; sans lien → 403 ; **un fichier hors du périmètre du lien
+  → 403** (c'est LE test qui compte : vérifier qu'on ne peut pas pivoter vers
+  une autre ressource de l'owner).
+- GREEN : le contrôle passe par `ShareLinkAccessChecker`, jamais par
+  `ResourceAccessChecker` (qui suppose un `User`).
+
+**Étape 5 — Création du lien depuis `ShareModal` + « Copier le lien »**
+- RED (fonctionnel) : POST crée le lien et l'affiche ; CSRF invalide → 403 ;
+  non-owner de la ressource → 403 ; **ressource `private` → 403** (le verrou de
+  l'étape 0 doit tenir jusqu'au bout de la chaîne HTTP, pas seulement en unitaire) ;
+  `expiresAt` absent → défaut 7 jours ; au-delà de 30 jours → ramené à 30 (ou 400,
+  à trancher).
+- GREEN : étendre `ShareModal` avec un onglet/bascule « Compte » ↔ « Lien »
+  (le composant est déjà paramétrable par ressource — ne pas le dupliquer),
+  route web, affichage du lien + bouton copier.
+- UI : sur une ressource `private`, l'onglet « Lien » **affiche pourquoi c'est
+  bloqué** et propose l'opt-in explicite (« Autoriser le partage par lien pour
+  cette ressource »), plutôt que de masquer le bouton sans explication.
+
+**Étape 6 — Révocation + page `/partages`**
+- RED : l'owner révoque → le lien renvoie 404 à la requête suivante ; les liens
+  apparaissent dans `/partages` avec leur date d'expiration et un bouton
+  « Révoquer » ; **supprimer la ressource supprime ses liens** (cf. B.2) ;
+  **repasser la ressource en `private` révoque tous ses liens actifs** — c'est le
+  bouton d'arrêt d'urgence, il doit être testé.
+- GREEN : `revokedAt`, `deleteByResource()` branché aux **5 mêmes points** que
+  `Share`, section « Liens publics » dans `shares.html.twig`.
+
+**Étape 7 — Envoi de l'email** (dépend de la config SMTP, cf. B.3)
+- RED : la création avec un email déclenche l'envoi (mailer mocké en test) ;
+  le mail contient le lien complet ; l'échec d'envoi ne casse pas la création
+  du lien (le lien reste copiable — dégradation gracieuse).
+
+### B.5 — Points à trancher avant de coder
+
+1. **Le verrou `visibility`, `private` par défaut** — c'est LA décision structurante
+   (cf. B.0 et B.1.a). Tout le reste en découle. À confirmer en premier.
+2. **Héritage de la visibilité : le plus restrictif gagne** — un fichier
+   `link_allowed` dans un dossier `private` reste non-partageable. Recommandé :
+   **oui**, sinon un simple déplacement de fichier contournerait le verrou et la
+   garantie ne vaudrait plus rien (cf. B.1.a).
+3. **`expiresAt` obligatoire, défaut 7 j, max 30 j** — confirmer (cf. B.0).
+4. **Lecture seule uniquement** — confirmer (cf. B.0).
+5. **Lien copiable d'abord, email ensuite** — confirmer (cf. B.3).
+6. **Un lien par ressource, ou plusieurs ?** Plusieurs liens permettent de révoquer
+   un destinataire sans casser les autres. Recommandé : plusieurs, pas de contrainte
+   d'unicité (contrairement à `Share`).
+7. **Mot de passe optionnel sur le lien ?** C'est la seule chose qui casse
+   l'équation « lien = accès » : le porteur du lien ne suffit plus. Hors v1, mais le
+   modèle le permettra (colonne nullable) — à garder en tête si des documents
+   sensibles doivent un jour transiter par lien.
+
+---
+
+## Partie C — Ce qu'il reste du chantier précédent
+
+- **Étape 10 (non faite)** : bandeau « Partagé par {owner} · lecture seule » sur
+  une ressource ouverte en tant que guest, avec masquage des actions d'écriture
+  côté UI si `permission = read`. La sécurité serveur est déjà en place ; ce n'est
+  que le reflet visuel. Petit chantier, indépendant du partage par lien.

--- a/migrations/Version20260714200946.php
+++ b/migrations/Version20260714200946.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260714200946 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Ajoute le verrou visibility (private par défaut) sur albums, files, folders — partage par lien.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE albums ADD visibility VARCHAR(12) DEFAULT \'private\' NOT NULL');
+        $this->addSql('ALTER TABLE files ADD visibility VARCHAR(12) DEFAULT \'private\' NOT NULL');
+        $this->addSql('ALTER TABLE folders ADD visibility VARCHAR(12) DEFAULT \'private\' NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE albums DROP visibility');
+        $this->addSql('ALTER TABLE files DROP visibility');
+        $this->addSql('ALTER TABLE folders DROP visibility');
+    }
+}

--- a/migrations/Version20260714201730.php
+++ b/migrations/Version20260714201730.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260714201730 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Crée la table share_links (partage par lien public, sans compte invité).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE share_links (id BINARY(16) NOT NULL, resource_type VARCHAR(10) NOT NULL, resource_id BINARY(16) NOT NULL, selector VARCHAR(32) NOT NULL, hashed_token VARCHAR(64) NOT NULL, expires_at DATETIME NOT NULL, created_at DATETIME NOT NULL, revoked_at DATETIME DEFAULT NULL, owner_id BINARY(16) NOT NULL, UNIQUE INDEX UNIQ_58EC4DF59692E25D (selector), INDEX IDX_58EC4DF57E3C61F9 (owner_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
+        $this->addSql('ALTER TABLE share_links ADD CONSTRAINT FK_58EC4DF57E3C61F9 FOREIGN KEY (owner_id) REFERENCES users (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE share_links DROP FOREIGN KEY FK_58EC4DF57E3C61F9');
+        $this->addSql('DROP TABLE share_links');
+    }
+}

--- a/migrations/Version20260714220928.php
+++ b/migrations/Version20260714220928.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260714220928 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Ajoute account_type (full/guest) sur users — statut permanent distinguant un compte invité.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE users ADD account_type VARCHAR(10) DEFAULT \'full\' NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE users DROP account_type');
+    }
+}

--- a/migrations/Version20260715091102.php
+++ b/migrations/Version20260715091102.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260715091102 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'ResetPasswordRequest.user en CASCADE — supprimer un compte invité en attente d\'activation ne doit plus lever de FK violation.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE reset_password_request DROP FOREIGN KEY `FK_7CE748AA76ED395`');
+        $this->addSql('ALTER TABLE reset_password_request ADD CONSTRAINT FK_7CE748AA76ED395 FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE reset_password_request DROP FOREIGN KEY FK_7CE748AA76ED395');
+        $this->addSql('ALTER TABLE reset_password_request ADD CONSTRAINT `FK_7CE748AA76ED395` FOREIGN KEY (user_id) REFERENCES users (id)');
+    }
+}

--- a/migrations/Version20260715094551.php
+++ b/migrations/Version20260715094551.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260715094551 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'ShareLink.expiresAt devient nullable — l\'owner peut choisir un lien permanent à la création.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE share_links CHANGE expires_at expires_at DATETIME DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE share_links CHANGE expires_at expires_at DATETIME NOT NULL');
+    }
+}

--- a/src/ApiResource/FileOutput.php
+++ b/src/ApiResource/FileOutput.php
@@ -10,7 +10,7 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\OpenApi\Model;
-use App\Controller\FileUploadController;
+use App\Controller\Api\FileUploadController;
 use App\State\FileProcessor;
 use App\State\FileProvider;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;

--- a/src/Controller/Api/AlbumAddMediaController.php
+++ b/src/Controller/Api/AlbumAddMediaController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Api;
 
 use App\Interface\AlbumRepositoryInterface;
 use App\Repository\MediaRepository;

--- a/src/Controller/Api/AlbumRemoveMediaController.php
+++ b/src/Controller/Api/AlbumRemoveMediaController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Api;
 
 use App\Interface\AlbumRepositoryInterface;
 use App\Repository\MediaRepository;

--- a/src/Controller/Api/FileDownloadController.php
+++ b/src/Controller/Api/FileDownloadController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Api;
 
 use App\Entity\Share;
 use App\Entity\User;

--- a/src/Controller/Api/FileUploadController.php
+++ b/src/Controller/Api/FileUploadController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Api;
 
 use App\ApiResource\FileOutput;
 use App\Message\MediaProcessMessage;

--- a/src/Controller/Api/MediaThumbnailController.php
+++ b/src/Controller/Api/MediaThumbnailController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Api;
 
 use App\Entity\Share;
 use App\Entity\User;

--- a/src/Controller/Api/RefreshTokenController.php
+++ b/src/Controller/Api/RefreshTokenController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Api;
 
 use App\Entity\RefreshToken;
 use App\Repository\RefreshTokenRepository;

--- a/src/Controller/Api/ResetPasswordController.php
+++ b/src/Controller/Api/ResetPasswordController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Controller;
+namespace App\Controller\Api;
 
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;

--- a/src/Controller/Web/FileWebController.php
+++ b/src/Controller/Web/FileWebController.php
@@ -10,6 +10,7 @@ use App\Interface\StorageServiceInterface;
 use App\Repository\FileRepository;
 use App\Interface\DefaultFolderServiceInterface;
 use App\Interface\SharedResourceCleanerInterface;
+use App\Security\GuestRestrictionChecker;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -43,6 +44,7 @@ final class FileWebController extends AbstractController
         private readonly FileRepository $fileRepository,
         private readonly EntityManagerInterface $em,
         private readonly SharedResourceCleanerInterface $sharedResourceCleaner,
+        private readonly GuestRestrictionChecker $guestRestrictionChecker,
     ) {}
 
     #[Route('/files/{id}/download', name: 'app_file_download', methods: ['GET'])]
@@ -77,6 +79,10 @@ final class FileWebController extends AbstractController
             throw $this->createAccessDeniedException('Jeton CSRF invalide.');
         }
 
+        /** @var \App\Entity\User $user */
+        $user = $this->getUser();
+        $this->guestRestrictionChecker->denyUnlessFullAccount($user);
+
         $folderId = $request->request->get('folder_id');
         $uploadedFile = $request->files->get('file');
 
@@ -96,8 +102,6 @@ final class FileWebController extends AbstractController
             );
         }
 
-        /** @var \App\Entity\User $user */
-        $user = $this->getUser();
         $folder = $this->folderService->resolve($folderId, null, $user);
 
         // Retire les caractères de contrôle ET < > (neutralise le XSS stocké si ce nom

--- a/src/Controller/Web/FileWebController.php
+++ b/src/Controller/Web/FileWebController.php
@@ -7,9 +7,9 @@ namespace App\Controller\Web;
 use App\Entity\File;
 use App\Entity\Share;
 use App\Interface\StorageServiceInterface;
-use App\Interface\ShareRepositoryInterface;
 use App\Repository\FileRepository;
 use App\Interface\DefaultFolderServiceInterface;
+use App\Interface\SharedResourceCleanerInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -42,7 +42,7 @@ final class FileWebController extends AbstractController
         private readonly DefaultFolderServiceInterface $folderService,
         private readonly FileRepository $fileRepository,
         private readonly EntityManagerInterface $em,
-        private readonly ShareRepositoryInterface $shareRepository,
+        private readonly SharedResourceCleanerInterface $sharedResourceCleaner,
     ) {}
 
     #[Route('/files/{id}/download', name: 'app_file_download', methods: ['GET'])]
@@ -161,7 +161,7 @@ final class FileWebController extends AbstractController
             return $this->redirect($folderId ? '/explorer?folder=' . $folderId : '/explorer');
         }
 
-        $this->shareRepository->deleteByResource(Share::RESOURCE_FILE, $file->getId());
+        $this->sharedResourceCleaner->deleteByResource(Share::RESOURCE_FILE, $file->getId());
         $this->em->remove($file);
         $this->em->flush();
 

--- a/src/Controller/Web/FolderBrowserController.php
+++ b/src/Controller/Web/FolderBrowserController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Controller;
+namespace App\Controller\Web;
 
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;

--- a/src/Controller/Web/GuestManagementWebController.php
+++ b/src/Controller/Web/GuestManagementWebController.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Web;
+
+use App\Entity\User;
+use App\Interface\UserRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Gestion CRUD des comptes invités (créer/éditer/supprimer).
+ *
+ * HomeCloud est mono-owner par instance (un seul compte "full") : la liste
+ * ne filtre donc pas par propriétaire de l'invitation, seulement par
+ * accountType=guest. Toute route ici vérifie explicitement isGuest() sur la
+ * cible, pour ne jamais permettre d'éditer/supprimer le compte owner lui-même
+ * ou un autre compte complet via cette page.
+ */
+#[IsGranted('ROLE_USER')]
+final class GuestManagementWebController extends AbstractController
+{
+    public function __construct(
+        private readonly UserRepositoryInterface $userRepository,
+        private readonly EntityManagerInterface $em,
+    ) {}
+
+    #[Route('/invites', name: 'app_guests')]
+    public function index(): Response
+    {
+        $guests = $this->userRepository->findBy(['accountType' => User::ACCOUNT_TYPE_GUEST], ['createdAt' => 'DESC']);
+
+        return $this->render('web/guests.html.twig', ['guests' => $guests]);
+    }
+
+    #[Route('/invites/{id}/edit', name: 'app_guest_edit', methods: ['POST'])]
+    public function edit(string $id, Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('guest-edit', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Jeton CSRF invalide.');
+        }
+
+        $guest = $this->findGuestOrFail($id);
+
+        $displayName = trim((string) $request->request->get('displayName', ''));
+        if ($displayName !== '') {
+            $guest->setDisplayName($displayName);
+            $this->em->flush();
+            $this->addFlash('success', 'Invité mis à jour.');
+        }
+
+        return $this->redirect('/invites');
+    }
+
+    #[Route('/invites/{id}/delete', name: 'app_guest_delete', methods: ['POST'])]
+    public function delete(string $id, Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('guest-delete', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Jeton CSRF invalide.');
+        }
+
+        $guest = $this->findGuestOrFail($id);
+
+        $this->em->remove($guest);
+        $this->em->flush();
+
+        $this->addFlash('success', 'Invité supprimé.');
+
+        return $this->redirect('/invites');
+    }
+
+    private function findGuestOrFail(string $id): User
+    {
+        $user = $this->userRepository->find(Uuid::fromString($id));
+
+        if ($user === null || !$user->isGuest()) {
+            throw $this->createNotFoundException('Invité introuvable.');
+        }
+
+        return $user;
+    }
+}

--- a/src/Controller/Web/PublicShareController.php
+++ b/src/Controller/Web/PublicShareController.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Web;
+
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Interface\ShareLinkAccessCheckerInterface;
+use App\Security\ResourceLocator;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Consultation d'une ressource via un lien de partage public — sans compte,
+ * sans session. Le secret est entièrement porté par (selector, token) dans
+ * l'URL ; aucune vérification ne repose sur l'utilisateur connecté.
+ *
+ * Volontairement : token faux, lien expiré ou révoqué renvoient tous 404
+ * (jamais 403), pour ne pas confirmer à un attaquant qu'un selector existe.
+ */
+final class PublicShareController extends AbstractController
+{
+    public function __construct(
+        private readonly ShareLinkAccessCheckerInterface $shareLinkAccessChecker,
+        private readonly ResourceLocator $resourceLocator,
+    ) {}
+
+    #[Route('/p/{selector}/{token}', name: 'app_public_share', methods: ['GET'])]
+    public function show(string $selector, string $token): Response
+    {
+        $link = $this->shareLinkAccessChecker->resolve($selector, $token);
+
+        if ($link === null) {
+            throw new NotFoundHttpException();
+        }
+
+        // ResourceLocator::locate() lève déjà NotFoundHttpException si la
+        // ressource a été supprimée depuis la création du lien — pas de
+        // traitement supplémentaire nécessaire, la 404 se propage telle quelle.
+        $resource = $this->resourceLocator->locate($link->getResourceType(), $link->getResourceId());
+
+        $response = $this->render('web/public_share.html.twig', [
+            'resource'     => $resource,
+            'resourceType' => $link->getResourceType(),
+            'resourceName' => $this->resourceName($resource),
+            'link'         => $link,
+        ]);
+
+        $response->headers->set('X-Robots-Tag', 'noindex, nofollow');
+
+        return $response;
+    }
+
+    private function resourceName(File|Folder|Album $resource): string
+    {
+        return match (true) {
+            $resource instanceof File   => $resource->getOriginalName(),
+            $resource instanceof Folder => $resource->getName(),
+            $resource instanceof Album  => $resource->getName(),
+        };
+    }
+}

--- a/src/Controller/Web/PublicShareController.php
+++ b/src/Controller/Web/PublicShareController.php
@@ -8,11 +8,13 @@ use App\Entity\Album;
 use App\Entity\File;
 use App\Entity\Folder;
 use App\Interface\FileRepositoryInterface;
+use App\Interface\MediaRepositoryInterface;
 use App\Interface\ShareLinkAccessCheckerInterface;
 use App\Interface\StorageServiceInterface;
 use App\Security\ResourceLocator;
 use App\Security\SharedFileScopeChecker;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\Response;
@@ -36,6 +38,7 @@ final class PublicShareController extends AbstractController
         private readonly ShareLinkAccessCheckerInterface $shareLinkAccessChecker,
         private readonly ResourceLocator $resourceLocator,
         private readonly FileRepositoryInterface $fileRepository,
+        private readonly MediaRepositoryInterface $mediaRepository,
         private readonly SharedFileScopeChecker $sharedFileScopeChecker,
         private readonly StorageServiceInterface $storageService,
     ) {}
@@ -50,6 +53,7 @@ final class PublicShareController extends AbstractController
             'resourceType' => $link->getResourceType(),
             'resourceName' => $this->resourceName($resource),
             'link'         => $link,
+            'token'        => $token,
         ]);
 
         $response->headers->set('X-Robots-Tag', 'noindex, nofollow');
@@ -92,6 +96,73 @@ final class PublicShareController extends AbstractController
         $response->headers->set('X-Robots-Tag', 'noindex, nofollow');
 
         return $response;
+    }
+
+    /**
+     * Sert le thumbnail d'un média pour la grille de vignettes de la page
+     * publique — équivalent de MediaGalleryController::thumbnail() mais sans
+     * compte, le contrôle passe par le lien plutôt que par la session.
+     */
+    #[Route('/p/{selector}/{token}/media/{mediaId}/thumbnail', name: 'app_public_share_media_thumbnail', methods: ['GET'])]
+    public function mediaThumbnail(string $selector, string $token, string $mediaId): Response
+    {
+        [$link, $linkResource] = $this->resolveLinkOrFail($selector, $token);
+        $media = $this->mediaInScopeOrFail($mediaId, $link, $linkResource);
+
+        if ($media->getThumbnailPath() === null) {
+            throw new NotFoundHttpException();
+        }
+
+        $absolutePath = $this->storageService->getAbsolutePath($media->getThumbnailPath());
+
+        if (!file_exists($absolutePath)) {
+            throw new NotFoundHttpException();
+        }
+
+        $response = new BinaryFileResponse($absolutePath);
+        $response->headers->set('Content-Type', 'image/jpeg');
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('X-Robots-Tag', 'noindex, nofollow');
+
+        return $response;
+    }
+
+    /**
+     * Sert le fichier original en affichage inline pour la lightbox de la
+     * page publique — équivalent de MediaGalleryController::full().
+     */
+    #[Route('/p/{selector}/{token}/media/{mediaId}/full', name: 'app_public_share_media_full', methods: ['GET'])]
+    public function mediaFull(string $selector, string $token, string $mediaId): Response
+    {
+        [$link, $linkResource] = $this->resolveLinkOrFail($selector, $token);
+        $media = $this->mediaInScopeOrFail($mediaId, $link, $linkResource);
+
+        $file = $media->getFile();
+        $absolutePath = $this->storageService->getAbsolutePath($file->getPath());
+
+        if (!file_exists($absolutePath)) {
+            throw new NotFoundHttpException();
+        }
+
+        $response = new BinaryFileResponse($absolutePath);
+        $response->headers->set('Content-Type', $file->getMimeType());
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('X-Robots-Tag', 'noindex, nofollow');
+        $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_INLINE);
+
+        return $response;
+    }
+
+    private function mediaInScopeOrFail(string $mediaId, \App\Entity\ShareLink $link, File|Folder|Album $linkResource): \App\Entity\Media
+    {
+        $media = $this->mediaRepository->findById(Uuid::fromString($mediaId))
+            ?? throw new NotFoundHttpException();
+
+        if (!$this->sharedFileScopeChecker->isInScope($media->getFile(), $link->getResourceType(), $link->getResourceId(), $linkResource)) {
+            throw new AccessDeniedHttpException('Ce média ne fait pas partie du partage.');
+        }
+
+        return $media;
     }
 
     private function resourceName(File|Folder|Album $resource): string

--- a/src/Controller/Web/PublicShareController.php
+++ b/src/Controller/Web/PublicShareController.php
@@ -7,12 +7,20 @@ namespace App\Controller\Web;
 use App\Entity\Album;
 use App\Entity\File;
 use App\Entity\Folder;
+use App\Interface\FileRepositoryInterface;
 use App\Interface\ShareLinkAccessCheckerInterface;
+use App\Interface\StorageServiceInterface;
 use App\Security\ResourceLocator;
+use App\Security\SharedFileScopeChecker;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\HeaderUtils;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * Consultation d'une ressource via un lien de partage public — sans compte,
@@ -27,21 +35,15 @@ final class PublicShareController extends AbstractController
     public function __construct(
         private readonly ShareLinkAccessCheckerInterface $shareLinkAccessChecker,
         private readonly ResourceLocator $resourceLocator,
+        private readonly FileRepositoryInterface $fileRepository,
+        private readonly SharedFileScopeChecker $sharedFileScopeChecker,
+        private readonly StorageServiceInterface $storageService,
     ) {}
 
     #[Route('/p/{selector}/{token}', name: 'app_public_share', methods: ['GET'])]
     public function show(string $selector, string $token): Response
     {
-        $link = $this->shareLinkAccessChecker->resolve($selector, $token);
-
-        if ($link === null) {
-            throw new NotFoundHttpException();
-        }
-
-        // ResourceLocator::locate() lève déjà NotFoundHttpException si la
-        // ressource a été supprimée depuis la création du lien — pas de
-        // traitement supplémentaire nécessaire, la 404 se propage telle quelle.
-        $resource = $this->resourceLocator->locate($link->getResourceType(), $link->getResourceId());
+        [$link, $resource] = $this->resolveLinkOrFail($selector, $token);
 
         $response = $this->render('web/public_share.html.twig', [
             'resource'     => $resource,
@@ -55,6 +57,43 @@ final class PublicShareController extends AbstractController
         return $response;
     }
 
+    #[Route('/p/{selector}/{token}/download/{fileId}', name: 'app_public_share_download', methods: ['GET'])]
+    public function download(string $selector, string $token, string $fileId): StreamedResponse
+    {
+        [$link, $linkResource] = $this->resolveLinkOrFail($selector, $token);
+
+        $file = $this->fileRepository->findById(Uuid::fromString($fileId))
+            ?? throw new NotFoundHttpException();
+
+        if (!$this->sharedFileScopeChecker->isInScope($file, $link->getResourceType(), $link->getResourceId(), $linkResource)) {
+            throw new AccessDeniedHttpException('Ce fichier ne fait pas partie du partage.');
+        }
+
+        $absolutePath = $this->storageService->getAbsolutePath($file->getPath());
+
+        if (!file_exists($absolutePath)) {
+            throw new NotFoundHttpException();
+        }
+
+        $detectedMime = (new \finfo(FILEINFO_MIME_TYPE))->file($absolutePath) ?: 'application/octet-stream';
+
+        $disposition = HeaderUtils::makeDisposition(
+            ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+            $file->getOriginalName(),
+        );
+
+        $response = new StreamedResponse(function () use ($absolutePath): void {
+            readfile($absolutePath);
+        });
+
+        $response->headers->set('Content-Type', $detectedMime);
+        $response->headers->set('Content-Disposition', $disposition);
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('X-Robots-Tag', 'noindex, nofollow');
+
+        return $response;
+    }
+
     private function resourceName(File|Folder|Album $resource): string
     {
         return match (true) {
@@ -62,5 +101,24 @@ final class PublicShareController extends AbstractController
             $resource instanceof Folder => $resource->getName(),
             $resource instanceof Album  => $resource->getName(),
         };
+    }
+
+    /**
+     * @return array{0: \App\Entity\ShareLink, 1: File|Folder|Album}
+     */
+    private function resolveLinkOrFail(string $selector, string $token): array
+    {
+        $link = $this->shareLinkAccessChecker->resolve($selector, $token);
+
+        if ($link === null) {
+            throw new NotFoundHttpException();
+        }
+
+        // ResourceLocator::locate() lève déjà NotFoundHttpException si la
+        // ressource a été supprimée depuis la création du lien — pas de
+        // traitement supplémentaire nécessaire, la 404 se propage telle quelle.
+        $resource = $this->resourceLocator->locate($link->getResourceType(), $link->getResourceId());
+
+        return [$link, $resource];
     }
 }

--- a/src/Controller/Web/ResourceVisibilityWebController.php
+++ b/src/Controller/Web/ResourceVisibilityWebController.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace App\Controller\Web;
 
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Folder;
 use App\Entity\Share;
 use App\Interface\OwnershipCheckerInterface;
 use App\Security\ResourceLocator;
 use App\Security\VisibilityRevoker;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,9 +20,12 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Uid\Uuid;
 
 /**
- * Bascule de visibilité d'une ressource. Seule direction supportée pour
- * l'instant : repasser en `private` (le bouton d'arrêt d'urgence), qui
- * révoque en cascade tous les ShareLink actifs — cf. VisibilityRevoker.
+ * Bascule de visibilité d'une ressource, dans les deux sens :
+ * - vers `private` (bouton d'arrêt d'urgence) : révoque en cascade tous les
+ *   ShareLink actifs — cf. VisibilityRevoker.
+ * - vers `link_allowed` (opt-in explicite) : préalable indispensable avant
+ *   que ShareLink puisse être créé sur cette ressource (VisibilityChecker
+ *   refuse sinon, cf. ShareLinkFactory).
  */
 #[IsGranted('ROLE_USER')]
 final class ResourceVisibilityWebController extends AbstractController
@@ -29,6 +36,7 @@ final class ResourceVisibilityWebController extends AbstractController
         private readonly ResourceLocator $resourceLocator,
         private readonly OwnershipCheckerInterface $ownershipChecker,
         private readonly VisibilityRevoker $visibilityRevoker,
+        private readonly EntityManagerInterface $em,
     ) {}
 
     #[Route('/resource-visibility-update', name: 'app_resource_visibility_update', methods: ['POST'])]
@@ -53,6 +61,14 @@ final class ResourceVisibilityWebController extends AbstractController
         if ($visibility === 'private') {
             $this->visibilityRevoker->makePrivate($resource, $resourceType, $uuid);
             $this->addFlash('success', 'Ressource repassée en privé. Les liens de partage actifs ont été révoqués.');
+        } elseif ($visibility === 'link_allowed') {
+            $resource->setVisibility(match (true) {
+                $resource instanceof File   => File::VISIBILITY_LINK_ALLOWED,
+                $resource instanceof Folder => Folder::VISIBILITY_LINK_ALLOWED,
+                $resource instanceof Album  => Album::VISIBILITY_LINK_ALLOWED,
+            });
+            $this->em->flush();
+            $this->addFlash('success', 'Partage par lien autorisé pour cette ressource.');
         }
 
         return $this->redirect($request->headers->get('referer') ?? '/explorer');

--- a/src/Controller/Web/ResourceVisibilityWebController.php
+++ b/src/Controller/Web/ResourceVisibilityWebController.php
@@ -71,6 +71,23 @@ final class ResourceVisibilityWebController extends AbstractController
             $this->addFlash('success', 'Partage par lien autorisé pour cette ressource.');
         }
 
-        return $this->redirect($request->headers->get('referer') ?? '/explorer');
+        return $this->redirect($this->redirectUrlFor($resourceType, $resourceId, $resource));
+    }
+
+    /**
+     * Dérive l'URL de retour depuis (resourceType, resourceId) plutôt que
+     * l'en-tête Referer : Referrer-Policy: no-referrer (posé pour protéger
+     * les tokens de ShareLink) fait que le navigateur ne l'envoie jamais,
+     * donc s'appuyer dessus renvoyait systématiquement vers /explorer.
+     */
+    private function redirectUrlFor(string $resourceType, string $resourceId, File|Folder|Album $resource): string
+    {
+        return match ($resourceType) {
+            Share::RESOURCE_ALBUM  => '/albums/' . $resourceId,
+            Share::RESOURCE_FOLDER => '/explorer?folder=' . $resourceId,
+            // Un fichier isolé n'a pas sa propre page : revenir au dossier qui le contient.
+            Share::RESOURCE_FILE   => '/explorer?folder=' . $resource->getFolder()->getId(),
+            default => '/explorer',
+        };
     }
 }

--- a/src/Controller/Web/ResourceVisibilityWebController.php
+++ b/src/Controller/Web/ResourceVisibilityWebController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Web;
+
+use App\Entity\Share;
+use App\Interface\OwnershipCheckerInterface;
+use App\Security\ResourceLocator;
+use App\Security\VisibilityRevoker;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Bascule de visibilité d'une ressource. Seule direction supportée pour
+ * l'instant : repasser en `private` (le bouton d'arrêt d'urgence), qui
+ * révoque en cascade tous les ShareLink actifs — cf. VisibilityRevoker.
+ */
+#[IsGranted('ROLE_USER')]
+final class ResourceVisibilityWebController extends AbstractController
+{
+    private const VALID_TYPES = [Share::RESOURCE_FILE, Share::RESOURCE_FOLDER, Share::RESOURCE_ALBUM];
+
+    public function __construct(
+        private readonly ResourceLocator $resourceLocator,
+        private readonly OwnershipCheckerInterface $ownershipChecker,
+        private readonly VisibilityRevoker $visibilityRevoker,
+    ) {}
+
+    #[Route('/resource-visibility-update', name: 'app_resource_visibility_update', methods: ['POST'])]
+    public function update(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('resource-visibility-update', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Jeton CSRF invalide.');
+        }
+
+        $resourceType = (string) $request->request->get('resourceType', '');
+        $resourceId   = (string) $request->request->get('resourceId', '');
+        $visibility   = (string) $request->request->get('visibility', '');
+
+        if (!in_array($resourceType, self::VALID_TYPES, true) || $resourceId === '') {
+            throw $this->createNotFoundException('Ressource invalide.');
+        }
+
+        $uuid = Uuid::fromString($resourceId);
+        $resource = $this->resourceLocator->locate($resourceType, $uuid);
+        $this->ownershipChecker->denyUnlessOwner($resource);
+
+        if ($visibility === 'private') {
+            $this->visibilityRevoker->makePrivate($resource, $resourceType, $uuid);
+            $this->addFlash('success', 'Ressource repassée en privé. Les liens de partage actifs ont été révoqués.');
+        }
+
+        return $this->redirect($request->headers->get('referer') ?? '/explorer');
+    }
+}

--- a/src/Controller/Web/ShareLinkWebController.php
+++ b/src/Controller/Web/ShareLinkWebController.php
@@ -52,11 +52,14 @@ final class ShareLinkWebController extends AbstractController
         /** @var User $owner */
         $owner = $this->getUser();
 
+        $duration = (string) $request->request->get('duration', '7d');
+
         try {
             $created = $this->shareLinkFactory->create(
                 $owner,
                 $resourceType,
                 Uuid::fromString($resourceId),
+                $duration,
             );
         } catch (ResourceNotPubliclyShareableException) {
             // Erreur légitime côté owner (ressource pas encore en link_allowed) :

--- a/src/Controller/Web/ShareLinkWebController.php
+++ b/src/Controller/Web/ShareLinkWebController.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Web;
+
+use App\Entity\Share;
+use App\Entity\User;
+use App\Security\ShareLinkFactory;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Création d'un lien de partage public depuis ShareModal.
+ *
+ * Distinct de ShareWebController::create() (partage entre comptes) :
+ * ici aucun invité n'est requis, ShareLinkFactory applique le verrou
+ * de visibilité (private → 403) et l'expiration obligatoire.
+ */
+#[IsGranted('ROLE_USER')]
+final class ShareLinkWebController extends AbstractController
+{
+    private const VALID_TYPES = [Share::RESOURCE_FILE, Share::RESOURCE_FOLDER, Share::RESOURCE_ALBUM];
+
+    public function __construct(
+        private readonly ShareLinkFactory $shareLinkFactory,
+    ) {}
+
+    #[Route('/share-link-create', name: 'app_share_link_create', methods: ['POST'])]
+    public function create(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('share-link-create', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Jeton CSRF invalide.');
+        }
+
+        $resourceType = (string) $request->request->get('resourceType', '');
+        $resourceId   = (string) $request->request->get('resourceId', '');
+        $redirectUrl  = $this->redirectUrlFor($resourceType, $resourceId);
+
+        if (!in_array($resourceType, self::VALID_TYPES, true)) {
+            $this->addFlash('error', 'Type de ressource invalide.');
+
+            return $this->redirect($redirectUrl);
+        }
+
+        /** @var User $owner */
+        $owner = $this->getUser();
+
+        $created = $this->shareLinkFactory->create(
+            $owner,
+            $resourceType,
+            Uuid::fromString($resourceId),
+        );
+
+        $publicUrl = $this->generateUrl('app_public_share', [
+            'selector' => $created->link->getSelector(),
+            'token'    => $created->plainToken,
+        ], UrlGeneratorInterface::ABSOLUTE_URL);
+
+        $this->addFlash('success', sprintf('Lien de partage créé : %s', $publicUrl));
+
+        return $this->redirect($redirectUrl);
+    }
+
+    private function redirectUrlFor(string $resourceType, string $resourceId): string
+    {
+        return match ($resourceType) {
+            Share::RESOURCE_ALBUM  => '/albums/' . $resourceId,
+            Share::RESOURCE_FOLDER => '/explorer?folder=' . $resourceId,
+            default => '/explorer',
+        };
+    }
+}

--- a/src/Controller/Web/ShareLinkWebController.php
+++ b/src/Controller/Web/ShareLinkWebController.php
@@ -6,6 +6,7 @@ namespace App\Controller\Web;
 
 use App\Entity\Share;
 use App\Entity\User;
+use App\Exception\ResourceNotPubliclyShareableException;
 use App\Security\ShareLinkFactory;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -51,11 +52,22 @@ final class ShareLinkWebController extends AbstractController
         /** @var User $owner */
         $owner = $this->getUser();
 
-        $created = $this->shareLinkFactory->create(
-            $owner,
-            $resourceType,
-            Uuid::fromString($resourceId),
-        );
+        try {
+            $created = $this->shareLinkFactory->create(
+                $owner,
+                $resourceType,
+                Uuid::fromString($resourceId),
+            );
+        } catch (ResourceNotPubliclyShareableException) {
+            // Erreur légitime côté owner (ressource pas encore en link_allowed) :
+            // redirection avec explication, pas une page d'exception brute.
+            $this->addFlash('error', 'Cette ressource est privée : basculez-la en partage par lien avant de créer un lien.');
+
+            return $this->redirect($redirectUrl);
+        }
+        // Non-owner ou ressource introuvable restent des 403/404 francs
+        // (cf. ShareWebController::create, même comportement) : ce ne sont
+        // pas des erreurs qu'un propriétaire légitime peut rencontrer.
 
         $publicUrl = $this->generateUrl('app_public_share', [
             'selector' => $created->link->getSelector(),

--- a/src/Controller/Web/ShareWebController.php
+++ b/src/Controller/Web/ShareWebController.php
@@ -9,7 +9,6 @@ use App\Entity\File;
 use App\Entity\Folder;
 use App\Entity\Share;
 use App\Entity\User;
-use App\Interface\MediaRepositoryInterface;
 use App\Interface\ShareLinkRepositoryInterface;
 use App\Interface\ShareRepositoryInterface;
 use App\Interface\UserRepositoryInterface;
@@ -43,7 +42,6 @@ final class ShareWebController extends AbstractController
         private readonly OwnershipChecker $ownershipChecker,
         private readonly EntityManagerInterface $em,
         private readonly GuestAccountCreator $guestAccountCreator,
-        private readonly MediaRepositoryInterface $mediaRepository,
     ) {}
 
     #[Route('/partages', name: 'app_shares')]
@@ -221,10 +219,15 @@ final class ShareWebController extends AbstractController
     }
 
     /**
-     * Vignette du premier média pour un lien pointant vers un album (ou un
-     * dossier contenant des images) — simple aperçu visuel dans la liste,
-     * pas une vraie visionneuse. Réutilise app_media_thumbnail (authentifiée) :
-     * c'est le owner connecté qui consulte /partages, pas un visiteur anonyme.
+     * Vignette du premier média AYANT UN THUMBNAIL pour un lien pointant vers
+     * un album — simple aperçu visuel dans la liste, pas une vraie
+     * visionneuse. Réutilise app_media_thumbnail (authentifiée) : c'est le
+     * owner connecté qui consulte /partages, pas un visiteur anonyme.
+     *
+     * Le premier média PAR POSITION n'a pas toujours de thumbnail (traitement
+     * async pas terminé, échec de génération...) : prendre systématiquement
+     * ->first() affichait une vignette vide alors qu'un autre média de
+     * l'album en avait une — bug capturé en usage réel.
      */
     private function resolveThumbnailUrlForLink(\App\Entity\ShareLink $link): ?string
     {
@@ -238,13 +241,13 @@ final class ShareWebController extends AbstractController
             return null;
         }
 
-        $firstMedia = $resource->getMedias()->first();
-
-        if ($firstMedia === false || $firstMedia->getThumbnailPath() === null) {
-            return null;
+        foreach ($resource->getMedias() as $media) {
+            if ($media->getThumbnailPath() !== null) {
+                return $this->generateUrl('app_media_thumbnail', ['id' => $media->getId()]);
+            }
         }
 
-        return $this->generateUrl('app_media_thumbnail', ['id' => $firstMedia->getId()]);
+        return null;
     }
 
     private function redirectUrlFor(string $resourceType, string $resourceId): string

--- a/src/Controller/Web/ShareWebController.php
+++ b/src/Controller/Web/ShareWebController.php
@@ -103,23 +103,19 @@ final class ShareWebController extends AbstractController
             $permission = Share::PERMISSION_READ;
         }
 
-        $guestEmail = trim((string) $request->request->get('guestEmail', ''));
-        $guest = $guestEmail !== '' ? $this->userRepository->findOneBy(['email' => $guestEmail]) : null;
+        $emails = array_values(array_unique(array_filter(array_map(
+            'trim',
+            explode(',', (string) $request->request->get('guestEmail', '')),
+        ), fn (string $email) => $email !== '')));
 
-        if ($guest === null) {
-            $this->addFlash('error', 'Aucun compte HomeCloud n\'est associé à cet email.');
+        if ($emails === []) {
+            $this->addFlash('error', 'Veuillez saisir au moins un email.');
 
             return $this->redirect($redirectUrl);
         }
 
         /** @var User $owner */
         $owner = $this->getUser();
-
-        if ($guest->getId()->equals($owner->getId())) {
-            $this->addFlash('error', 'Vous ne pouvez pas partager une ressource avec vous-même.');
-
-            return $this->redirect($redirectUrl);
-        }
 
         try {
             $resource = $this->resourceLocator->locate($resourceType, \Symfony\Component\Uid\Uuid::fromString($resourceId));
@@ -130,18 +126,51 @@ final class ShareWebController extends AbstractController
             return $this->redirect($redirectUrl);
         }
 
-        $share = new Share($owner, $guest, $resourceType, \Symfony\Component\Uid\Uuid::fromString($resourceId), $permission);
-        $this->em->persist($share);
+        $shared = [];
+        $unknown = [];
+        $selfShareAttempted = false;
 
-        try {
-            $this->em->flush();
-        } catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException) {
-            $this->addFlash('error', 'Un partage identique existe déjà pour cet utilisateur.');
+        foreach ($emails as $email) {
+            $guest = $this->userRepository->findOneBy(['email' => $email]);
 
-            return $this->redirect($redirectUrl);
+            if ($guest === null) {
+                $unknown[] = $email;
+                continue;
+            }
+
+            if ($guest->getId()->equals($owner->getId())) {
+                $selfShareAttempted = true;
+                continue;
+            }
+
+            $share = new Share($owner, $guest, $resourceType, \Symfony\Component\Uid\Uuid::fromString($resourceId), $permission);
+            $this->em->persist($share);
+
+            try {
+                $this->em->flush();
+            } catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException) {
+                $this->em->detach($share);
+                $unknown[] = $email . ' (partage déjà existant)';
+                continue;
+            }
+
+            $shared[] = $email;
         }
 
-        $this->addFlash('success', sprintf('Ressource partagée avec %s.', $guest->getDisplayName()));
+        if ($shared !== []) {
+            $this->addFlash('success', sprintf('Ressource partagée avec %s.', implode(', ', $shared)));
+        }
+
+        if ($unknown !== []) {
+            $this->addFlash('error', sprintf(
+                'Aucun compte HomeCloud n\'est associé à : %s.',
+                implode(', ', $unknown),
+            ));
+        }
+
+        if ($selfShareAttempted && $shared === [] && $unknown === []) {
+            $this->addFlash('error', 'Vous ne pouvez pas partager une ressource avec vous-même.');
+        }
 
         return $this->redirect($redirectUrl);
     }

--- a/src/Controller/Web/ShareWebController.php
+++ b/src/Controller/Web/ShareWebController.php
@@ -50,23 +50,17 @@ final class ShareWebController extends AbstractController
         /** @var User $user */
         $user = $this->getUser();
 
-        $shares = $this->shareRepository->findByUser($user, limit: 100);
-
-        $outgoing = [];
-        $incoming = [];
-
-        foreach ($shares as $share) {
-            $row = [
+        // findByUser retourne owner OU guest, mais HomeCloud est mono-owner
+        // par instance : l'utilisateur connecté ici est toujours l'owner, il
+        // n'y a donc jamais de partage "reçu" à distinguer (cf. GuestRestrictionChecker,
+        // les invités n'ont pas accès à cette page).
+        $outgoing = array_map(
+            fn ($share) => [
                 'share'        => $share,
                 'resourceName' => $this->resolveResourceName($share),
-            ];
-
-            if ($share->getOwner()->getId()->equals($user->getId())) {
-                $outgoing[] = $row;
-            } else {
-                $incoming[] = $row;
-            }
-        }
+            ],
+            $this->shareRepository->findByUser($user, limit: 100),
+        );
 
         $shareLinks = array_map(
             fn ($link) => [
@@ -78,7 +72,6 @@ final class ShareWebController extends AbstractController
 
         return $this->render('web/shares.html.twig', [
             'outgoing'   => $outgoing,
-            'incoming'   => $incoming,
             'shareLinks' => $shareLinks,
         ]);
     }

--- a/src/Controller/Web/ShareWebController.php
+++ b/src/Controller/Web/ShareWebController.php
@@ -9,6 +9,7 @@ use App\Entity\File;
 use App\Entity\Folder;
 use App\Entity\Share;
 use App\Entity\User;
+use App\Interface\ShareLinkRepositoryInterface;
 use App\Interface\ShareRepositoryInterface;
 use App\Interface\UserRepositoryInterface;
 use App\Security\OwnershipChecker;
@@ -20,6 +21,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * Page web « Partages » — liste les partages sortants (créés par
@@ -33,6 +35,7 @@ final class ShareWebController extends AbstractController
 
     public function __construct(
         private readonly ShareRepositoryInterface $shareRepository,
+        private readonly ShareLinkRepositoryInterface $shareLinkRepository,
         private readonly ResourceLocator $resourceLocator,
         private readonly UserRepositoryInterface $userRepository,
         private readonly OwnershipChecker $ownershipChecker,
@@ -63,9 +66,18 @@ final class ShareWebController extends AbstractController
             }
         }
 
+        $shareLinks = array_map(
+            fn ($link) => [
+                'link'         => $link,
+                'resourceName' => $this->resolveResourceNameForLink($link),
+            ],
+            $this->shareLinkRepository->findByOwner($user, limit: 100),
+        );
+
         return $this->render('web/shares.html.twig', [
-            'outgoing' => $outgoing,
-            'incoming' => $incoming,
+            'outgoing'   => $outgoing,
+            'incoming'   => $incoming,
+            'shareLinks' => $shareLinks,
         ]);
     }
 
@@ -132,6 +144,46 @@ final class ShareWebController extends AbstractController
         $this->addFlash('success', sprintf('Ressource partagée avec %s.', $guest->getDisplayName()));
 
         return $this->redirect($redirectUrl);
+    }
+
+    #[Route('/share-link-revoke', name: 'app_share_link_revoke', methods: ['POST'])]
+    public function revokeLink(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('share-link-revoke', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Jeton CSRF invalide.');
+        }
+
+        $linkId = (string) $request->request->get('linkId', '');
+        $link = $this->shareLinkRepository->find(Uuid::fromString($linkId))
+            ?? throw $this->createNotFoundException('Lien introuvable.');
+
+        /** @var User $user */
+        $user = $this->getUser();
+        if (!$link->getOwner()->getId()->equals($user->getId())) {
+            throw $this->createAccessDeniedException('Vous n\'êtes pas le propriétaire de ce lien.');
+        }
+
+        $link->revoke();
+        $this->em->flush();
+
+        $this->addFlash('success', 'Lien de partage révoqué.');
+
+        return $this->redirect('/partages');
+    }
+
+    private function resolveResourceNameForLink(\App\Entity\ShareLink $link): string
+    {
+        try {
+            $resource = $this->resourceLocator->locate($link->getResourceType(), $link->getResourceId());
+        } catch (NotFoundHttpException) {
+            return 'Ressource supprimée';
+        }
+
+        return match (true) {
+            $resource instanceof File   => $resource->getOriginalName(),
+            $resource instanceof Folder => $resource->getName(),
+            $resource instanceof Album  => $resource->getName(),
+        };
     }
 
     private function redirectUrlFor(string $resourceType, string $resourceId): string

--- a/src/Controller/Web/ShareWebController.php
+++ b/src/Controller/Web/ShareWebController.php
@@ -9,6 +9,7 @@ use App\Entity\File;
 use App\Entity\Folder;
 use App\Entity\Share;
 use App\Entity\User;
+use App\Interface\MediaRepositoryInterface;
 use App\Interface\ShareLinkRepositoryInterface;
 use App\Interface\ShareRepositoryInterface;
 use App\Interface\UserRepositoryInterface;
@@ -42,6 +43,7 @@ final class ShareWebController extends AbstractController
         private readonly OwnershipChecker $ownershipChecker,
         private readonly EntityManagerInterface $em,
         private readonly GuestAccountCreator $guestAccountCreator,
+        private readonly MediaRepositoryInterface $mediaRepository,
     ) {}
 
     #[Route('/partages', name: 'app_shares')]
@@ -64,8 +66,9 @@ final class ShareWebController extends AbstractController
 
         $shareLinks = array_map(
             fn ($link) => [
-                'link'         => $link,
-                'resourceName' => $this->resolveResourceNameForLink($link),
+                'link'          => $link,
+                'resourceName'  => $this->resolveResourceNameForLink($link),
+                'thumbnailUrl'  => $this->resolveThumbnailUrlForLink($link),
             ],
             $this->shareLinkRepository->findByOwner($user, limit: 100),
         );
@@ -215,6 +218,33 @@ final class ShareWebController extends AbstractController
             $resource instanceof Folder => $resource->getName(),
             $resource instanceof Album  => $resource->getName(),
         };
+    }
+
+    /**
+     * Vignette du premier média pour un lien pointant vers un album (ou un
+     * dossier contenant des images) — simple aperçu visuel dans la liste,
+     * pas une vraie visionneuse. Réutilise app_media_thumbnail (authentifiée) :
+     * c'est le owner connecté qui consulte /partages, pas un visiteur anonyme.
+     */
+    private function resolveThumbnailUrlForLink(\App\Entity\ShareLink $link): ?string
+    {
+        try {
+            $resource = $this->resourceLocator->locate($link->getResourceType(), $link->getResourceId());
+        } catch (NotFoundHttpException) {
+            return null;
+        }
+
+        if (!$resource instanceof Album) {
+            return null;
+        }
+
+        $firstMedia = $resource->getMedias()->first();
+
+        if ($firstMedia === false || $firstMedia->getThumbnailPath() === null) {
+            return null;
+        }
+
+        return $this->generateUrl('app_media_thumbnail', ['id' => $firstMedia->getId()]);
     }
 
     private function redirectUrlFor(string $resourceType, string $resourceId): string

--- a/src/Controller/Web/ShareWebController.php
+++ b/src/Controller/Web/ShareWebController.php
@@ -14,6 +14,7 @@ use App\Interface\ShareRepositoryInterface;
 use App\Interface\UserRepositoryInterface;
 use App\Security\OwnershipChecker;
 use App\Security\ResourceLocator;
+use App\Service\GuestAccountCreator;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -40,6 +41,7 @@ final class ShareWebController extends AbstractController
         private readonly UserRepositoryInterface $userRepository,
         private readonly OwnershipChecker $ownershipChecker,
         private readonly EntityManagerInterface $em,
+        private readonly GuestAccountCreator $guestAccountCreator,
     ) {}
 
     #[Route('/partages', name: 'app_shares')]
@@ -127,15 +129,22 @@ final class ShareWebController extends AbstractController
         }
 
         $shared = [];
-        $unknown = [];
+        $failed = [];
         $selfShareAttempted = false;
 
         foreach ($emails as $email) {
             $guest = $this->userRepository->findOneBy(['email' => $email]);
 
             if ($guest === null) {
-                $unknown[] = $email;
-                continue;
+                if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+                    $failed[] = $email . ' (email invalide)';
+                    continue;
+                }
+
+                // Email inconnu mais valide : plutôt que d'échouer, on crée
+                // un compte invité (sans mot de passe utilisable, cf.
+                // GuestAccountCreator) et on partage avec ce nouveau compte.
+                $guest = $this->guestAccountCreator->create($email);
             }
 
             if ($guest->getId()->equals($owner->getId())) {
@@ -150,7 +159,7 @@ final class ShareWebController extends AbstractController
                 $this->em->flush();
             } catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException) {
                 $this->em->detach($share);
-                $unknown[] = $email . ' (partage déjà existant)';
+                $failed[] = $email . ' (partage déjà existant)';
                 continue;
             }
 
@@ -161,14 +170,14 @@ final class ShareWebController extends AbstractController
             $this->addFlash('success', sprintf('Ressource partagée avec %s.', implode(', ', $shared)));
         }
 
-        if ($unknown !== []) {
+        if ($failed !== []) {
             $this->addFlash('error', sprintf(
-                'Aucun compte HomeCloud n\'est associé à : %s.',
-                implode(', ', $unknown),
+                'Échec du partage pour : %s.',
+                implode(', ', $failed),
             ));
         }
 
-        if ($selfShareAttempted && $shared === [] && $unknown === []) {
+        if ($selfShareAttempted && $shared === [] && $failed === []) {
             $this->addFlash('error', 'Vous ne pouvez pas partager une ressource avec vous-même.');
         }
 

--- a/src/Entity/Album.php
+++ b/src/Entity/Album.php
@@ -30,6 +30,9 @@ use Symfony\Component\Uid\Uuid;
 #[ORM\Table(name: 'albums')]
 class Album
 {
+    public const VISIBILITY_PRIVATE = 'private';
+    public const VISIBILITY_LINK_ALLOWED = 'link_allowed';
+
     #[ORM\Id]
     #[ORM\Column(type: 'uuid', unique: true)]
     private Uuid $id;
@@ -47,6 +50,13 @@ class Album
 
     #[ORM\Column]
     private \DateTimeImmutable $createdAt;
+
+    /**
+     * private par défaut : le serveur refuse de créer un lien public tant que
+     * l'owner n'a pas explicitement basculé la ressource en link_allowed.
+     */
+    #[ORM\Column(type: 'string', length: 12, options: ['default' => self::VISIBILITY_PRIVATE])]
+    private string $visibility = self::VISIBILITY_PRIVATE;
 
     public function __construct(string $name, User $owner)
     {
@@ -169,5 +179,15 @@ class Album
     public function getCreatedAt(): \DateTimeImmutable
     {
         return $this->createdAt;
+    }
+
+    public function getVisibility(): string
+    {
+        return $this->visibility;
+    }
+
+    public function setVisibility(string $visibility): void
+    {
+        $this->visibility = $visibility;
     }
 }

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -26,6 +26,9 @@ use Symfony\Component\Uid\Uuid;
  */
 class File
 {
+    public const VISIBILITY_PRIVATE = 'private';
+    public const VISIBILITY_LINK_ALLOWED = 'link_allowed';
+
     #[ORM\Id]
     #[ORM\Column(type: 'uuid', unique: true)]
     private Uuid $id;
@@ -53,6 +56,13 @@ class File
      */
     #[ORM\Column(options: ['default' => false])]
     private bool $neutralized = false;
+
+    /**
+     * private par défaut : le serveur refuse de créer un lien public tant que
+     * l'owner n'a pas explicitement basculé la ressource en link_allowed.
+     */
+    #[ORM\Column(type: 'string', length: 12, options: ['default' => self::VISIBILITY_PRIVATE])]
+    private string $visibility = self::VISIBILITY_PRIVATE;
 
     #[ORM\ManyToOne(targetEntity: Folder::class)]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
@@ -148,6 +158,16 @@ class File
     public function isNeutralized(): bool
     {
         return $this->neutralized;
+    }
+
+    public function getVisibility(): string
+    {
+        return $this->visibility;
+    }
+
+    public function setVisibility(string $visibility): void
+    {
+        $this->visibility = $visibility;
     }
 
     /**

--- a/src/Entity/Folder.php
+++ b/src/Entity/Folder.php
@@ -15,6 +15,9 @@ use Symfony\Component\Uid\Uuid;
 #[ORM\Table(name: 'folders')]
 class Folder
 {
+    public const VISIBILITY_PRIVATE = 'private';
+    public const VISIBILITY_LINK_ALLOWED = 'link_allowed';
+
     #[ORM\Id]
     #[ORM\Column(type: 'uuid', unique: true)]
     private Uuid $id;
@@ -39,6 +42,13 @@ class Folder
 
     #[ORM\Column(type: 'string', enumType: FolderMediaType::class, options: ['default' => 'general'])]
     private FolderMediaType $mediaType = FolderMediaType::General;
+
+    /**
+     * private par défaut : le serveur refuse de créer un lien public tant que
+     * l'owner n'a pas explicitement basculé la ressource en link_allowed.
+     */
+    #[ORM\Column(type: 'string', length: 12, options: ['default' => self::VISIBILITY_PRIVATE])]
+    private string $visibility = self::VISIBILITY_PRIVATE;
 
     #[ORM\Column]
     private \DateTimeImmutable $createdAt;
@@ -107,5 +117,15 @@ class Folder
     public function getCreatedAt(): \DateTimeImmutable
     {
         return $this->createdAt;
+    }
+
+    public function getVisibility(): string
+    {
+        return $this->visibility;
+    }
+
+    public function setVisibility(string $visibility): void
+    {
+        $this->visibility = $visibility;
     }
 }

--- a/src/Entity/ResetPasswordRequest.php
+++ b/src/Entity/ResetPasswordRequest.php
@@ -18,7 +18,7 @@ class ResetPasswordRequest implements ResetPasswordRequestInterface
     private ?int $id = null;
 
     #[ORM\ManyToOne]
-    #[ORM\JoinColumn(nullable: false)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     private ?User $user = null;
 
     public function __construct(User $user, \DateTimeInterface $expiresAt, string $selector, string $hashedToken)

--- a/src/Entity/ShareLink.php
+++ b/src/Entity/ShareLink.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\ShareLinkRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Lien de partage public : donne accès à une ressource sans compte HomeCloud,
+ * via un secret porté par l'URL (selector + token), jamais par une session.
+ *
+ * Choix, distincts de Share (partage entre comptes, cf. src/Entity/Share.php) :
+ * - lecture seule uniquement : pas de champ `permission`, le lien n'autorise
+ *   jamais l'écriture.
+ * - expiresAt NON nullable : un lien qui n'expire jamais est une fuite qui
+ *   n'expire jamais (inverse du défaut permanent de Share).
+ * - selector (clair, indexé) + hashedToken (hash du secret) : si la base
+ *   fuite, les liens ne sont pas rejouables. Le token en clair n'existe que
+ *   dans l'URL envoyée, jamais en base (cf. ShareLinkTokenGenerator).
+ */
+#[ORM\Entity(repositoryClass: ShareLinkRepository::class)]
+#[ORM\Table(name: 'share_links')]
+class ShareLink
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    private Uuid $id;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private User $owner;
+
+    /** file | folder | album */
+    #[ORM\Column(type: 'string', length: 10)]
+    private string $resourceType;
+
+    #[ORM\Column(type: 'uuid')]
+    private Uuid $resourceId;
+
+    #[ORM\Column(type: 'string', length: 32, unique: true)]
+    private string $selector;
+
+    #[ORM\Column(type: 'string', length: 64)]
+    private string $hashedToken;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $expiresAt;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $revokedAt = null;
+
+    public function __construct(
+        User $owner,
+        string $resourceType,
+        Uuid $resourceId,
+        string $selector,
+        string $hashedToken,
+        \DateTimeImmutable $expiresAt,
+    ) {
+        $this->id = Uuid::v7();
+        $this->owner = $owner;
+        $this->resourceType = $resourceType;
+        $this->resourceId = $resourceId;
+        $this->selector = $selector;
+        $this->hashedToken = $hashedToken;
+        $this->expiresAt = $expiresAt;
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getOwner(): User
+    {
+        return $this->owner;
+    }
+
+    public function getResourceType(): string
+    {
+        return $this->resourceType;
+    }
+
+    public function getResourceId(): Uuid
+    {
+        return $this->resourceId;
+    }
+
+    public function getSelector(): string
+    {
+        return $this->selector;
+    }
+
+    public function getExpiresAt(): \DateTimeImmutable
+    {
+        return $this->expiresAt;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getRevokedAt(): ?\DateTimeImmutable
+    {
+        return $this->revokedAt;
+    }
+
+    public function revoke(): void
+    {
+        $this->revokedAt = new \DateTimeImmutable();
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->expiresAt < new \DateTimeImmutable();
+    }
+
+    public function isActive(): bool
+    {
+        return $this->revokedAt === null && !$this->isExpired();
+    }
+
+    /**
+     * Comparaison à temps constant : évite qu'un attaquant déduise le token
+     * correct octet par octet en mesurant le temps de réponse (timing attack).
+     */
+    public function verifyToken(string $token): bool
+    {
+        return hash_equals($this->hashedToken, hash('sha256', $token));
+    }
+}

--- a/src/Entity/ShareLink.php
+++ b/src/Entity/ShareLink.php
@@ -15,8 +15,11 @@ use Symfony\Component\Uid\Uuid;
  * Choix, distincts de Share (partage entre comptes, cf. src/Entity/Share.php) :
  * - lecture seule uniquement : pas de champ `permission`, le lien n'autorise
  *   jamais l'écriture.
- * - expiresAt NON nullable : un lien qui n'expire jamais est une fuite qui
- *   n'expire jamais (inverse du défaut permanent de Share).
+ * - expiresAt nullable = permanent, choisi explicitement par l'owner à la
+ *   création (cf. ShareLinkFactory) — pour un usage type livraison d'album
+ *   à un client, où la révocation manuelle reste le seul moyen de couper
+ *   l'accès. Ce n'est plus un défaut implicite comme pour Share : l'owner
+ *   choisit une durée bornée (1/7/30 jours) ou "permanent" à chaque lien.
  * - selector (clair, indexé) + hashedToken (hash du secret) : si la base
  *   fuite, les liens ne sont pas rejouables. Le token en clair n'existe que
  *   dans l'URL envoyée, jamais en base (cf. ShareLinkTokenGenerator).
@@ -46,8 +49,8 @@ class ShareLink
     #[ORM\Column(type: 'string', length: 64)]
     private string $hashedToken;
 
-    #[ORM\Column(type: 'datetime_immutable')]
-    private \DateTimeImmutable $expiresAt;
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $expiresAt;
 
     #[ORM\Column(type: 'datetime_immutable')]
     private \DateTimeImmutable $createdAt;
@@ -61,7 +64,7 @@ class ShareLink
         Uuid $resourceId,
         string $selector,
         string $hashedToken,
-        \DateTimeImmutable $expiresAt,
+        ?\DateTimeImmutable $expiresAt,
     ) {
         $this->id = Uuid::v7();
         $this->owner = $owner;
@@ -98,7 +101,7 @@ class ShareLink
         return $this->selector;
     }
 
-    public function getExpiresAt(): \DateTimeImmutable
+    public function getExpiresAt(): ?\DateTimeImmutable
     {
         return $this->expiresAt;
     }
@@ -120,7 +123,7 @@ class ShareLink
 
     public function isExpired(): bool
     {
-        return $this->expiresAt < new \DateTimeImmutable();
+        return $this->expiresAt !== null && $this->expiresAt < new \DateTimeImmutable();
     }
 
     public function isActive(): bool

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -14,6 +14,9 @@ use Symfony\Component\Uid\Uuid;
 #[ORM\Table(name: 'users')]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
+    public const ACCOUNT_TYPE_FULL = 'full';
+    public const ACCOUNT_TYPE_GUEST = 'guest';
+
     #[ORM\Id]
     #[ORM\Column(type: 'uuid', unique: true)]
     private Uuid $id;
@@ -29,6 +32,16 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     #[ORM\Column]
     private \DateTimeImmutable $createdAt;
+
+    /**
+     * full | guest — fixé à la création, ne change jamais automatiquement.
+     * Un invité reste un invité même après avoir défini son mot de passe :
+     * ce n'est pas un état transitoire comme un password vide, mais un
+     * statut permanent qui restreint ses droits (pas d'upload, pas
+     * d'espace personnel — cf. la restriction fonctionnelle du chantier).
+     */
+    #[ORM\Column(type: 'string', length: 10, options: ['default' => self::ACCOUNT_TYPE_FULL])]
+    private string $accountType = self::ACCOUNT_TYPE_FULL;
 
     public function __construct(string $email, string $displayName)
     {
@@ -92,5 +105,20 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setPassword(string $password): void
     {
         $this->password = $password;
+    }
+
+    public function getAccountType(): string
+    {
+        return $this->accountType;
+    }
+
+    public function markAsGuest(): void
+    {
+        $this->accountType = self::ACCOUNT_TYPE_GUEST;
+    }
+
+    public function isGuest(): bool
+    {
+        return $this->accountType === self::ACCOUNT_TYPE_GUEST;
     }
 }

--- a/src/Exception/GuestNotAllowedException.php
+++ b/src/Exception/GuestNotAllowedException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * Levée quand un compte invité tente une action réservée aux comptes complets
+ * (upload, création de dossier/album) — un invité est exclusivement
+ * lecture/téléchargement, quelle que soit la permission du Share reçu.
+ */
+final class GuestNotAllowedException extends AccessDeniedHttpException
+{
+    public function __construct()
+    {
+        parent::__construct('Un compte invité ne peut pas créer de contenu.');
+    }
+}

--- a/src/Exception/ResourceNotPubliclyShareableException.php
+++ b/src/Exception/ResourceNotPubliclyShareableException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * Levée quand on tente de créer un lien public sur une ressource `private`
+ * (ou dont un parent est `private` — le plus restrictif gagne).
+ */
+final class ResourceNotPubliclyShareableException extends AccessDeniedHttpException
+{
+    public function __construct()
+    {
+        parent::__construct('Cette ressource n\'est pas autorisée au partage par lien public.');
+    }
+}

--- a/src/Interface/ResourceLocatorInterface.php
+++ b/src/Interface/ResourceLocatorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Folder;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Contrat de résolution d'une ressource polymorphe (resourceType + resourceId).
+ * Respecte le Dependency Inversion Principle (SOLID D).
+ */
+interface ResourceLocatorInterface
+{
+    public function locate(string $resourceType, Uuid $resourceId): File|Folder|Album;
+}

--- a/src/Interface/ShareLinkAccessCheckerInterface.php
+++ b/src/Interface/ShareLinkAccessCheckerInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\ShareLink;
+
+/**
+ * Contrat de résolution d'un lien de partage public à partir de son secret.
+ * Respecte le Dependency Inversion Principle (SOLID D).
+ */
+interface ShareLinkAccessCheckerInterface
+{
+    /**
+     * Retourne le ShareLink si (selector, token) désigne un lien actif, sinon null.
+     * Ne distingue jamais "inconnu" de "invalide/expiré/révoqué" dans le retour :
+     * à l'appelant de répondre 404 dans tous les cas, pour ne pas confirmer
+     * l'existence d'un selector à un attaquant.
+     */
+    public function resolve(string $selector, string $token): ?ShareLink;
+}

--- a/src/Interface/ShareLinkRepositoryInterface.php
+++ b/src/Interface/ShareLinkRepositoryInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Interface;
 
 use App\Entity\ShareLink;
+use App\Entity\User;
 use Doctrine\DBAL\LockMode;
 use Symfony\Component\Uid\Uuid;
 
@@ -17,6 +18,12 @@ interface ShareLinkRepositoryInterface
     public function find(mixed $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null): ?ShareLink;
 
     public function findBySelector(string $selector): ?ShareLink;
+
+    /** @return ShareLink[] */
+    public function findByOwner(User $owner, int $limit = 100): array;
+
+    /** @return ShareLink[] */
+    public function findActiveByResource(string $resourceType, Uuid $resourceId): array;
 
     /** Supprime tous les liens pointant vers cette ressource (nettoyage à la suppression). */
     public function deleteByResource(string $resourceType, Uuid $resourceId): void;

--- a/src/Interface/ShareLinkRepositoryInterface.php
+++ b/src/Interface/ShareLinkRepositoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\ShareLink;
+use Doctrine\DBAL\LockMode;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Contrat pour l'accès aux données ShareLink.
+ * Respecte le Dependency Inversion Principle (SOLID D).
+ */
+interface ShareLinkRepositoryInterface
+{
+    public function find(mixed $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null): ?ShareLink;
+
+    public function findBySelector(string $selector): ?ShareLink;
+
+    /** Supprime tous les liens pointant vers cette ressource (nettoyage à la suppression). */
+    public function deleteByResource(string $resourceType, Uuid $resourceId): void;
+}

--- a/src/Interface/SharedResourceCleanerInterface.php
+++ b/src/Interface/SharedResourceCleanerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Contrat de nettoyage de tout partage (Share + ShareLink) pointant vers une
+ * ressource supprimée. Respecte le Dependency Inversion Principle (SOLID D).
+ */
+interface SharedResourceCleanerInterface
+{
+    public function deleteByResource(string $resourceType, Uuid $resourceId): void;
+}

--- a/src/Interface/VisibilityCheckerInterface.php
+++ b/src/Interface/VisibilityCheckerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Exception\ResourceNotPubliclyShareableException;
+
+/**
+ * Contrat du verrou de partage par lien public.
+ * Respecte le Dependency Inversion Principle (SOLID D).
+ */
+interface VisibilityCheckerInterface
+{
+    /**
+     * Une ressource est publiquement partageable si elle-même ET tous ses
+     * parents (dossiers) sont `link_allowed` : le plus restrictif gagne.
+     */
+    public function isPubliclyShareable(File|Folder|Album $resource): bool;
+
+    /**
+     * @throws ResourceNotPubliclyShareableException si la ressource (ou un parent) est `private`
+     */
+    public function denyUnlessPubliclyShareable(File|Folder|Album $resource): void;
+}

--- a/src/Repository/ShareLinkRepository.php
+++ b/src/Repository/ShareLinkRepository.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\ShareLink;
+use App\Interface\ShareLinkRepositoryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<ShareLink>
+ *
+ * @method ShareLink|null find($id, $lockMode = null, $lockVersion = null)
+ * @method ShareLink|null findOneBy(array $criteria, array $orderBy = null)
+ * @method ShareLink[]    findAll()
+ * @method ShareLink[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class ShareLinkRepository extends ServiceEntityRepository implements ShareLinkRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ShareLink::class);
+    }
+
+    public function find(mixed $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null): ?ShareLink
+    {
+        return parent::find($id, $lockMode, $lockVersion);
+    }
+
+    public function findBySelector(string $selector): ?ShareLink
+    {
+        return $this->findOneBy(['selector' => $selector]);
+    }
+
+    /** Supprime tous les liens pointant vers cette ressource (nettoyage à la suppression). */
+    public function deleteByResource(string $resourceType, Uuid $resourceId): void
+    {
+        $this->createQueryBuilder('sl')
+            ->delete()
+            ->where('sl.resourceType = :type')
+            ->andWhere('sl.resourceId = :rid')
+            ->setParameter('type', $resourceType)
+            ->setParameter('rid', $resourceId, 'uuid')
+            ->getQuery()
+            ->execute();
+    }
+}

--- a/src/Repository/ShareLinkRepository.php
+++ b/src/Repository/ShareLinkRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\ShareLink;
+use App\Entity\User;
 use App\Interface\ShareLinkRepositoryInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\LockMode;
@@ -34,6 +35,32 @@ class ShareLinkRepository extends ServiceEntityRepository implements ShareLinkRe
     public function findBySelector(string $selector): ?ShareLink
     {
         return $this->findOneBy(['selector' => $selector]);
+    }
+
+    public function findByOwner(User $owner, int $limit = 100): array
+    {
+        return $this->createQueryBuilder('sl')
+            ->where('sl.owner = :owner')
+            ->setParameter('owner', $owner->getId(), 'uuid')
+            ->orderBy('sl.createdAt', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /** @return ShareLink[] */
+    public function findActiveByResource(string $resourceType, Uuid $resourceId): array
+    {
+        return $this->createQueryBuilder('sl')
+            ->where('sl.resourceType = :type')
+            ->andWhere('sl.resourceId = :rid')
+            ->andWhere('sl.revokedAt IS NULL')
+            ->andWhere('sl.expiresAt > :now')
+            ->setParameter('type', $resourceType)
+            ->setParameter('rid', $resourceId, 'uuid')
+            ->setParameter('now', new \DateTimeImmutable())
+            ->getQuery()
+            ->getResult();
     }
 
     /** Supprime tous les liens pointant vers cette ressource (nettoyage à la suppression). */

--- a/src/Security/CreatedShareLink.php
+++ b/src/Security/CreatedShareLink.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Entity\ShareLink;
+
+/**
+ * Résultat de ShareLinkFactory::create().
+ * `plainToken` n'existe qu'ici : ShareLink ne stocke que son hash, donc c'est
+ * la seule occasion de composer l'URL complète à afficher/copier à l'owner.
+ */
+final readonly class CreatedShareLink
+{
+    public function __construct(
+        public ShareLink $link,
+        public string $plainToken,
+    ) {}
+}

--- a/src/Security/GeneratedShareLinkToken.php
+++ b/src/Security/GeneratedShareLinkToken.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+/**
+ * Résultat de ShareLinkTokenGenerator::generate().
+ * `token` est en clair : à mettre dans l'URL, jamais en base.
+ * `hashedToken` est ce qui doit être persisté sur ShareLink.
+ */
+final readonly class GeneratedShareLinkToken
+{
+    public function __construct(
+        public string $selector,
+        public string $token,
+        public string $hashedToken,
+    ) {}
+}

--- a/src/Security/GuestRestrictionChecker.php
+++ b/src/Security/GuestRestrictionChecker.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Entity\User;
+use App\Exception\GuestNotAllowedException;
+
+/**
+ * Un compte invité (accountType=guest) est exclusivement lecture/téléchargement :
+ * pas d'upload, pas de création de dossier/album, pas d'espace personnel.
+ * Vaut indépendamment de la permission (read|write) d'un Share reçu — un
+ * invité reste lecture seule même via un partage en write.
+ */
+final readonly class GuestRestrictionChecker
+{
+    public function denyUnlessFullAccount(User $user): void
+    {
+        if ($user->isGuest()) {
+            throw new GuestNotAllowedException();
+        }
+    }
+}

--- a/src/Security/ResourceLocator.php
+++ b/src/Security/ResourceLocator.php
@@ -11,6 +11,7 @@ use App\Entity\Share;
 use App\Interface\AlbumRepositoryInterface;
 use App\Interface\FileRepositoryInterface;
 use App\Interface\FolderRepositoryInterface;
+use App\Interface\ResourceLocatorInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Uid\Uuid;
 
@@ -20,7 +21,7 @@ use Symfony\Component\Uid\Uuid;
  * Point d'entrée unique pour traduire la paire (type, id) stockée sur `Share`
  * en File|Folder|Album, sans dupliquer un `match` dans chaque appelant.
  */
-final readonly class ResourceLocator
+final readonly class ResourceLocator implements ResourceLocatorInterface
 {
     public function __construct(
         private FileRepositoryInterface $fileRepository,

--- a/src/Security/ShareLinkAccessChecker.php
+++ b/src/Security/ShareLinkAccessChecker.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Entity\ShareLink;
+use App\Interface\ShareLinkAccessCheckerInterface;
+use App\Interface\ShareLinkRepositoryInterface;
+
+/**
+ * Vérifie si un couple (selector, token) désigne un lien de partage public actif.
+ *
+ * Symétrique de ShareAccessChecker (partage entre comptes), mais l'identité
+ * n'est plus un User authentifié : c'est un secret porté par l'URL.
+ */
+final readonly class ShareLinkAccessChecker implements ShareLinkAccessCheckerInterface
+{
+    public function __construct(
+        private ShareLinkRepositoryInterface $shareLinkRepository,
+    ) {}
+
+    public function resolve(string $selector, string $token): ?ShareLink
+    {
+        $link = $this->shareLinkRepository->findBySelector($selector);
+
+        if ($link === null || !$link->verifyToken($token) || !$link->isActive()) {
+            return null;
+        }
+
+        return $link;
+    }
+}

--- a/src/Security/ShareLinkFactory.php
+++ b/src/Security/ShareLinkFactory.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Entity\ShareLink;
+use App\Entity\User;
+use App\Interface\OwnershipCheckerInterface;
+use App\Interface\ResourceLocatorInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Construit et persiste un ShareLink après vérifications :
+ * - ownership réel de la ressource (denyUnlessOwner)
+ * - verrou de visibilité (denyUnlessPubliclyShareable) : c'est le point qui
+ *   fait exister le verrou posé à l'étape 0. Sans cet appel, `visibility`
+ *   ne serait qu'un champ décoratif — c'est ICI qu'il devient une garantie.
+ *
+ * expiresAt : obligatoire côté modèle (ShareLink ne l'accepte jamais null),
+ * défaut 7 jours si absent, ramené à 30 jours si demandé au-delà.
+ */
+final readonly class ShareLinkFactory
+{
+    private const DEFAULT_EXPIRATION_DAYS = 7;
+    private const MAX_EXPIRATION_DAYS = 30;
+
+    public function __construct(
+        private ResourceLocatorInterface $resourceLocator,
+        private OwnershipCheckerInterface $ownershipChecker,
+        private VisibilityChecker $visibilityChecker,
+        private ShareLinkTokenGenerator $tokenGenerator,
+        private EntityManagerInterface $em,
+    ) {}
+
+    public function create(
+        User $owner,
+        string $resourceType,
+        Uuid $resourceId,
+        ?\DateTimeImmutable $requestedExpiresAt = null,
+    ): CreatedShareLink {
+        $resource = $this->resourceLocator->locate($resourceType, $resourceId);
+
+        $this->ownershipChecker->denyUnlessOwner($resource);
+        $this->visibilityChecker->denyUnlessPubliclyShareable($resource);
+
+        $expiresAt = $this->clampExpiration($requestedExpiresAt);
+
+        $generated = $this->tokenGenerator->generate();
+
+        $link = new ShareLink(
+            $owner,
+            $resourceType,
+            $resourceId,
+            $generated->selector,
+            $generated->hashedToken,
+            $expiresAt,
+        );
+
+        $this->em->persist($link);
+        $this->em->flush();
+
+        return new CreatedShareLink($link, $generated->token);
+    }
+
+    private function clampExpiration(?\DateTimeImmutable $requested): \DateTimeImmutable
+    {
+        $max = new \DateTimeImmutable(sprintf('+%d days', self::MAX_EXPIRATION_DAYS));
+
+        if ($requested === null) {
+            return new \DateTimeImmutable(sprintf('+%d days', self::DEFAULT_EXPIRATION_DAYS));
+        }
+
+        return $requested > $max ? $max : $requested;
+    }
+}

--- a/src/Security/ShareLinkFactory.php
+++ b/src/Security/ShareLinkFactory.php
@@ -18,13 +18,22 @@ use Symfony\Component\Uid\Uuid;
  *   fait exister le verrou posé à l'étape 0. Sans cet appel, `visibility`
  *   ne serait qu'un champ décoratif — c'est ICI qu'il devient une garantie.
  *
- * expiresAt : obligatoire côté modèle (ShareLink ne l'accepte jamais null),
- * défaut 7 jours si absent, ramené à 30 jours si demandé au-delà.
+ * $duration : choix explicite de l'owner à la création, pas un champ libre.
+ * '1d'|'7d'|'30d' bornent une durée fixe ; 'permanent' laisse expiresAt à
+ * null (cf. ShareLink — usage type livraison d'album à un client, où la
+ * révocation manuelle reste le seul moyen de couper l'accès). Une valeur
+ * absente ou non reconnue retombe sur le défaut 7 jours plutôt que d'échouer :
+ * ce n'est pas une donnée de sécurité critique, une erreur de saisie ne doit
+ * pas bloquer la création du lien.
  */
 final readonly class ShareLinkFactory
 {
-    private const DEFAULT_EXPIRATION_DAYS = 7;
-    private const MAX_EXPIRATION_DAYS = 30;
+    private const DURATIONS = [
+        '1d'  => 1,
+        '7d'  => 7,
+        '30d' => 30,
+    ];
+    private const DEFAULT_DURATION = '7d';
 
     public function __construct(
         private ResourceLocatorInterface $resourceLocator,
@@ -38,14 +47,14 @@ final readonly class ShareLinkFactory
         User $owner,
         string $resourceType,
         Uuid $resourceId,
-        ?\DateTimeImmutable $requestedExpiresAt = null,
+        string $duration = self::DEFAULT_DURATION,
     ): CreatedShareLink {
         $resource = $this->resourceLocator->locate($resourceType, $resourceId);
 
         $this->ownershipChecker->denyUnlessOwner($resource);
         $this->visibilityChecker->denyUnlessPubliclyShareable($resource);
 
-        $expiresAt = $this->clampExpiration($requestedExpiresAt);
+        $expiresAt = $this->resolveExpiration($duration);
 
         $generated = $this->tokenGenerator->generate();
 
@@ -64,14 +73,14 @@ final readonly class ShareLinkFactory
         return new CreatedShareLink($link, $generated->token);
     }
 
-    private function clampExpiration(?\DateTimeImmutable $requested): \DateTimeImmutable
+    private function resolveExpiration(string $duration): ?\DateTimeImmutable
     {
-        $max = new \DateTimeImmutable(sprintf('+%d days', self::MAX_EXPIRATION_DAYS));
-
-        if ($requested === null) {
-            return new \DateTimeImmutable(sprintf('+%d days', self::DEFAULT_EXPIRATION_DAYS));
+        if ($duration === 'permanent') {
+            return null;
         }
 
-        return $requested > $max ? $max : $requested;
+        $days = self::DURATIONS[$duration] ?? self::DURATIONS[self::DEFAULT_DURATION];
+
+        return new \DateTimeImmutable(sprintf('+%d days', $days));
     }
 }

--- a/src/Security/ShareLinkTokenGenerator.php
+++ b/src/Security/ShareLinkTokenGenerator.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+/**
+ * Génère le triplet (selector, token en clair, hash du token) d'un lien de
+ * partage public. Ne persiste rien — SRP : génération seule.
+ *
+ * Le token en clair n'existe qu'une fois, ici, pour être placé dans l'URL
+ * envoyée à l'utilisateur ; seul son hash est destiné à être stocké en base.
+ * `random_bytes` (CSPRNG) exclut tout token devinable — jamais `uniqid()`,
+ * `rand()`, ni un UUID (qui encode un timestamp).
+ */
+final readonly class ShareLinkTokenGenerator
+{
+    public function generate(): GeneratedShareLinkToken
+    {
+        $selector = bin2hex(random_bytes(16));
+        $token = bin2hex(random_bytes(32));
+        $hashedToken = hash('sha256', $token);
+
+        return new GeneratedShareLinkToken($selector, $token, $hashedToken);
+    }
+}

--- a/src/Security/SharedFileScopeChecker.php
+++ b/src/Security/SharedFileScopeChecker.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Share;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Vérifie qu'un fichier fait bien partie du périmètre d'un lien de partage
+ * public, pour empêcher qu'un porteur de lien pivote vers une autre ressource
+ * de l'owner en changeant simplement l'id de fichier dans l'URL.
+ *
+ * - lien sur un File   : seul ce fichier
+ * - lien sur un Folder : tout fichier directement dans ce dossier
+ * - lien sur un Album  : tout fichier qui est le support d'un Media de l'album
+ */
+final readonly class SharedFileScopeChecker
+{
+    public function isInScope(File $file, string $linkResourceType, Uuid $linkResourceId, File|Folder|Album $linkResource): bool
+    {
+        return match ($linkResourceType) {
+            Share::RESOURCE_FILE   => $file->getId()->equals($linkResourceId),
+            Share::RESOURCE_FOLDER => $file->getFolder()->getId()->equals($linkResourceId),
+            Share::RESOURCE_ALBUM  => $this->isFileInAlbum($file, $linkResource),
+            default => false,
+        };
+    }
+
+    private function isFileInAlbum(File $file, File|Folder|Album $linkResource): bool
+    {
+        if (!$linkResource instanceof Album) {
+            return false;
+        }
+
+        foreach ($linkResource->getMedias() as $media) {
+            if ($media->getFile()->getId()->equals($file->getId())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Security/SharedFileScopeChecker.php
+++ b/src/Security/SharedFileScopeChecker.php
@@ -16,7 +16,11 @@ use Symfony\Component\Uid\Uuid;
  * de l'owner en changeant simplement l'id de fichier dans l'URL.
  *
  * - lien sur un File   : seul ce fichier
- * - lien sur un Folder : tout fichier directement dans ce dossier
+ * - lien sur un Folder : tout fichier dans ce dossier OU l'un de ses
+ *   sous-dossiers, à n'importe quelle profondeur — cohérent avec
+ *   VisibilityChecker, qui autorise déjà ces fichiers par remontée des
+ *   ancêtres (partager Docs/ doit aussi permettre de télécharger
+ *   Docs/Sous/fichier.txt, pas seulement de le voir listé).
  * - lien sur un Album  : tout fichier qui est le support d'un Media de l'album
  */
 final readonly class SharedFileScopeChecker
@@ -25,10 +29,23 @@ final readonly class SharedFileScopeChecker
     {
         return match ($linkResourceType) {
             Share::RESOURCE_FILE   => $file->getId()->equals($linkResourceId),
-            Share::RESOURCE_FOLDER => $file->getFolder()->getId()->equals($linkResourceId),
+            Share::RESOURCE_FOLDER => $this->isFileUnderFolder($file, $linkResourceId),
             Share::RESOURCE_ALBUM  => $this->isFileInAlbum($file, $linkResource),
             default => false,
         };
+    }
+
+    private function isFileUnderFolder(File $file, Uuid $linkedFolderId): bool
+    {
+        $folder = $file->getFolder();
+        while ($folder !== null) {
+            if ($folder->getId()->equals($linkedFolderId)) {
+                return true;
+            }
+            $folder = $folder->getParent();
+        }
+
+        return false;
     }
 
     private function isFileInAlbum(File $file, File|Folder|Album $linkResource): bool

--- a/src/Security/SharedResourceCleaner.php
+++ b/src/Security/SharedResourceCleaner.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Interface\ShareLinkRepositoryInterface;
+use App\Interface\SharedResourceCleanerInterface;
+use App\Interface\ShareRepositoryInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Point d'entrée unique pour nettoyer TOUT partage (Share + ShareLink)
+ * pointant vers une ressource supprimée.
+ *
+ * Avant l'introduction de ShareLink, chaque appelant appelait directement
+ * ShareRepository::deleteByResource(). Ajouter ShareLink en dupliquant l'appel
+ * à chaque site aurait risqué d'en oublier un — ce service centralise les deux
+ * suppressions pour qu'un futur 3e mécanisme de partage n'ait qu'un seul
+ * endroit à modifier.
+ */
+final readonly class SharedResourceCleaner implements SharedResourceCleanerInterface
+{
+    public function __construct(
+        private ShareRepositoryInterface $shareRepository,
+        private ShareLinkRepositoryInterface $shareLinkRepository,
+    ) {}
+
+    public function deleteByResource(string $resourceType, Uuid $resourceId): void
+    {
+        $this->shareRepository->deleteByResource($resourceType, $resourceId);
+        $this->shareLinkRepository->deleteByResource($resourceType, $resourceId);
+    }
+}

--- a/src/Security/VisibilityChecker.php
+++ b/src/Security/VisibilityChecker.php
@@ -12,34 +12,46 @@ use App\Interface\VisibilityCheckerInterface;
 
 /**
  * Verrou de partage par lien public : le serveur refuse de rendre une
- * ressource publiquement accessible tant que l'owner n'a pas explicitement
- * basculé sa visibilité en `link_allowed` — sur la ressource elle-même ET
- * sur toute la chaîne de ses dossiers parents (le plus restrictif gagne).
+ * ressource publiquement accessible tant que l'owner n'a jamais autorisé
+ * `link_allowed`, ni sur la ressource elle-même, ni sur l'un de ses
+ * dossiers ancêtres — sur ce point c'est un OU, pas un ET.
  *
- * Sans cette remontée des parents, déplacer un fichier "link_allowed" dans un
- * dossier "private" ne le protégerait pas : le verrou ne vaudrait plus rien.
+ * Trois mécanismes de partage indépendants s'appuient sur cette même règle :
+ * - partage d'un fichier isolé (icône sur sa vignette) : ne dépend jamais de
+ *   son dossier parent, même s'il est private.
+ * - partage d'un dossier (icône en haut à droite dans l'explorateur) :
+ *   rend accessible tout son contenu, récursivement, y compris les fichiers
+ *   ajoutés après coup — vérifié dynamiquement à chaque requête (remontée
+ *   des ancêtres), jamais par une mise à jour en masse au moment du clic.
+ * - partage d'un album : inchangé, un album n'a pas de parent.
+ *
+ * Une ressource est donc publiquement partageable si ELLE-MÊME est
+ * `link_allowed`, OU si l'un de ses ancêtres (remontée complète de la
+ * chaîne des dossiers) l'est. Un sous-dossier `link_allowed` reste un point
+ * d'entrée de partage valide même si son propre parent est `private` : on
+ * peut partager `Docs/Factures/` sans jamais toucher à `Docs/`.
  */
 final readonly class VisibilityChecker implements VisibilityCheckerInterface
 {
     public function isPubliclyShareable(File|Folder|Album $resource): bool
     {
-        if ($resource->getVisibility() !== Folder::VISIBILITY_LINK_ALLOWED) {
-            return false;
+        if ($resource->getVisibility() === Folder::VISIBILITY_LINK_ALLOWED) {
+            return true;
         }
 
         if ($resource instanceof Album) {
-            return true;
+            return false;
         }
 
         $parent = $resource instanceof File ? $resource->getFolder() : $resource->getParent();
         while ($parent !== null) {
-            if ($parent->getVisibility() !== Folder::VISIBILITY_LINK_ALLOWED) {
-                return false;
+            if ($parent->getVisibility() === Folder::VISIBILITY_LINK_ALLOWED) {
+                return true;
             }
             $parent = $parent->getParent();
         }
 
-        return true;
+        return false;
     }
 
     public function denyUnlessPubliclyShareable(File|Folder|Album $resource): void

--- a/src/Security/VisibilityChecker.php
+++ b/src/Security/VisibilityChecker.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Exception\ResourceNotPubliclyShareableException;
+use App\Interface\VisibilityCheckerInterface;
+
+/**
+ * Verrou de partage par lien public : le serveur refuse de rendre une
+ * ressource publiquement accessible tant que l'owner n'a pas explicitement
+ * basculé sa visibilité en `link_allowed` — sur la ressource elle-même ET
+ * sur toute la chaîne de ses dossiers parents (le plus restrictif gagne).
+ *
+ * Sans cette remontée des parents, déplacer un fichier "link_allowed" dans un
+ * dossier "private" ne le protégerait pas : le verrou ne vaudrait plus rien.
+ */
+final readonly class VisibilityChecker implements VisibilityCheckerInterface
+{
+    public function isPubliclyShareable(File|Folder|Album $resource): bool
+    {
+        if ($resource->getVisibility() !== Folder::VISIBILITY_LINK_ALLOWED) {
+            return false;
+        }
+
+        if ($resource instanceof Album) {
+            return true;
+        }
+
+        $parent = $resource instanceof File ? $resource->getFolder() : $resource->getParent();
+        while ($parent !== null) {
+            if ($parent->getVisibility() !== Folder::VISIBILITY_LINK_ALLOWED) {
+                return false;
+            }
+            $parent = $parent->getParent();
+        }
+
+        return true;
+    }
+
+    public function denyUnlessPubliclyShareable(File|Folder|Album $resource): void
+    {
+        if (!$this->isPubliclyShareable($resource)) {
+            throw new ResourceNotPubliclyShareableException();
+        }
+    }
+}

--- a/src/Security/VisibilityRevoker.php
+++ b/src/Security/VisibilityRevoker.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Interface\ShareLinkRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Repasse une ressource en `private` et révoque en cascade tous ses liens
+ * de partage publics actifs — le "bouton d'arrêt d'urgence" du plan de
+ * partage. Sans la révocation en cascade, changer la visibilité ne ferait
+ * qu'empêcher la création de FUTURS liens, en laissant les liens déjà émis
+ * fonctionner jusqu'à leur expiration naturelle.
+ */
+final readonly class VisibilityRevoker
+{
+    public function __construct(
+        private ShareLinkRepositoryInterface $shareLinkRepository,
+        private EntityManagerInterface $em,
+    ) {}
+
+    public function makePrivate(File|Folder|Album $resource, string $resourceType, \Symfony\Component\Uid\Uuid $resourceId): void
+    {
+        $resource->setVisibility(match (true) {
+            $resource instanceof File   => File::VISIBILITY_PRIVATE,
+            $resource instanceof Folder => Folder::VISIBILITY_PRIVATE,
+            $resource instanceof Album  => Album::VISIBILITY_PRIVATE,
+        });
+
+        foreach ($this->shareLinkRepository->findActiveByResource($resourceType, $resourceId) as $link) {
+            $link->revoke();
+        }
+
+        $this->em->flush();
+    }
+}

--- a/src/Service/AlbumService.php
+++ b/src/Service/AlbumService.php
@@ -11,7 +11,7 @@ use App\Entity\User;
 use App\Interface\AlbumRepositoryInterface;
 use App\Interface\AlbumServiceInterface;
 use App\Interface\MediaRepositoryInterface;
-use App\Interface\ShareRepositoryInterface;
+use App\Interface\SharedResourceCleanerInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Uid\Uuid;
 
@@ -27,7 +27,7 @@ final class AlbumService implements AlbumServiceInterface
     public function __construct(
         private readonly AlbumRepositoryInterface $repository,
         private readonly MediaRepositoryInterface $mediaRepository,
-        private readonly ShareRepositoryInterface $shareRepository,
+        private readonly SharedResourceCleanerInterface $sharedResourceCleaner,
     ) {}
 
     /**
@@ -99,7 +99,7 @@ final class AlbumService implements AlbumServiceInterface
      */
     public function delete(Album $album): void
     {
-        $this->shareRepository->deleteByResource(Share::RESOURCE_ALBUM, $album->getId());
+        $this->sharedResourceCleaner->deleteByResource(Share::RESOURCE_ALBUM, $album->getId());
         $this->repository->remove($album);
     }
 

--- a/src/Service/AlbumService.php
+++ b/src/Service/AlbumService.php
@@ -12,6 +12,7 @@ use App\Interface\AlbumRepositoryInterface;
 use App\Interface\AlbumServiceInterface;
 use App\Interface\MediaRepositoryInterface;
 use App\Interface\SharedResourceCleanerInterface;
+use App\Security\GuestRestrictionChecker;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Uid\Uuid;
 
@@ -28,6 +29,7 @@ final class AlbumService implements AlbumServiceInterface
         private readonly AlbumRepositoryInterface $repository,
         private readonly MediaRepositoryInterface $mediaRepository,
         private readonly SharedResourceCleanerInterface $sharedResourceCleaner,
+        private readonly GuestRestrictionChecker $guestRestrictionChecker,
     ) {}
 
     /**
@@ -42,6 +44,8 @@ final class AlbumService implements AlbumServiceInterface
      */
     public function create(string $name, User $owner, array $mediaIds = []): Album
     {
+        $this->guestRestrictionChecker->denyUnlessFullAccount($owner);
+
         $album = new Album($name, $owner);
         $this->addOwnedMediasTo($album, $mediaIds, $owner);
         $this->repository->save($album);

--- a/src/Service/CreateFileService.php
+++ b/src/Service/CreateFileService.php
@@ -9,6 +9,7 @@ use App\Interface\CreateFileServiceInterface;
 use App\Interface\DefaultFolderServiceInterface;
 use App\Interface\StorageServiceInterface;
 use App\Repository\UserRepository;
+use App\Security\GuestRestrictionChecker;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -47,6 +48,7 @@ final class CreateFileService implements CreateFileServiceInterface
         private readonly DefaultFolderServiceInterface $defaultFolderService,
         private readonly EntityManagerInterface $em,
         private readonly UserRepository $userRepository,
+        private readonly GuestRestrictionChecker $guestRestrictionChecker,
     ) {}
 
     /**
@@ -73,6 +75,8 @@ final class CreateFileService implements CreateFileServiceInterface
         // 2. Auth: fetch user
         $owner = $this->userRepository->find($ownerId)
             ?? throw new NotFoundHttpException('User not found');
+
+        $this->guestRestrictionChecker->denyUnlessFullAccount($owner);
 
         // 3. Folder resolution: folderId > newFolderName > Uploads
         $folder = $this->defaultFolderService->resolve($folderId, $newFolderName, $owner);

--- a/src/Service/FolderService.php
+++ b/src/Service/FolderService.php
@@ -14,6 +14,7 @@ use App\Interface\FilenameValidatorInterface;
 use App\Interface\FolderRepositoryInterface;
 use App\Interface\OwnershipCheckerInterface;
 use App\Interface\SharedResourceCleanerInterface;
+use App\Security\GuestRestrictionChecker;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -45,6 +46,7 @@ final class FolderService
         private readonly LoggerInterface $logger,
         private readonly Stopwatch $stopwatch,
         private readonly SharedResourceCleanerInterface $sharedResourceCleaner,
+        private readonly GuestRestrictionChecker $guestRestrictionChecker,
     ) {}
 
     /**
@@ -52,6 +54,8 @@ final class FolderService
      */
     public function createFolder(User $owner, string $name, ?Folder $parent, FolderMediaType $mediaType): Folder
     {
+        $this->guestRestrictionChecker->denyUnlessFullAccount($owner);
+
         $event = $this->stopwatch->start('folder.create');
 
         $this->filenameValidator->validate($name);

--- a/src/Service/FolderService.php
+++ b/src/Service/FolderService.php
@@ -13,7 +13,7 @@ use App\Interface\DefaultFolderServiceInterface;
 use App\Interface\FilenameValidatorInterface;
 use App\Interface\FolderRepositoryInterface;
 use App\Interface\OwnershipCheckerInterface;
-use App\Interface\ShareRepositoryInterface;
+use App\Interface\SharedResourceCleanerInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -44,7 +44,7 @@ final class FolderService
         private readonly EntityManagerInterface $em,
         private readonly LoggerInterface $logger,
         private readonly Stopwatch $stopwatch,
-        private readonly ShareRepositoryInterface $shareRepository,
+        private readonly SharedResourceCleanerInterface $sharedResourceCleaner,
     ) {}
 
     /**
@@ -194,16 +194,16 @@ final class FolderService
                 $desc = $this->folderRepository->find($descId);
                 if ($desc !== null) {
                     $this->em->refresh($desc);
-                    $this->shareRepository->deleteByResource(Share::RESOURCE_FOLDER, $desc->getId());
+                    $this->sharedResourceCleaner->deleteByResource(Share::RESOURCE_FOLDER, $desc->getId());
                     $this->em->remove($desc);
                 }
             }
             $this->em->refresh($folder);
-            $this->shareRepository->deleteByResource(Share::RESOURCE_FOLDER, $folder->getId());
+            $this->sharedResourceCleaner->deleteByResource(Share::RESOURCE_FOLDER, $folder->getId());
             $this->em->remove($folder);
             $this->em->flush();
         } else {
-            $this->shareRepository->deleteByResource(Share::RESOURCE_FOLDER, $folder->getId());
+            $this->sharedResourceCleaner->deleteByResource(Share::RESOURCE_FOLDER, $folder->getId());
             $this->em->remove($folder);
             $this->em->flush();
         }

--- a/src/Service/GuestAccountCreator.php
+++ b/src/Service/GuestAccountCreator.php
@@ -39,6 +39,7 @@ final readonly class GuestAccountCreator
         $displayName = ucfirst(explode('@', $email)[0]);
 
         $user = new User($email, $displayName);
+        $user->markAsGuest();
         $this->em->persist($user);
         $this->em->flush();
 

--- a/src/Service/GuestAccountCreator.php
+++ b/src/Service/GuestAccountCreator.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
+
+/**
+ * Crée un compte pour un email inconnu au moment d'un partage entre comptes,
+ * plutôt que de faire échouer le partage avec "aucun compte associé".
+ *
+ * Le compte est créé sans mot de passe (User::$password garde son défaut
+ * '' — password_hash() ne produit jamais '' comme hash valide, donc
+ * password_verify() renvoie toujours false : le compte est structurellement
+ * impossible à authentifier tant que l'invité n'a pas défini son mot de
+ * passe). L'email envoyé réutilise le même mécanisme que la réinitialisation
+ * de mot de passe (ResetPasswordHelperInterface, déjà dans le projet) —
+ * "définir un mot de passe" et "activer un compte invité" sont la même
+ * opération du point de vue de l'invité.
+ */
+final readonly class GuestAccountCreator
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private ResetPasswordHelperInterface $resetPasswordHelper,
+        private MailerInterface $mailer,
+        private UrlGeneratorInterface $urlGenerator,
+    ) {}
+
+    public function create(string $email): User
+    {
+        $displayName = ucfirst(explode('@', $email)[0]);
+
+        $user = new User($email, $displayName);
+        $this->em->persist($user);
+        $this->em->flush();
+
+        $resetToken = $this->resetPasswordHelper->generateResetToken($user);
+        $activationUrl = $this->urlGenerator->generate(
+            'web_reset_password_confirm',
+            ['token' => $resetToken->getToken()],
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+
+        $invitationEmail = (new TemplatedEmail())
+            ->from(new Address('no-reply@homecloud.fr'))
+            ->to($user->getEmail())
+            ->subject('Vous avez été invité(e) sur HomeCloud')
+            ->htmlTemplate('reset_password/guest_invitation_email.html.twig')
+            ->context(['activationUrl' => $activationUrl]);
+
+        $this->mailer->send($invitationEmail);
+
+        return $user;
+    }
+}

--- a/src/State/FileProcessor.php
+++ b/src/State/FileProcessor.php
@@ -11,11 +11,11 @@ use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\FileOutput;
 use App\Entity\Share;
 use App\Interface\DefaultFolderServiceInterface;
-use App\Interface\ShareRepositoryInterface;
 use App\Repository\FileRepository;
 use App\Repository\MediaRepository;
 use App\Security\AuthenticationResolver;
 use App\Security\ResourceAccessChecker;
+use App\Interface\SharedResourceCleanerInterface;
 use App\Service\FileActionService;
 use App\Service\IriExtractor;
 use App\Interface\StorageServiceInterface;
@@ -50,7 +50,7 @@ final class FileProcessor implements ProcessorInterface
         private readonly FileActionService $fileActionService,
         private readonly RequestStack $requestStack,
         private readonly IriExtractor $iriExtractor,
-        private readonly ShareRepositoryInterface $shareRepository,
+        private readonly SharedResourceCleanerInterface $sharedResourceCleaner,
     ) {}
 
     /**
@@ -85,7 +85,7 @@ final class FileProcessor implements ProcessorInterface
         }
 
         $this->storageService->delete($file->getPath());
-        $this->shareRepository->deleteByResource(Share::RESOURCE_FILE, $file->getId());
+        $this->sharedResourceCleaner->deleteByResource(Share::RESOURCE_FILE, $file->getId());
         $this->em->remove($file);
         $this->em->flush();
 

--- a/templates/components/FileCard.html.twig
+++ b/templates/components/FileCard.html.twig
@@ -41,6 +41,11 @@
 			<a href="{{ path('app_file_download', { id: item.id }) }}"
 			   class="hc-item-action hc-item-action--move"
 			   title="Télécharger {{ item.originalName ?? item.name|e('html') }}"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-download"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></a>
+			<button type="button"
+			        id="share-open-btn-{{ item.id }}"
+			        data-testid="share-file-btn-{{ item.id }}"
+			        class="share-btn hc-item-action"
+			        title="Partager {{ (item.originalName ?? item.name)|e('html') }}"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon"><path d="M18 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 22a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM8.6 13.5l6.8 4M15.4 6.5l-6.8 4"/></svg></button>
 			<a href="#"
 			   role="button"
 			   data-testid="move-file-btn-{{ item.id }}"
@@ -60,4 +65,8 @@
 		{% endif %}
 	</div>
 </div>
+
+{% if item.id is defined %}
+<twig:ShareModal resourceType="file" resourceId="{{ item.id }}" />
+{% endif %}
 {# Props attendues : item (entité File) #}

--- a/templates/components/ShareModal.html.twig
+++ b/templates/components/ShareModal.html.twig
@@ -83,36 +83,67 @@
     </form>
 
     {# Onglet "Lien" — lien public sans compte (ShareLink) #}
-    <form method="post" action="{{ path('app_share_link_create') }}" class="share-tab-panel flex flex-col hidden" data-tab-panel="link">
-      <input type="hidden" name="_token" value="{{ csrf_token('share-link-create') }}">
-      <input type="hidden" name="resourceType" value="{{ resourceType }}">
-      <input type="hidden" name="resourceId" value="{{ resourceId }}">
+    <div class="share-tab-panel flex flex-col hidden" data-tab-panel="link">
 
-      <div class="px-6 pt-4">
-        <p class="text-sm" style="color: var(--hc-text-2);">
-          Toute personne recevant ce lien pourra consulter cette ressource sans
-          créer de compte, en lecture seule, jusqu'à expiration.
-        </p>
-      </div>
+      {# Étape 1 — autoriser explicitement le partage par lien. Toujours
+         affiché (pas de moyen simple de connaître ici l'état actuel de
+         `visibility` sans requête supplémentaire) : le clic est idempotent,
+         sans effet nuisible si la ressource est déjà link_allowed. #}
+      <form method="post" action="{{ path('app_resource_visibility_update') }}" class="flex flex-col">
+        <input type="hidden" name="_token" value="{{ csrf_token('resource-visibility-update') }}">
+        <input type="hidden" name="resourceType" value="{{ resourceType }}">
+        <input type="hidden" name="resourceId" value="{{ resourceId }}">
+        <input type="hidden" name="visibility" value="link_allowed">
 
-      <div class="flex gap-2 justify-end px-6 py-4 mt-2" style="border-top: 1px solid var(--hc-border);">
-        <button type="button" class="share-modal-cancel"
-                style="background: none; border: none; color: var(--hc-text-2); cursor: pointer; padding: 0.5rem 1rem; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500;">
-          Annuler
-        </button>
-        <button type="submit" data-testid="share-link-submit"
-                class="px-4 py-2 rounded-md text-sm font-semibold"
-                style="background: var(--hc-accent); color: var(--hc-accent-contrast, #fff); border: none; cursor: pointer;">
-          Créer le lien
-        </button>
-      </div>
-    </form>
+        <div class="px-6 pt-4">
+          <p class="text-sm" style="color: var(--hc-text-2);">
+            Une ressource est privée par défaut. Autorisez le partage par lien
+            avant de pouvoir en créer un.
+          </p>
+        </div>
+
+        <div class="flex justify-end px-6 pt-3">
+          <button type="submit" data-testid="allow-link-sharing-submit"
+                  class="px-4 py-2 rounded-md text-sm font-semibold"
+                  style="background: var(--hc-surface-2); color: var(--hc-text); border: 1px solid var(--hc-border); cursor: pointer;">
+            Autoriser le partage par lien
+          </button>
+        </div>
+      </form>
+
+      {# Étape 2 — créer le lien effectif (échoue en 403 tant que l'étape 1
+         n'a pas été faite, cf. VisibilityChecker côté serveur). #}
+      <form method="post" action="{{ path('app_share_link_create') }}" class="flex flex-col">
+        <input type="hidden" name="_token" value="{{ csrf_token('share-link-create') }}">
+        <input type="hidden" name="resourceType" value="{{ resourceType }}">
+        <input type="hidden" name="resourceId" value="{{ resourceId }}">
+
+        <div class="px-6 pt-4">
+          <p class="text-sm" style="color: var(--hc-text-2);">
+            Toute personne recevant ce lien pourra consulter cette ressource sans
+            créer de compte, en lecture seule, jusqu'à expiration.
+          </p>
+        </div>
+
+        <div class="flex gap-2 justify-end px-6 py-4 mt-2" style="border-top: 1px solid var(--hc-border);">
+          <button type="button" class="share-modal-cancel"
+                  style="background: none; border: none; color: var(--hc-text-2); cursor: pointer; padding: 0.5rem 1rem; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500;">
+            Annuler
+          </button>
+          <button type="submit" data-testid="share-link-submit"
+                  class="px-4 py-2 rounded-md text-sm font-semibold"
+                  style="background: var(--hc-accent); color: var(--hc-accent-contrast, #fff); border: none; cursor: pointer;">
+            Créer le lien
+          </button>
+        </div>
+      </form>
+    </div>
 
     {# Bouton d'arrêt d'urgence — repasse la ressource en private, révoque
-       en cascade tous les liens publics actifs (visibility déjà link_allowed
-       si un lien a été créé). Formulaire caché : présent sur toutes les
-       ressources pour fournir le token CSRF, l'action reste toujours possible
-       même si aucun lien n'a jamais été créé (no-op silencieux côté serveur). #}
+       en cascade tous les liens publics actifs. Formulaire caché : présent
+       sur toutes les ressources pour fournir le token CSRF, l'action reste
+       toujours possible même si aucun lien n'a jamais été créé (no-op
+       silencieux côté serveur). #}
     <form method="post" action="{{ path('app_resource_visibility_update') }}" class="hidden" data-testid="resource-visibility-private-form">
       <input type="hidden" name="_token" value="{{ csrf_token('resource-visibility-update') }}">
       <input type="hidden" name="resourceType" value="{{ resourceType }}">

--- a/templates/components/ShareModal.html.twig
+++ b/templates/components/ShareModal.html.twig
@@ -108,6 +108,18 @@
       </div>
     </form>
 
+    {# Bouton d'arrêt d'urgence — repasse la ressource en private, révoque
+       en cascade tous les liens publics actifs (visibility déjà link_allowed
+       si un lien a été créé). Formulaire caché : présent sur toutes les
+       ressources pour fournir le token CSRF, l'action reste toujours possible
+       même si aucun lien n'a jamais été créé (no-op silencieux côté serveur). #}
+    <form method="post" action="{{ path('app_resource_visibility_update') }}" class="hidden" data-testid="resource-visibility-private-form">
+      <input type="hidden" name="_token" value="{{ csrf_token('resource-visibility-update') }}">
+      <input type="hidden" name="resourceType" value="{{ resourceType }}">
+      <input type="hidden" name="resourceId" value="{{ resourceId }}">
+      <input type="hidden" name="visibility" value="private">
+    </form>
+
   </div>
 </div>
 

--- a/templates/components/ShareModal.html.twig
+++ b/templates/components/ShareModal.html.twig
@@ -45,10 +45,10 @@
 
       <div class="px-6 pt-4">
         <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
-          Email de l'invité
+          Email(s) de l'invité — séparés par une virgule
         </label>
-        <input type="email" name="guestEmail" data-testid="share-guest-email"
-               placeholder="ami@example.com" required
+        <input type="email" name="guestEmail" data-testid="share-guest-email" multiple
+               placeholder="ami@example.com, autre@example.com" required
                class="w-full px-3 py-2 rounded-md text-sm"
                style="border: 1px solid var(--hc-border); background: var(--hc-bg); color: var(--hc-text);">
       </div>

--- a/templates/components/ShareModal.html.twig
+++ b/templates/components/ShareModal.html.twig
@@ -121,8 +121,22 @@
         <div class="px-6 pt-4">
           <p class="text-sm" style="color: var(--hc-text-2);">
             Toute personne recevant ce lien pourra consulter cette ressource sans
-            créer de compte, en lecture seule, jusqu'à expiration.
+            créer de compte, en lecture seule.
           </p>
+        </div>
+
+        <div class="px-6 pt-4">
+          <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
+            Durée de validité
+          </label>
+          <select name="duration" data-testid="share-link-duration"
+                  class="w-full px-3 py-2 rounded-md text-sm"
+                  style="border: 1px solid var(--hc-border); background: var(--hc-bg); color: var(--hc-text);">
+            <option value="1d">1 jour</option>
+            <option value="7d" selected>7 jours</option>
+            <option value="30d">30 jours</option>
+            <option value="permanent">Permanent — jusqu'à révocation manuelle</option>
+          </select>
         </div>
 
         <div class="flex gap-2 justify-end px-6 py-4 mt-2" style="border-top: 1px solid var(--hc-border);">

--- a/templates/components/ShareModal.html.twig
+++ b/templates/components/ShareModal.html.twig
@@ -1,6 +1,9 @@
 {# === ShareModal component ===
-   Modale d'invitation à partager une ressource (file|folder|album).
-   Soumet un formulaire POST classique vers app_share_create.
+   Modale de partage d'une ressource (file|folder|album), deux onglets :
+   - "Compte" : formulaire existant, POST vers app_share_create (Share, entre comptes).
+   - "Lien" : POST vers app_share_link_create (ShareLink, sans compte). Si la
+     ressource est `private`, le verrou VisibilityChecker refuse la création
+     (403) — l'onglet l'explique plutôt que de masquer le bouton sans raison.
    Props attendues : resourceType (string), resourceId (string). #}
 <div id="share-modal-{{ resourceId }}"
      data-testid="share-modal"
@@ -9,14 +12,10 @@
      aria-modal="true"
      role="dialog">
 
-  <form method="post" action="{{ path('app_share_create') }}"
-        class="flex flex-col"
-        style="background: var(--hc-surface); color: var(--hc-text); border: 1px solid var(--hc-border);
-               border-radius: 1rem; box-shadow: var(--hc-shadow-crisp); width: 100%; max-width: 440px;
-               margin: 1rem;">
-    <input type="hidden" name="_token" value="{{ csrf_token('share-create') }}">
-    <input type="hidden" name="resourceType" value="{{ resourceType }}">
-    <input type="hidden" name="resourceId" value="{{ resourceId }}">
+  <div class="flex flex-col"
+       style="background: var(--hc-surface); color: var(--hc-text); border: 1px solid var(--hc-border);
+              border-radius: 1rem; box-shadow: var(--hc-shadow-crisp); width: 100%; max-width: 440px;
+              margin: 1rem;">
 
     {# Header #}
     <div class="flex items-center justify-between px-6 py-4" style="border-bottom: 1px solid var(--hc-border);">
@@ -26,47 +25,90 @@
               style="background: var(--hc-surface-2); color: var(--hc-text-2); border: none; cursor: pointer;">×</button>
     </div>
 
-    {# Email #}
-    <div class="px-6 pt-4">
-      <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
-        Email de l'invité
-      </label>
-      <input type="email" name="guestEmail" data-testid="share-guest-email"
-             placeholder="ami@example.com" required
-             class="w-full px-3 py-2 rounded-md text-sm"
-             style="border: 1px solid var(--hc-border); background: var(--hc-bg); color: var(--hc-text);">
+    {# Onglets #}
+    <div class="flex px-6 pt-3" style="gap: 4px; border-bottom: 1px solid var(--hc-border);">
+      <button type="button" class="share-tab-btn share-tab-btn--active" data-tab="account" data-testid="share-tab-account"
+              style="padding: 0.5rem 0.75rem; font-size: 0.8125rem; font-weight: 600; background: none; border: none; cursor: pointer; border-bottom: 2px solid var(--hc-accent);">
+        Compte
+      </button>
+      <button type="button" class="share-tab-btn" data-tab="link" data-testid="share-tab-link"
+              style="padding: 0.5rem 0.75rem; font-size: 0.8125rem; font-weight: 600; background: none; border: none; cursor: pointer; border-bottom: 2px solid transparent; color: var(--hc-text-2);">
+        Lien
+      </button>
     </div>
 
-    {# Permission #}
-    <div class="px-6 pt-4">
-      <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
-        Permission
-      </label>
-      <div class="flex gap-3 text-sm">
-        <label class="flex items-center gap-1.5 cursor-pointer">
-          <input type="radio" name="permission" value="read" checked>
-          Lecture seule
+    {# Onglet "Compte" — partage entre comptes HomeCloud (Share) #}
+    <form method="post" action="{{ path('app_share_create') }}" class="share-tab-panel flex flex-col" data-tab-panel="account">
+      <input type="hidden" name="_token" value="{{ csrf_token('share-create') }}">
+      <input type="hidden" name="resourceType" value="{{ resourceType }}">
+      <input type="hidden" name="resourceId" value="{{ resourceId }}">
+
+      <div class="px-6 pt-4">
+        <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
+          Email de l'invité
         </label>
-        <label class="flex items-center gap-1.5 cursor-pointer">
-          <input type="radio" name="permission" value="write">
-          Lecture/écriture
-        </label>
+        <input type="email" name="guestEmail" data-testid="share-guest-email"
+               placeholder="ami@example.com" required
+               class="w-full px-3 py-2 rounded-md text-sm"
+               style="border: 1px solid var(--hc-border); background: var(--hc-bg); color: var(--hc-text);">
       </div>
-    </div>
 
-    {# Actions #}
-    <div class="flex gap-2 justify-end px-6 py-4 mt-2" style="border-top: 1px solid var(--hc-border);">
-      <button type="button" class="share-modal-cancel"
-              style="background: none; border: none; color: var(--hc-text-2); cursor: pointer; padding: 0.5rem 1rem; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500;">
-        Annuler
-      </button>
-      <button type="submit" data-testid="share-submit"
-              class="px-4 py-2 rounded-md text-sm font-semibold"
-              style="background: var(--hc-accent); color: var(--hc-accent-contrast, #fff); border: none; cursor: pointer;">
-        Partager
-      </button>
-    </div>
-  </form>
+      <div class="px-6 pt-4">
+        <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
+          Permission
+        </label>
+        <div class="flex gap-3 text-sm">
+          <label class="flex items-center gap-1.5 cursor-pointer">
+            <input type="radio" name="permission" value="read" checked>
+            Lecture seule
+          </label>
+          <label class="flex items-center gap-1.5 cursor-pointer">
+            <input type="radio" name="permission" value="write">
+            Lecture/écriture
+          </label>
+        </div>
+      </div>
+
+      <div class="flex gap-2 justify-end px-6 py-4 mt-2" style="border-top: 1px solid var(--hc-border);">
+        <button type="button" class="share-modal-cancel"
+                style="background: none; border: none; color: var(--hc-text-2); cursor: pointer; padding: 0.5rem 1rem; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500;">
+          Annuler
+        </button>
+        <button type="submit" data-testid="share-submit"
+                class="px-4 py-2 rounded-md text-sm font-semibold"
+                style="background: var(--hc-accent); color: var(--hc-accent-contrast, #fff); border: none; cursor: pointer;">
+          Partager
+        </button>
+      </div>
+    </form>
+
+    {# Onglet "Lien" — lien public sans compte (ShareLink) #}
+    <form method="post" action="{{ path('app_share_link_create') }}" class="share-tab-panel flex flex-col hidden" data-tab-panel="link">
+      <input type="hidden" name="_token" value="{{ csrf_token('share-link-create') }}">
+      <input type="hidden" name="resourceType" value="{{ resourceType }}">
+      <input type="hidden" name="resourceId" value="{{ resourceId }}">
+
+      <div class="px-6 pt-4">
+        <p class="text-sm" style="color: var(--hc-text-2);">
+          Toute personne recevant ce lien pourra consulter cette ressource sans
+          créer de compte, en lecture seule, jusqu'à expiration.
+        </p>
+      </div>
+
+      <div class="flex gap-2 justify-end px-6 py-4 mt-2" style="border-top: 1px solid var(--hc-border);">
+        <button type="button" class="share-modal-cancel"
+                style="background: none; border: none; color: var(--hc-text-2); cursor: pointer; padding: 0.5rem 1rem; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500;">
+          Annuler
+        </button>
+        <button type="submit" data-testid="share-link-submit"
+                class="px-4 py-2 rounded-md text-sm font-semibold"
+                style="background: var(--hc-accent); color: var(--hc-accent-contrast, #fff); border: none; cursor: pointer;">
+          Créer le lien
+        </button>
+      </div>
+    </form>
+
+  </div>
 </div>
 
 <script>
@@ -90,12 +132,30 @@
 
     if (openBtn) openBtn.addEventListener('click', open);
     if (closeBtn) closeBtn.addEventListener('click', close);
-    if (cancelBtn) cancelBtn.addEventListener('click', close);
+    modal.querySelectorAll('.share-modal-cancel').forEach(function (btn) {
+        btn.addEventListener('click', close);
+    });
     modal.addEventListener('click', function (e) {
         if (e.target === modal) close();
     });
     document.addEventListener('keydown', function (e) {
         if (e.key === 'Escape' && modal.style.display === 'flex') close();
+    });
+
+    var tabBtns = modal.querySelectorAll('.share-tab-btn');
+    var tabPanels = modal.querySelectorAll('.share-tab-panel');
+    tabBtns.forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var target = btn.getAttribute('data-tab');
+            tabBtns.forEach(function (b) {
+                b.classList.toggle('share-tab-btn--active', b === btn);
+                b.style.borderBottomColor = b === btn ? 'var(--hc-accent)' : 'transparent';
+                b.style.color = b === btn ? '' : 'var(--hc-text-2)';
+            });
+            tabPanels.forEach(function (panel) {
+                panel.classList.toggle('hidden', panel.getAttribute('data-tab-panel') !== target);
+            });
+        });
     });
 }());
 </script>

--- a/templates/reset_password/guest_invitation_email.html.twig
+++ b/templates/reset_password/guest_invitation_email.html.twig
@@ -1,0 +1,13 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Invitation HomeCloud{% endblock %}
+
+{% block body %}
+<p>Bonjour,</p>
+
+<p>Quelqu'un vient de partager une ressource avec vous sur HomeCloud. Un compte a été créé pour vous.</p>
+
+<p><a href="{{ activationUrl }}">Cliquez ici pour définir votre mot de passe et accéder à votre compte</a></p>
+
+<p>Si vous ne vous attendiez pas à cette invitation, vous pouvez ignorer cet email.</p>
+{% endblock %}

--- a/templates/web/guests.html.twig
+++ b/templates/web/guests.html.twig
@@ -1,0 +1,63 @@
+{% extends 'web/layout.html.twig' %}
+
+{% block title %}Invités — HomeCloud{% endblock %}
+
+{% block content %}
+
+{% set guestIcon %}<svg width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/></svg>{% endset %}
+
+<div class="flex flex-col gap-7 max-w-[1100px] mx-auto h-full">
+
+  <div class="flex items-center justify-between">
+    <div>
+      <h1 class="text-2xl font-black tracking-tight mb-1 flex items-center gap-2">
+        {{ guestIcon }}
+        Invités
+      </h1>
+      <p class="hc-page-sub">{{ guests|length }} compte{{ guests|length != 1 ? 's' : '' }} invité{{ guests|length != 1 ? 's' : '' }}</p>
+    </div>
+  </div>
+
+  {% if guests is empty %}
+    <div data-testid="guests-empty">
+      <twig:EmptyState
+        title="Aucun invité"
+        subtitle="Les comptes créés automatiquement lors d'un partage vers un email inconnu apparaîtront ici."
+        icon="<svg width='64' height='64' fill='none' stroke='currentColor' stroke-width='1.5' viewBox='0 0 24 24' class='hc-icon'><path d='M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2'/><circle cx='9' cy='7' r='4'/></svg>"
+      />
+    </div>
+  {% else %}
+    <div class="hc-item-card" style="display:flex; flex-direction:column; gap:0; padding:0;" data-testid="guests-list">
+      {% for guest in guests %}
+        <div class="flex items-center justify-between px-4 py-3" style="border-bottom:1px solid var(--hc-border);" data-testid="guest-row-{{ guest.id }}">
+          <div>
+            <div class="hc-item-name">{{ guest.displayName }}</div>
+            <div class="hc-item-meta">{{ guest.email }} · créé le {{ guest.createdAt|date('d/m/Y') }}</div>
+          </div>
+          <div class="flex items-center gap-2">
+            <form method="post" action="{{ path('app_guest_edit', { id: guest.id }) }}" class="flex items-center gap-2">
+              <input type="hidden" name="_token" value="{{ csrf_token('guest-edit') }}">
+              <input type="text" name="displayName" value="{{ guest.displayName }}"
+                     data-testid="guest-edit-name-{{ guest.id }}"
+                     class="px-2 py-1 rounded-md text-sm"
+                     style="border:1px solid var(--hc-border); background:var(--hc-bg); color:var(--hc-text); width:140px;">
+              <button type="submit" class="hc-item-action" style="background:none; border:none; cursor:pointer; font-size:0.8125rem; font-weight:600;">
+                Enregistrer
+              </button>
+            </form>
+            <form method="post" action="{{ path('app_guest_delete', { id: guest.id }) }}"
+                  onsubmit="return confirm('Supprimer le compte invité « {{ guest.displayName|e('js') }} » ?')">
+              <input type="hidden" name="_token" value="{{ csrf_token('guest-delete') }}">
+              <button type="submit" class="hc-item-action hc-item-action--danger" style="background:none; border:none; cursor:pointer; font-size:0.8125rem; font-weight:600;">
+                Supprimer
+              </button>
+            </form>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+
+</div>
+
+{% endblock %}

--- a/templates/web/layout.html.twig
+++ b/templates/web/layout.html.twig
@@ -78,6 +78,14 @@
                 </svg>
                 Partages
             </a>
+
+            <a href="{{ path('app_guests') }}"
+               class="hc-nav-item {{ current_route == 'app_guests' ? 'active' : '' }}">
+                <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                    <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/>
+                </svg>
+                Invités
+            </a>
         </nav>
     </aside>
 

--- a/templates/web/public_share.html.twig
+++ b/templates/web/public_share.html.twig
@@ -11,7 +11,17 @@
 
 <div style="max-width:1100px; margin:0 auto;">
     <p class="hc-item-meta" style="margin-bottom:4px;">Ressource partagée en lecture seule</p>
-    <h1 class="text-2xl font-black tracking-tight mb-4">{{ resourceName }}</h1>
+    <h1 class="text-2xl font-black tracking-tight mb-2">{{ resourceName }}</h1>
+
+    {% if link.expiresAt is not null %}
+        <div style="display:inline-block; padding:6px 14px; border-radius:999px; background:var(--hc-surface-2); border:1px solid var(--hc-border); font-size:0.8125rem; font-weight:600; margin-bottom:20px;">
+            Lien valable jusqu'au {{ link.expiresAt|date('d/m/Y') }}
+        </div>
+    {% else %}
+        <div style="display:inline-block; padding:6px 14px; border-radius:999px; background:var(--hc-surface-2); border:1px solid var(--hc-border); font-size:0.8125rem; font-weight:600; margin-bottom:20px;">
+            Lien permanent
+        </div>
+    {% endif %}
 
     {% if resourceType == 'file' %}
         <div class="hc-item-card" style="max-width:480px; padding:24px;">
@@ -67,8 +77,6 @@
             <twig:GalleryLightbox />
         {% endif %}
     {% endif %}
-
-    <p class="hc-item-meta" style="margin-top:24px;">Lien valable jusqu'au {{ link.expiresAt|date('d/m/Y') }}.</p>
 </div>
 
 </body>

--- a/templates/web/public_share.html.twig
+++ b/templates/web/public_share.html.twig
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    <title>{{ resourceName }} — Partagé via HomeCloud</title>
+    <link rel="stylesheet" href="{{ asset('styles/layout.css') }}">
+</head>
+<body class="hc-bg" style="min-height:100vh; display:flex; align-items:center; justify-content:center; padding:24px;">
+
+<div class="hc-item-card" style="max-width:560px; width:100%; padding:32px;">
+    <p class="hc-item-meta" style="margin-bottom:8px;">Ressource partagée en lecture seule</p>
+    <h1 class="text-2xl font-black tracking-tight mb-4">{{ resourceName }}</h1>
+
+    {% if resourceType == 'file' %}
+        <p class="hc-item-meta">{{ resource.mimeType }} · {{ (resource.size / 1024)|round }} Ko</p>
+    {% elseif resourceType == 'folder' %}
+        <div class="hc-item-meta">{{ resource.files|length }} fichier{{ resource.files|length != 1 ? 's' : '' }}</div>
+        <ul>
+            {% for file in resource.files %}
+                <li class="hc-item-name">{{ file.originalName }}</li>
+            {% endfor %}
+        </ul>
+    {% elseif resourceType == 'album' %}
+        <div class="hc-item-meta">{{ resource.medias|length }} média{{ resource.medias|length != 1 ? 's' : '' }}</div>
+    {% endif %}
+
+    <p class="hc-item-meta" style="margin-top:24px;">Lien valable jusqu'au {{ link.expiresAt|date('d/m/Y') }}.</p>
+</div>
+
+</body>
+</html>

--- a/templates/web/public_share.html.twig
+++ b/templates/web/public_share.html.twig
@@ -5,25 +5,67 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex, nofollow">
     <title>{{ resourceName }} — Partagé via HomeCloud</title>
-    <link rel="stylesheet" href="{{ asset('styles/layout.css') }}">
+    {{ importmap('app') }}
 </head>
-<body class="hc-bg" style="min-height:100vh; display:flex; align-items:center; justify-content:center; padding:24px;">
+<body class="hc-bg" style="min-height:100vh; padding:24px;">
 
-<div class="hc-item-card" style="max-width:560px; width:100%; padding:32px;">
-    <p class="hc-item-meta" style="margin-bottom:8px;">Ressource partagée en lecture seule</p>
+<div style="max-width:1100px; margin:0 auto;">
+    <p class="hc-item-meta" style="margin-bottom:4px;">Ressource partagée en lecture seule</p>
     <h1 class="text-2xl font-black tracking-tight mb-4">{{ resourceName }}</h1>
 
     {% if resourceType == 'file' %}
-        <p class="hc-item-meta">{{ resource.mimeType }} · {{ (resource.size / 1024)|round }} Ko</p>
+        <div class="hc-item-card" style="max-width:480px; padding:24px;">
+            <p class="hc-item-meta">{{ resource.mimeType }} · {{ (resource.size / 1024)|round }} Ko</p>
+            <a href="{{ path('app_public_share_download', { selector: link.selector, token: token, fileId: resource.id }) }}"
+               class="hc-item-action" style="display:inline-block; margin-top:12px;">
+                Télécharger
+            </a>
+        </div>
     {% elseif resourceType == 'folder' %}
-        <div class="hc-item-meta">{{ resource.files|length }} fichier{{ resource.files|length != 1 ? 's' : '' }}</div>
-        <ul>
+        <p class="hc-item-meta" style="margin-bottom:12px;">{{ resource.files|length }} fichier{{ resource.files|length != 1 ? 's' : '' }}</p>
+        <div class="hc-item-card" style="display:flex; flex-direction:column; gap:0; padding:0;">
             {% for file in resource.files %}
-                <li class="hc-item-name">{{ file.originalName }}</li>
+                <div class="flex items-center justify-between px-4 py-3" style="border-bottom:1px solid var(--hc-border);">
+                    <span class="hc-item-name">{{ file.originalName }}</span>
+                    <a href="{{ path('app_public_share_download', { selector: link.selector, token: token, fileId: file.id }) }}"
+                       class="hc-item-action">Télécharger</a>
+                </div>
             {% endfor %}
-        </ul>
+        </div>
     {% elseif resourceType == 'album' %}
-        <div class="hc-item-meta">{{ resource.medias|length }} média{{ resource.medias|length != 1 ? 's' : '' }}</div>
+        <p class="hc-item-meta" style="margin-bottom:12px;">{{ resource.medias|length }} média{{ resource.medias|length != 1 ? 's' : '' }}</p>
+
+        {% if resource.medias is not empty %}
+            <div class="hc-media-grid">
+                {% for media in resource.medias %}
+                    <div class="hc-media-thumb">
+                        <a href="#"
+                           data-lightbox
+                           data-media-type="{{ media.mediaType }}"
+                           data-full-src="{{ path('app_public_share_media_full', { selector: link.selector, token: token, mediaId: media.id }) }}"
+                           class="hc-media-thumb-link">
+                            {% if media.thumbnailPath %}
+                                <img src="{{ path('app_public_share_media_thumbnail', { selector: link.selector, token: token, mediaId: media.id }) }}"
+                                     alt="{{ media.file.originalName }}"
+                                     loading="lazy"
+                                     class="hc-media-thumb-img">
+                            {% else %}
+                                <div class="hc-media-thumb-fallback">
+                                    {% if media.mediaType == 'video' %}
+                                        <svg width="28" height="28" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-video"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
+                                    {% else %}
+                                        <svg width="28" height="28" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-images"><path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5z"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+                                    {% endif %}
+                                </div>
+                            {% endif %}
+                        </a>
+                        <div class="hc-media-thumb-caption">{{ media.file.originalName }}</div>
+                    </div>
+                {% endfor %}
+            </div>
+
+            <twig:GalleryLightbox />
+        {% endif %}
     {% endif %}
 
     <p class="hc-item-meta" style="margin-top:24px;">Lien valable jusqu'au {{ link.expiresAt|date('d/m/Y') }}.</p>

--- a/templates/web/shares.html.twig
+++ b/templates/web/shares.html.twig
@@ -16,41 +16,8 @@
         {{ shareIcon }}
         Partages
       </h1>
-      <p class="hc-page-sub">{{ incoming|length }} reçu{{ incoming|length != 1 ? 's' : '' }} · {{ outgoing|length }} envoyé{{ outgoing|length != 1 ? 's' : '' }}</p>
+      <p class="hc-page-sub">{{ outgoing|length }} envoyé{{ outgoing|length != 1 ? 's' : '' }}</p>
     </div>
-  </div>
-
-  {# === Partagés avec moi (entrants) === #}
-  <div>
-    <h2 class="text-sm font-semibold uppercase tracking-wide mb-3" style="color:var(--hc-text-2);">Partagés avec moi</h2>
-    {% if incoming is empty %}
-      <div data-testid="shares-incoming-empty">
-        <twig:EmptyState
-          title="Aucun partage reçu"
-          subtitle="Les ressources qu'on partage avec vous apparaîtront ici."
-          icon="<svg width='64' height='64' fill='none' stroke='currentColor' stroke-width='1.5' viewBox='0 0 24 24' class='hc-icon'><path d='M18 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 22a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM8.6 13.5l6.8 4M15.4 6.5l-6.8 4'/></svg>"
-        />
-      </div>
-    {% else %}
-      <div class="hc-item-card" style="display:flex; flex-direction:column; gap:0; padding:0;" data-testid="shares-incoming-list">
-        {% for row in incoming %}
-          <div class="flex items-center justify-between px-4 py-3" style="border-bottom:1px solid var(--hc-border);" data-testid="share-row-incoming">
-            <div>
-              <div class="hc-item-name">{{ row.resourceName }}</div>
-              <div class="hc-item-meta">
-                Partagé par {{ row.share.owner.displayName }} ·
-                {{ row.share.permission == 'write' ? 'lecture/écriture' : 'lecture seule' }} ·
-                {% if row.share.expiresAt %}
-                  {{ row.share.isActive ? 'expire le ' ~ row.share.expiresAt|date('d/m/Y') : 'expiré le ' ~ row.share.expiresAt|date('d/m/Y') }}
-                {% else %}
-                  permanent
-                {% endif %}
-              </div>
-            </div>
-          </div>
-        {% endfor %}
-      </div>
-    {% endif %}
   </div>
 
   {# === Mes partages (sortants) === #}

--- a/templates/web/shares.html.twig
+++ b/templates/web/shares.html.twig
@@ -86,6 +86,43 @@
     {% endif %}
   </div>
 
+  {# === Liens publics === #}
+  <div>
+    <h2 class="text-sm font-semibold uppercase tracking-wide mb-3" style="color:var(--hc-text-2);">Liens publics</h2>
+    {% if shareLinks is empty %}
+      <div data-testid="share-links-empty">
+        <twig:EmptyState
+          title="Aucun lien de partage créé"
+          subtitle="Créez un lien depuis l'onglet « Lien » de la modale de partage pour donner accès sans compte."
+          icon="<svg width='64' height='64' fill='none' stroke='currentColor' stroke-width='1.5' viewBox='0 0 24 24' class='hc-icon'><path d='M18 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 22a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM8.6 13.5l6.8 4M15.4 6.5l-6.8 4'/></svg>"
+        />
+      </div>
+    {% else %}
+      <div class="hc-item-card" style="display:flex; flex-direction:column; gap:0; padding:0;" data-testid="share-links-list">
+        {% for row in shareLinks %}
+          <div class="flex items-center justify-between px-4 py-3" style="border-bottom:1px solid var(--hc-border);" data-testid="share-link-row">
+            <div>
+              <div class="hc-item-name">{{ row.resourceName }}</div>
+              <div class="hc-item-meta">
+                Lien public · lecture seule ·
+                {{ row.link.isActive ? 'expire le ' ~ row.link.expiresAt|date('d/m/Y') : 'révoqué/expiré le ' ~ row.link.expiresAt|date('d/m/Y') }}
+              </div>
+            </div>
+            {% if row.link.isActive %}
+              <form method="post" action="{{ path('app_share_link_revoke') }}">
+                <input type="hidden" name="_token" value="{{ csrf_token('share-link-revoke') }}">
+                <input type="hidden" name="linkId" value="{{ row.link.id }}">
+                <button type="submit" class="hc-item-action hc-item-action--danger" style="background:none; border:none; cursor:pointer; font-size:0.8125rem; font-weight:600;">
+                  Révoquer
+                </button>
+              </form>
+            {% endif %}
+          </div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </div>
+
 </div>
 
 {% endblock %}

--- a/templates/web/shares.html.twig
+++ b/templates/web/shares.html.twig
@@ -68,11 +68,16 @@
       <div class="hc-item-card" style="display:flex; flex-direction:column; gap:0; padding:0;" data-testid="share-links-list">
         {% for row in shareLinks %}
           <div class="flex items-center justify-between px-4 py-3" style="border-bottom:1px solid var(--hc-border);" data-testid="share-link-row">
-            <div>
-              <div class="hc-item-name">{{ row.resourceName }}</div>
-              <div class="hc-item-meta">
-                Lien public · lecture seule ·
-                {{ row.link.isActive ? 'expire le ' ~ row.link.expiresAt|date('d/m/Y') : 'révoqué/expiré le ' ~ row.link.expiresAt|date('d/m/Y') }}
+            <div class="flex items-center gap-3">
+              {% if row.thumbnailUrl %}
+                <img src="{{ row.thumbnailUrl }}" alt="" style="width:40px; height:40px; object-fit:cover; border-radius:0.5rem; flex-shrink:0;">
+              {% endif %}
+              <div>
+                <div class="hc-item-name">{{ row.resourceName }}</div>
+                <div class="hc-item-meta">
+                  Lien public · lecture seule ·
+                  {{ row.link.isActive ? 'expire le ' ~ row.link.expiresAt|date('d/m/Y') : 'révoqué/expiré le ' ~ row.link.expiresAt|date('d/m/Y') }}
+                </div>
               </div>
             </div>
             {% if row.link.isActive %}

--- a/templates/web/shares.html.twig
+++ b/templates/web/shares.html.twig
@@ -76,7 +76,11 @@
                 <div class="hc-item-name">{{ row.resourceName }}</div>
                 <div class="hc-item-meta">
                   Lien public · lecture seule ·
-                  {{ row.link.isActive ? 'expire le ' ~ row.link.expiresAt|date('d/m/Y') : 'révoqué/expiré le ' ~ row.link.expiresAt|date('d/m/Y') }}
+                  {% if row.link.expiresAt is null %}
+                    {{ row.link.isActive ? 'permanent' : 'révoqué' }}
+                  {% else %}
+                    {{ row.link.isActive ? 'expire le ' ~ row.link.expiresAt|date('d/m/Y') : 'révoqué/expiré le ' ~ row.link.expiresAt|date('d/m/Y') }}
+                  {% endif %}
                 </div>
               </div>
             </div>

--- a/tests/Service/AlbumServiceTest.php
+++ b/tests/Service/AlbumServiceTest.php
@@ -12,6 +12,7 @@ use App\Entity\User;
 use App\Interface\AlbumRepositoryInterface;
 use App\Interface\MediaRepositoryInterface;
 use App\Interface\SharedResourceCleanerInterface;
+use App\Security\GuestRestrictionChecker;
 use App\Service\AlbumService;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -35,7 +36,12 @@ final class AlbumServiceTest extends TestCase
         $this->repository = $this->createMock(AlbumRepositoryInterface::class);
         $this->mediaRepository = $this->createMock(MediaRepositoryInterface::class);
         $this->sharedResourceCleaner = $this->createMock(SharedResourceCleanerInterface::class);
-        $this->service = new AlbumService($this->repository, $this->mediaRepository, $this->sharedResourceCleaner);
+        $this->service = new AlbumService(
+            $this->repository,
+            $this->mediaRepository,
+            $this->sharedResourceCleaner,
+            new GuestRestrictionChecker(),
+        );
     }
 
     private function makeUser(): User
@@ -168,6 +174,15 @@ final class AlbumServiceTest extends TestCase
         $album = $this->service->create('Vacances', $user);
 
         $this->assertCount(0, $album->getMedias());
+    }
+
+    public function testCreateThrowsForGuestAccount(): void
+    {
+        $guest = new User('guest@example.com', 'Guest');
+        $guest->markAsGuest();
+
+        $this->expectException(\App\Exception\GuestNotAllowedException::class);
+        $this->service->create('Vacances', $guest);
     }
 
     // --- delete() ---

--- a/tests/Service/AlbumServiceTest.php
+++ b/tests/Service/AlbumServiceTest.php
@@ -11,7 +11,7 @@ use App\Entity\Media;
 use App\Entity\User;
 use App\Interface\AlbumRepositoryInterface;
 use App\Interface\MediaRepositoryInterface;
-use App\Interface\ShareRepositoryInterface;
+use App\Interface\SharedResourceCleanerInterface;
 use App\Service\AlbumService;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -27,15 +27,15 @@ final class AlbumServiceTest extends TestCase
     private AlbumRepositoryInterface $repository;
     /** @var MediaRepositoryInterface&MockObject */
     private MediaRepositoryInterface $mediaRepository;
-    /** @var ShareRepositoryInterface&MockObject */
-    private ShareRepositoryInterface $shareRepository;
+    /** @var SharedResourceCleanerInterface&MockObject */
+    private SharedResourceCleanerInterface $sharedResourceCleaner;
 
     protected function setUp(): void
     {
         $this->repository = $this->createMock(AlbumRepositoryInterface::class);
         $this->mediaRepository = $this->createMock(MediaRepositoryInterface::class);
-        $this->shareRepository = $this->createMock(ShareRepositoryInterface::class);
-        $this->service = new AlbumService($this->repository, $this->mediaRepository, $this->shareRepository);
+        $this->sharedResourceCleaner = $this->createMock(SharedResourceCleanerInterface::class);
+        $this->service = new AlbumService($this->repository, $this->mediaRepository, $this->sharedResourceCleaner);
     }
 
     private function makeUser(): User

--- a/tests/Service/CreateFileServiceTest.php
+++ b/tests/Service/CreateFileServiceTest.php
@@ -8,6 +8,7 @@ use App\Entity\User;
 use App\Interface\DefaultFolderServiceInterface;
 use App\Interface\StorageServiceInterface;
 use App\Repository\UserRepository;
+use App\Security\GuestRestrictionChecker;
 use App\Service\CreateFileService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
@@ -35,6 +36,7 @@ class CreateFileServiceTest extends TestCase
             $this->defaultFolderService,
             $this->em,
             $this->userRepository,
+            new GuestRestrictionChecker(),
         );
     }
 
@@ -314,5 +316,20 @@ class CreateFileServiceTest extends TestCase
 
         // Assert
         $this->assertTrue($file->isNeutralized());
+    }
+
+    public function testCreateFromUploadThrowsForGuestAccount(): void
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'test');
+        file_put_contents($tmpFile, 'contenu');
+        $uploadedFile = new UploadedFile($tmpFile, 'doc.txt', 'text/plain', null, true);
+
+        $guest = new User('guest@example.com', 'Guest');
+        $guest->markAsGuest();
+
+        $this->userRepository->method('find')->willReturn($guest);
+
+        $this->expectException(\App\Exception\GuestNotAllowedException::class);
+        $this->service->createFromUpload($uploadedFile, (string) $guest->getId());
     }
 }

--- a/tests/Unit/Entity/ShareLinkTest.php
+++ b/tests/Unit/Entity/ShareLinkTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Share;
+use App\Entity\ShareLink;
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class ShareLinkTest extends TestCase
+{
+    private function makeOwner(): User
+    {
+        return $this->createMock(User::class);
+    }
+
+    public function testIsActiveWhenNotExpiredAndNotRevoked(): void
+    {
+        $link = new ShareLink(
+            $this->makeOwner(),
+            Share::RESOURCE_FILE,
+            Uuid::v7(),
+            'selector0000000000000000000000',
+            hash('sha256', 'plain-token'),
+            new \DateTimeImmutable('+7 days'),
+        );
+
+        $this->assertTrue($link->isActive());
+    }
+
+    public function testIsNotActiveWhenExpired(): void
+    {
+        $link = new ShareLink(
+            $this->makeOwner(),
+            Share::RESOURCE_FILE,
+            Uuid::v7(),
+            'selector0000000000000000000000',
+            hash('sha256', 'plain-token'),
+            new \DateTimeImmutable('-1 second'),
+        );
+
+        $this->assertFalse($link->isActive());
+    }
+
+    public function testIsNotActiveWhenRevoked(): void
+    {
+        $link = new ShareLink(
+            $this->makeOwner(),
+            Share::RESOURCE_FILE,
+            Uuid::v7(),
+            'selector0000000000000000000000',
+            hash('sha256', 'plain-token'),
+            new \DateTimeImmutable('+7 days'),
+        );
+
+        $link->revoke();
+
+        $this->assertFalse($link->isActive());
+    }
+
+    public function testVerifyTokenReturnsTrueForCorrectToken(): void
+    {
+        $link = new ShareLink(
+            $this->makeOwner(),
+            Share::RESOURCE_FILE,
+            Uuid::v7(),
+            'selector0000000000000000000000',
+            hash('sha256', 'plain-token'),
+            new \DateTimeImmutable('+7 days'),
+        );
+
+        $this->assertTrue($link->verifyToken('plain-token'));
+    }
+
+    public function testVerifyTokenReturnsFalseForTamperedToken(): void
+    {
+        $link = new ShareLink(
+            $this->makeOwner(),
+            Share::RESOURCE_FILE,
+            Uuid::v7(),
+            'selector0000000000000000000000',
+            hash('sha256', 'plain-token'),
+            new \DateTimeImmutable('+7 days'),
+        );
+
+        $this->assertFalse($link->verifyToken('plain-tokeX'));
+    }
+}

--- a/tests/Unit/Entity/ShareLinkTest.php
+++ b/tests/Unit/Entity/ShareLinkTest.php
@@ -88,4 +88,39 @@ final class ShareLinkTest extends TestCase
 
         $this->assertFalse($link->verifyToken('plain-tokeX'));
     }
+
+    public function testPermanentLinkWithNullExpiresAtIsNeverExpired(): void
+    {
+        // Cas d'usage : livraison d'un album à un client (photographe), qui
+        // ne veut pas surveiller/renouveler un lien qui expirerait tout seul.
+        // La révocation manuelle reste le seul moyen de couper l'accès.
+        $link = new ShareLink(
+            $this->makeOwner(),
+            Share::RESOURCE_ALBUM,
+            Uuid::v7(),
+            'selector0000000000000000000000',
+            hash('sha256', 'plain-token'),
+            null,
+        );
+
+        $this->assertNull($link->getExpiresAt());
+        $this->assertFalse($link->isExpired());
+        $this->assertTrue($link->isActive());
+    }
+
+    public function testPermanentLinkIsNotActiveOnceRevoked(): void
+    {
+        $link = new ShareLink(
+            $this->makeOwner(),
+            Share::RESOURCE_ALBUM,
+            Uuid::v7(),
+            'selector0000000000000000000000',
+            hash('sha256', 'plain-token'),
+            null,
+        );
+
+        $link->revoke();
+
+        $this->assertFalse($link->isActive());
+    }
 }

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+final class UserTest extends TestCase
+{
+    public function testDefaultAccountTypeIsFull(): void
+    {
+        $user = new User('someone@example.com', 'Someone');
+
+        $this->assertSame(User::ACCOUNT_TYPE_FULL, $user->getAccountType());
+        $this->assertFalse($user->isGuest());
+    }
+
+    public function testMarkAsGuestSetsAccountTypeToGuest(): void
+    {
+        $user = new User('guest@example.com', 'Guest');
+
+        $user->markAsGuest();
+
+        $this->assertSame(User::ACCOUNT_TYPE_GUEST, $user->getAccountType());
+        $this->assertTrue($user->isGuest());
+    }
+
+}

--- a/tests/Unit/Security/GuestRestrictionCheckerTest.php
+++ b/tests/Unit/Security/GuestRestrictionCheckerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Entity\User;
+use App\Exception\GuestNotAllowedException;
+use App\Security\GuestRestrictionChecker;
+use PHPUnit\Framework\TestCase;
+
+final class GuestRestrictionCheckerTest extends TestCase
+{
+    private function makeUser(bool $isGuest): User
+    {
+        $user = $this->createMock(User::class);
+        $user->method('isGuest')->willReturn($isGuest);
+
+        return $user;
+    }
+
+    public function testDenyUnlessFullAccountThrowsForGuest(): void
+    {
+        $checker = new GuestRestrictionChecker();
+
+        $this->expectException(GuestNotAllowedException::class);
+        $checker->denyUnlessFullAccount($this->makeUser(true));
+    }
+
+    public function testDenyUnlessFullAccountDoesNotThrowForFullAccount(): void
+    {
+        $checker = new GuestRestrictionChecker();
+
+        $checker->denyUnlessFullAccount($this->makeUser(false));
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/Unit/Security/ShareLinkAccessCheckerTest.php
+++ b/tests/Unit/Security/ShareLinkAccessCheckerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Entity\Share;
+use App\Entity\ShareLink;
+use App\Entity\User;
+use App\Interface\ShareLinkRepositoryInterface;
+use App\Security\ShareLinkAccessChecker;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class ShareLinkAccessCheckerTest extends TestCase
+{
+    private function makeShareLink(\DateTimeImmutable $expiresAt, string $plainToken = 'plain-token'): ShareLink
+    {
+        $owner = $this->createMock(User::class);
+
+        return new ShareLink(
+            $owner,
+            Share::RESOURCE_FILE,
+            Uuid::v7(),
+            'selector0000000000000000000000',
+            hash('sha256', $plainToken),
+            $expiresAt,
+        );
+    }
+
+    public function testUnknownSelectorReturnsNull(): void
+    {
+        $repository = $this->createMock(ShareLinkRepositoryInterface::class);
+        $repository->method('findBySelector')->willReturn(null);
+
+        $checker = new ShareLinkAccessChecker($repository);
+
+        $this->assertNull($checker->resolve('unknown-selector', 'any-token'));
+    }
+
+    public function testInvalidTokenReturnsNull(): void
+    {
+        $link = $this->makeShareLink(new \DateTimeImmutable('+7 days'));
+        $repository = $this->createMock(ShareLinkRepositoryInterface::class);
+        $repository->method('findBySelector')->willReturn($link);
+
+        $checker = new ShareLinkAccessChecker($repository);
+
+        $this->assertNull($checker->resolve('selector0000000000000000000000', 'wrong-token'));
+    }
+
+    public function testExpiredLinkReturnsNull(): void
+    {
+        $link = $this->makeShareLink(new \DateTimeImmutable('-1 second'));
+        $repository = $this->createMock(ShareLinkRepositoryInterface::class);
+        $repository->method('findBySelector')->willReturn($link);
+
+        $checker = new ShareLinkAccessChecker($repository);
+
+        $this->assertNull($checker->resolve('selector0000000000000000000000', 'plain-token'));
+    }
+
+    public function testRevokedLinkReturnsNull(): void
+    {
+        $link = $this->makeShareLink(new \DateTimeImmutable('+7 days'));
+        $link->revoke();
+        $repository = $this->createMock(ShareLinkRepositoryInterface::class);
+        $repository->method('findBySelector')->willReturn($link);
+
+        $checker = new ShareLinkAccessChecker($repository);
+
+        $this->assertNull($checker->resolve('selector0000000000000000000000', 'plain-token'));
+    }
+
+    public function testValidLinkReturnsTheShareLink(): void
+    {
+        $link = $this->makeShareLink(new \DateTimeImmutable('+7 days'));
+        $repository = $this->createMock(ShareLinkRepositoryInterface::class);
+        $repository->method('findBySelector')->willReturn($link);
+
+        $checker = new ShareLinkAccessChecker($repository);
+
+        $this->assertSame($link, $checker->resolve('selector0000000000000000000000', 'plain-token'));
+    }
+}

--- a/tests/Unit/Security/ShareLinkFactoryTest.php
+++ b/tests/Unit/Security/ShareLinkFactoryTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Share;
+use App\Entity\ShareLink;
+use App\Entity\User;
+use App\Exception\ResourceNotPubliclyShareableException;
+use App\Interface\OwnershipCheckerInterface;
+use App\Interface\ResourceLocatorInterface;
+use App\Security\ShareLinkFactory;
+use App\Security\ShareLinkTokenGenerator;
+use App\Security\VisibilityChecker;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\Uid\Uuid;
+
+final class ShareLinkFactoryTest extends TestCase
+{
+    private function makeFile(string $visibility, ?Folder $folder = null): File
+    {
+        $file = $this->createMock(File::class);
+        $file->method('getId')->willReturn(Uuid::v7());
+        $file->method('getVisibility')->willReturn($visibility);
+        $file->method('getFolder')->willReturn($folder ?? $this->makeFolder(Folder::VISIBILITY_LINK_ALLOWED));
+
+        return $file;
+    }
+
+    private function makeFolder(string $visibility, ?Folder $parent = null): Folder
+    {
+        $folder = $this->createMock(Folder::class);
+        $folder->method('getVisibility')->willReturn($visibility);
+        $folder->method('getParent')->willReturn($parent);
+
+        return $folder;
+    }
+
+    private function makeFactory(
+        File|Folder $resource,
+        bool $isOwner = true,
+    ): ShareLinkFactory {
+        $resourceLocator = $this->createMock(ResourceLocatorInterface::class);
+        $resourceLocator->method('locate')->willReturn($resource);
+
+        $ownershipChecker = $this->createMock(OwnershipCheckerInterface::class);
+        if ($isOwner) {
+            $ownershipChecker->method('denyUnlessOwner');
+        } else {
+            $ownershipChecker->method('denyUnlessOwner')
+                ->willThrowException(new AccessDeniedHttpException('not owner'));
+        }
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('persist');
+        $em->method('flush');
+
+        return new ShareLinkFactory(
+            $resourceLocator,
+            $ownershipChecker,
+            new VisibilityChecker(),
+            new ShareLinkTokenGenerator(),
+            $em,
+        );
+    }
+
+    public function testCreatesLinkForPubliclyShareableResource(): void
+    {
+        $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED);
+        $owner = $this->createMock(User::class);
+        $factory = $this->makeFactory($file);
+
+        $created = $factory->create($owner, Share::RESOURCE_FILE, $file->getId());
+
+        $this->assertInstanceOf(ShareLink::class, $created->link);
+        $this->assertNotSame('', $created->plainToken);
+    }
+
+    public function testThrowsWhenResourceIsPrivate(): void
+    {
+        // Le test qui compte pour cette étape : le verrou posé à l'étape 0
+        // doit être appelé ici, pas seulement exister dans le vide.
+        $file = $this->makeFile(File::VISIBILITY_PRIVATE);
+        $owner = $this->createMock(User::class);
+        $factory = $this->makeFactory($file);
+
+        $this->expectException(ResourceNotPubliclyShareableException::class);
+        $factory->create($owner, Share::RESOURCE_FILE, $file->getId());
+    }
+
+    public function testThrowsWhenParentFolderIsPrivate(): void
+    {
+        $privateFolder = $this->makeFolder(Folder::VISIBILITY_PRIVATE);
+        $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED, $privateFolder);
+        $owner = $this->createMock(User::class);
+        $factory = $this->makeFactory($file);
+
+        $this->expectException(ResourceNotPubliclyShareableException::class);
+        $factory->create($owner, Share::RESOURCE_FILE, $file->getId());
+    }
+
+    public function testThrowsWhenNotOwner(): void
+    {
+        $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED);
+        $owner = $this->createMock(User::class);
+        $factory = $this->makeFactory($file, isOwner: false);
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $factory->create($owner, Share::RESOURCE_FILE, $file->getId());
+    }
+
+    public function testDefaultsExpirationToSevenDays(): void
+    {
+        $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED);
+        $owner = $this->createMock(User::class);
+        $factory = $this->makeFactory($file);
+
+        $created = $factory->create($owner, Share::RESOURCE_FILE, $file->getId());
+
+        $expected = new \DateTimeImmutable('+7 days');
+        $this->assertEqualsWithDelta($expected->getTimestamp(), $created->link->getExpiresAt()->getTimestamp(), 5);
+    }
+
+    public function testClampsExpirationBeyondThirtyDaysToThirty(): void
+    {
+        $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED);
+        $owner = $this->createMock(User::class);
+        $factory = $this->makeFactory($file);
+
+        $requested = new \DateTimeImmutable('+90 days');
+        $created = $factory->create($owner, Share::RESOURCE_FILE, $file->getId(), $requested);
+
+        $expected = new \DateTimeImmutable('+30 days');
+        $this->assertEqualsWithDelta($expected->getTimestamp(), $created->link->getExpiresAt()->getTimestamp(), 5);
+    }
+
+    public function testAcceptsExpirationWithinThirtyDays(): void
+    {
+        $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED);
+        $owner = $this->createMock(User::class);
+        $factory = $this->makeFactory($file);
+
+        $requested = new \DateTimeImmutable('+15 days');
+        $created = $factory->create($owner, Share::RESOURCE_FILE, $file->getId(), $requested);
+
+        $expected = new \DateTimeImmutable('+15 days');
+        $this->assertEqualsWithDelta($expected->getTimestamp(), $created->link->getExpiresAt()->getTimestamp(), 5);
+    }
+}

--- a/tests/Unit/Security/ShareLinkFactoryTest.php
+++ b/tests/Unit/Security/ShareLinkFactoryTest.php
@@ -27,7 +27,7 @@ final class ShareLinkFactoryTest extends TestCase
         $file = $this->createMock(File::class);
         $file->method('getId')->willReturn(Uuid::v7());
         $file->method('getVisibility')->willReturn($visibility);
-        $file->method('getFolder')->willReturn($folder ?? $this->makeFolder(Folder::VISIBILITY_LINK_ALLOWED));
+        $file->method('getFolder')->willReturn($folder ?? $this->makeFolder(Folder::VISIBILITY_PRIVATE));
 
         return $file;
     }
@@ -93,10 +93,24 @@ final class ShareLinkFactoryTest extends TestCase
         $factory->create($owner, Share::RESOURCE_FILE, $file->getId());
     }
 
-    public function testThrowsWhenParentFolderIsPrivate(): void
+    public function testCreatesLinkForPrivateFileWhenParentFolderIsLinkAllowed(): void
+    {
+        // Partage de dossier (cascade) : un fichier private hérite de
+        // l'autorisation de son dossier parent.
+        $linkAllowedFolder = $this->makeFolder(Folder::VISIBILITY_LINK_ALLOWED);
+        $file = $this->makeFile(File::VISIBILITY_PRIVATE, $linkAllowedFolder);
+        $owner = $this->createMock(User::class);
+        $factory = $this->makeFactory($file);
+
+        $created = $factory->create($owner, Share::RESOURCE_FILE, $file->getId());
+
+        $this->assertInstanceOf(ShareLink::class, $created->link);
+    }
+
+    public function testThrowsWhenNeitherResourceNorAnyAncestorIsLinkAllowed(): void
     {
         $privateFolder = $this->makeFolder(Folder::VISIBILITY_PRIVATE);
-        $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED, $privateFolder);
+        $file = $this->makeFile(File::VISIBILITY_PRIVATE, $privateFolder);
         $owner = $this->createMock(User::class);
         $factory = $this->makeFactory($file);
 

--- a/tests/Unit/Security/ShareLinkFactoryTest.php
+++ b/tests/Unit/Security/ShareLinkFactoryTest.php
@@ -128,7 +128,7 @@ final class ShareLinkFactoryTest extends TestCase
         $factory->create($owner, Share::RESOURCE_FILE, $file->getId());
     }
 
-    public function testDefaultsExpirationToSevenDays(): void
+    public function testDefaultsExpirationToSevenDaysWhenDurationOmitted(): void
     {
         $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED);
         $owner = $this->createMock(User::class);
@@ -140,29 +140,50 @@ final class ShareLinkFactoryTest extends TestCase
         $this->assertEqualsWithDelta($expected->getTimestamp(), $created->link->getExpiresAt()->getTimestamp(), 5);
     }
 
-    public function testClampsExpirationBeyondThirtyDaysToThirty(): void
+    public function testDurationOneDay(): void
     {
         $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED);
         $owner = $this->createMock(User::class);
         $factory = $this->makeFactory($file);
 
-        $requested = new \DateTimeImmutable('+90 days');
-        $created = $factory->create($owner, Share::RESOURCE_FILE, $file->getId(), $requested);
+        $created = $factory->create($owner, Share::RESOURCE_FILE, $file->getId(), '1d');
+
+        $expected = new \DateTimeImmutable('+1 day');
+        $this->assertEqualsWithDelta($expected->getTimestamp(), $created->link->getExpiresAt()->getTimestamp(), 5);
+    }
+
+    public function testDurationThirtyDays(): void
+    {
+        $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED);
+        $owner = $this->createMock(User::class);
+        $factory = $this->makeFactory($file);
+
+        $created = $factory->create($owner, Share::RESOURCE_FILE, $file->getId(), '30d');
 
         $expected = new \DateTimeImmutable('+30 days');
         $this->assertEqualsWithDelta($expected->getTimestamp(), $created->link->getExpiresAt()->getTimestamp(), 5);
     }
 
-    public function testAcceptsExpirationWithinThirtyDays(): void
+    public function testDurationPermanentLeavesExpiresAtNull(): void
     {
         $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED);
         $owner = $this->createMock(User::class);
         $factory = $this->makeFactory($file);
 
-        $requested = new \DateTimeImmutable('+15 days');
-        $created = $factory->create($owner, Share::RESOURCE_FILE, $file->getId(), $requested);
+        $created = $factory->create($owner, Share::RESOURCE_FILE, $file->getId(), 'permanent');
 
-        $expected = new \DateTimeImmutable('+15 days');
+        $this->assertNull($created->link->getExpiresAt());
+    }
+
+    public function testUnknownDurationFallsBackToSevenDays(): void
+    {
+        $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED);
+        $owner = $this->createMock(User::class);
+        $factory = $this->makeFactory($file);
+
+        $created = $factory->create($owner, Share::RESOURCE_FILE, $file->getId(), 'not-a-real-duration');
+
+        $expected = new \DateTimeImmutable('+7 days');
         $this->assertEqualsWithDelta($expected->getTimestamp(), $created->link->getExpiresAt()->getTimestamp(), 5);
     }
 }

--- a/tests/Unit/Security/ShareLinkTokenGeneratorTest.php
+++ b/tests/Unit/Security/ShareLinkTokenGeneratorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Security\ShareLinkTokenGenerator;
+use PHPUnit\Framework\TestCase;
+
+final class ShareLinkTokenGeneratorTest extends TestCase
+{
+    public function testGeneratedTokenIs64HexCharacters(): void
+    {
+        $generator = new ShareLinkTokenGenerator();
+
+        $generated = $generator->generate();
+
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $generated->token);
+    }
+
+    public function testGeneratedSelectorIs32HexCharacters(): void
+    {
+        $generator = new ShareLinkTokenGenerator();
+
+        $generated = $generator->generate();
+
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $generated->selector);
+    }
+
+    public function testTwoCallsProduceDifferentTokensAndSelectors(): void
+    {
+        $generator = new ShareLinkTokenGenerator();
+
+        $first = $generator->generate();
+        $second = $generator->generate();
+
+        $this->assertNotSame($first->token, $second->token);
+        $this->assertNotSame($first->selector, $second->selector);
+    }
+
+    public function testHashedTokenIsNotThePlainToken(): void
+    {
+        $generator = new ShareLinkTokenGenerator();
+
+        $generated = $generator->generate();
+
+        $this->assertNotSame($generated->token, $generated->hashedToken);
+    }
+
+    public function testHashedTokenMatchesHashOfPlainToken(): void
+    {
+        $generator = new ShareLinkTokenGenerator();
+
+        $generated = $generator->generate();
+
+        $this->assertSame(hash('sha256', $generated->token), $generated->hashedToken);
+    }
+}

--- a/tests/Unit/Security/SharedFileScopeCheckerTest.php
+++ b/tests/Unit/Security/SharedFileScopeCheckerTest.php
@@ -64,6 +64,47 @@ final class SharedFileScopeCheckerTest extends TestCase
         $this->assertFalse($checker->isInScope($file, Share::RESOURCE_FOLDER, $linkedFolder->getId(), $linkedFolder));
     }
 
+    public function testFolderLinkAllowsAFileInASubfolder(): void
+    {
+        // Partager Docs/ doit couvrir Docs/Sous/fichier.txt, pas seulement
+        // les fichiers directement dans Docs/ — cohérent avec VisibilityChecker
+        // qui autorise déjà ce fichier par remontée des ancêtres.
+        $linkedFolder = $this->createMock(Folder::class);
+        $linkedFolder->method('getId')->willReturn(Uuid::v7());
+
+        $subfolder = $this->createMock(Folder::class);
+        $subfolder->method('getId')->willReturn(Uuid::v7());
+        $subfolder->method('getParent')->willReturn($linkedFolder);
+
+        $file = $this->createMock(File::class);
+        $file->method('getFolder')->willReturn($subfolder);
+
+        $checker = new SharedFileScopeChecker();
+
+        $this->assertTrue($checker->isInScope($file, Share::RESOURCE_FOLDER, $linkedFolder->getId(), $linkedFolder));
+    }
+
+    public function testFolderLinkDeniesAFileInAnUnrelatedFolderHierarchy(): void
+    {
+        $linkedFolder = $this->createMock(Folder::class);
+        $linkedFolder->method('getId')->willReturn(Uuid::v7());
+
+        $unrelatedGrandParent = $this->createMock(Folder::class);
+        $unrelatedGrandParent->method('getId')->willReturn(Uuid::v7());
+        $unrelatedGrandParent->method('getParent')->willReturn(null);
+
+        $unrelatedFolder = $this->createMock(Folder::class);
+        $unrelatedFolder->method('getId')->willReturn(Uuid::v7());
+        $unrelatedFolder->method('getParent')->willReturn($unrelatedGrandParent);
+
+        $file = $this->createMock(File::class);
+        $file->method('getFolder')->willReturn($unrelatedFolder);
+
+        $checker = new SharedFileScopeChecker();
+
+        $this->assertFalse($checker->isInScope($file, Share::RESOURCE_FOLDER, $linkedFolder->getId(), $linkedFolder));
+    }
+
     public function testAlbumLinkAllowsAFileThatIsAMediaOfThatAlbum(): void
     {
         $file = $this->createMock(File::class);

--- a/tests/Unit/Security/SharedFileScopeCheckerTest.php
+++ b/tests/Unit/Security/SharedFileScopeCheckerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Share;
+use App\Security\SharedFileScopeChecker;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class SharedFileScopeCheckerTest extends TestCase
+{
+    public function testFileLinkAllowsExactlyTheLinkedFile(): void
+    {
+        $file = $this->createMock(File::class);
+        $file->method('getId')->willReturn(Uuid::v7());
+
+        $checker = new SharedFileScopeChecker();
+
+        $this->assertTrue($checker->isInScope($file, Share::RESOURCE_FILE, $file->getId(), $file));
+    }
+
+    public function testFileLinkDeniesADifferentFile(): void
+    {
+        $linkedFileId = Uuid::v7();
+        $otherFile = $this->createMock(File::class);
+        $otherFile->method('getId')->willReturn(Uuid::v7());
+
+        $checker = new SharedFileScopeChecker();
+
+        $this->assertFalse($checker->isInScope($otherFile, Share::RESOURCE_FILE, $linkedFileId, $otherFile));
+    }
+
+    public function testFolderLinkAllowsAFileDirectlyInThatFolder(): void
+    {
+        $folder = $this->createMock(Folder::class);
+        $folder->method('getId')->willReturn(Uuid::v7());
+
+        $file = $this->createMock(File::class);
+        $file->method('getFolder')->willReturn($folder);
+
+        $checker = new SharedFileScopeChecker();
+
+        $this->assertTrue($checker->isInScope($file, Share::RESOURCE_FOLDER, $folder->getId(), $folder));
+    }
+
+    public function testFolderLinkDeniesAFileInAnotherFolder(): void
+    {
+        $linkedFolder = $this->createMock(Folder::class);
+        $linkedFolder->method('getId')->willReturn(Uuid::v7());
+
+        $otherFolder = $this->createMock(Folder::class);
+        $otherFolder->method('getId')->willReturn(Uuid::v7());
+
+        $file = $this->createMock(File::class);
+        $file->method('getFolder')->willReturn($otherFolder);
+
+        $checker = new SharedFileScopeChecker();
+
+        $this->assertFalse($checker->isInScope($file, Share::RESOURCE_FOLDER, $linkedFolder->getId(), $linkedFolder));
+    }
+
+    public function testAlbumLinkAllowsAFileThatIsAMediaOfThatAlbum(): void
+    {
+        $file = $this->createMock(File::class);
+        $file->method('getId')->willReturn(Uuid::v7());
+
+        $media = $this->createMock(\App\Entity\Media::class);
+        $media->method('getFile')->willReturn($file);
+
+        $album = $this->createMock(Album::class);
+        $album->method('getMedias')->willReturn(new \Doctrine\Common\Collections\ArrayCollection([$media]));
+
+        $checker = new SharedFileScopeChecker();
+
+        $this->assertTrue($checker->isInScope($file, Share::RESOURCE_ALBUM, $album->getId(), $album));
+    }
+
+    public function testAlbumLinkDeniesAFileNotInAlbum(): void
+    {
+        $file = $this->createMock(File::class);
+        $file->method('getId')->willReturn(Uuid::v7());
+
+        $otherFile = $this->createMock(File::class);
+        $otherFile->method('getId')->willReturn(Uuid::v7());
+        $media = $this->createMock(\App\Entity\Media::class);
+        $media->method('getFile')->willReturn($otherFile);
+
+        $album = $this->createMock(Album::class);
+        $album->method('getMedias')->willReturn(new \Doctrine\Common\Collections\ArrayCollection([$media]));
+
+        $checker = new SharedFileScopeChecker();
+
+        $this->assertFalse($checker->isInScope($file, Share::RESOURCE_ALBUM, $album->getId(), $album));
+    }
+}

--- a/tests/Unit/Security/SharedResourceCleanerIntegrationTest.php
+++ b/tests/Unit/Security/SharedResourceCleanerIntegrationTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Share;
+use App\Entity\ShareLink;
+use App\Entity\User;
+use App\Tests\AuthenticatedApiTestCase;
+
+/**
+ * Vérifie que les 4 sites d'appel réels de deleteByResource (File API,
+ * File web, Folder récursif, Album) passent bien par SharedResourceCleaner
+ * — donc suppriment aussi les ShareLink, pas seulement les Share.
+ *
+ * Test d'intégration (vraie base) plutôt qu'unitaire : ce qui compte est le
+ * comportement de bout en bout après suppression HTTP réelle, pas l'appel
+ * isolé d'une méthode.
+ */
+final class SharedResourceCleanerIntegrationTest extends AuthenticatedApiTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM share_links');
+        $conn->executeStatement('DELETE FROM shares');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM albums');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function makeLink(User $owner, string $resourceType, \Symfony\Component\Uid\Uuid $resourceId): ShareLink
+    {
+        $link = new ShareLink(
+            $owner,
+            $resourceType,
+            $resourceId,
+            bin2hex(random_bytes(16)),
+            hash('sha256', 'plain-token'),
+            new \DateTimeImmutable('+7 days'),
+        );
+        $this->em->persist($link);
+        $this->em->flush();
+
+        return $link;
+    }
+
+    public function testDeletingFileViaApiRemovesItsShareLink(): void
+    {
+        $owner = $this->createUser('cleaner-file@example.com', 'password123', 'Owner');
+        $folder = $this->createFolder('Docs', $owner);
+        $file = new File('doc.txt', 'text/plain', 10, 'test/doc.txt', $folder, $owner);
+        $this->em->persist($file);
+        $this->em->flush();
+        $this->makeLink($owner, Share::RESOURCE_FILE, $file->getId());
+
+        $client = $this->createAuthenticatedClient($owner);
+        $client->request('DELETE', '/api/v1/files/' . $file->getId());
+
+        static::assertResponseStatusCodeSame(204);
+        $this->em->clear();
+        $remaining = $this->em->getRepository(ShareLink::class)->findOneBy(['resourceId' => $file->getId()]);
+        $this->assertNull($remaining);
+    }
+
+    public function testDeletingAlbumViaServiceRemovesItsShareLink(): void
+    {
+        $owner = $this->createUser('cleaner-album@example.com', 'password123', 'Owner');
+        $album = new Album('Vacances', $owner);
+        $this->em->persist($album);
+        $this->em->flush();
+        $this->makeLink($owner, Share::RESOURCE_ALBUM, $album->getId());
+
+        $albumService = static::getContainer()->get(\App\Service\AlbumService::class);
+        $albumService->delete($album);
+
+        $this->em->clear();
+        $remaining = $this->em->getRepository(ShareLink::class)->findOneBy(['resourceId' => $album->getId()]);
+        $this->assertNull($remaining);
+    }
+}

--- a/tests/Unit/Security/SharedResourceCleanerTest.php
+++ b/tests/Unit/Security/SharedResourceCleanerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Entity\Share;
+use App\Interface\ShareLinkRepositoryInterface;
+use App\Interface\ShareRepositoryInterface;
+use App\Security\SharedResourceCleaner;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class SharedResourceCleanerTest extends TestCase
+{
+    public function testDeleteByResourceCleansBothSharesAndShareLinks(): void
+    {
+        $resourceId = Uuid::v7();
+
+        $shareRepository = $this->createMock(ShareRepositoryInterface::class);
+        $shareRepository->expects($this->once())
+            ->method('deleteByResource')
+            ->with(Share::RESOURCE_FILE, $resourceId);
+
+        $shareLinkRepository = $this->createMock(ShareLinkRepositoryInterface::class);
+        $shareLinkRepository->expects($this->once())
+            ->method('deleteByResource')
+            ->with(Share::RESOURCE_FILE, $resourceId);
+
+        $cleaner = new SharedResourceCleaner($shareRepository, $shareLinkRepository);
+
+        $cleaner->deleteByResource(Share::RESOURCE_FILE, $resourceId);
+    }
+}

--- a/tests/Unit/Security/VisibilityCheckerTest.php
+++ b/tests/Unit/Security/VisibilityCheckerTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Security\VisibilityChecker;
+use PHPUnit\Framework\TestCase;
+
+final class VisibilityCheckerTest extends TestCase
+{
+    private function makeFolder(string $visibility, ?Folder $parent = null): Folder
+    {
+        $folder = $this->createMock(Folder::class);
+        $folder->method('getVisibility')->willReturn($visibility);
+        $folder->method('getParent')->willReturn($parent);
+
+        return $folder;
+    }
+
+    private function makeFile(string $visibility, ?Folder $folder = null): File
+    {
+        $file = $this->createMock(File::class);
+        $file->method('getVisibility')->willReturn($visibility);
+        $file->method('getFolder')->willReturn($folder ?? $this->makeFolder(Folder::VISIBILITY_LINK_ALLOWED));
+
+        return $file;
+    }
+
+    private function makeAlbum(string $visibility): Album
+    {
+        $album = $this->createMock(Album::class);
+        $album->method('getVisibility')->willReturn($visibility);
+
+        return $album;
+    }
+
+    public function testPrivateResourceIsNotPubliclyShareable(): void
+    {
+        $file = $this->makeFile(File::VISIBILITY_PRIVATE);
+
+        $checker = new VisibilityChecker();
+
+        $this->assertFalse($checker->isPubliclyShareable($file));
+    }
+
+    public function testLinkAllowedResourceWithoutParentIsPubliclyShareable(): void
+    {
+        $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED, null);
+
+        $checker = new VisibilityChecker();
+
+        $this->assertTrue($checker->isPubliclyShareable($file));
+    }
+
+    public function testLinkAllowedFolderIsPubliclyShareable(): void
+    {
+        $folder = $this->makeFolder(Folder::VISIBILITY_LINK_ALLOWED);
+
+        $checker = new VisibilityChecker();
+
+        $this->assertTrue($checker->isPubliclyShareable($folder));
+    }
+
+    public function testLinkAllowedAlbumIsPubliclyShareable(): void
+    {
+        $album = $this->makeAlbum(Album::VISIBILITY_LINK_ALLOWED);
+
+        $checker = new VisibilityChecker();
+
+        $this->assertTrue($checker->isPubliclyShareable($album));
+    }
+
+    public function testLinkAllowedFileInLinkAllowedFolderIsPubliclyShareable(): void
+    {
+        $folder = $this->makeFolder(Folder::VISIBILITY_LINK_ALLOWED);
+        $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED, $folder);
+
+        $checker = new VisibilityChecker();
+
+        $this->assertTrue($checker->isPubliclyShareable($file));
+    }
+
+    public function testLinkAllowedFileInPrivateFolderIsNotPubliclyShareable(): void
+    {
+        // Le plus restrictif gagne : sinon déplacer un fichier dans un dossier
+        // "Privé" ne le protégerait pas, et le verrou ne vaudrait plus rien.
+        $folder = $this->makeFolder(Folder::VISIBILITY_PRIVATE);
+        $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED, $folder);
+
+        $checker = new VisibilityChecker();
+
+        $this->assertFalse($checker->isPubliclyShareable($file));
+    }
+
+    public function testLinkAllowedFileInLinkAllowedSubfolderOfPrivateFolderIsNotPubliclyShareable(): void
+    {
+        // La remontée doit parcourir toute la chaîne des parents, pas seulement
+        // le parent direct.
+        $grandParent = $this->makeFolder(Folder::VISIBILITY_PRIVATE);
+        $parent = $this->makeFolder(Folder::VISIBILITY_LINK_ALLOWED, $grandParent);
+        $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED, $parent);
+
+        $checker = new VisibilityChecker();
+
+        $this->assertFalse($checker->isPubliclyShareable($file));
+    }
+
+    public function testDenyUnlessPubliclyShareableThrowsOnPrivateResource(): void
+    {
+        $file = $this->makeFile(File::VISIBILITY_PRIVATE);
+
+        $checker = new VisibilityChecker();
+
+        $this->expectException(\App\Exception\ResourceNotPubliclyShareableException::class);
+        $checker->denyUnlessPubliclyShareable($file);
+    }
+
+    public function testDenyUnlessPubliclyShareableDoesNotThrowOnShareableResource(): void
+    {
+        $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED, null);
+
+        $checker = new VisibilityChecker();
+
+        $checker->denyUnlessPubliclyShareable($file);
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/Unit/Security/VisibilityCheckerTest.php
+++ b/tests/Unit/Security/VisibilityCheckerTest.php
@@ -25,7 +25,7 @@ final class VisibilityCheckerTest extends TestCase
     {
         $file = $this->createMock(File::class);
         $file->method('getVisibility')->willReturn($visibility);
-        $file->method('getFolder')->willReturn($folder ?? $this->makeFolder(Folder::VISIBILITY_LINK_ALLOWED));
+        $file->method('getFolder')->willReturn($folder ?? $this->makeFolder(Folder::VISIBILITY_PRIVATE));
 
         return $file;
     }
@@ -84,29 +84,68 @@ final class VisibilityCheckerTest extends TestCase
         $this->assertTrue($checker->isPubliclyShareable($file));
     }
 
-    public function testLinkAllowedFileInPrivateFolderIsNotPubliclyShareable(): void
+    public function testLinkAllowedFileInPrivateFolderIsPubliclyShareable(): void
     {
-        // Le plus restrictif gagne : sinon déplacer un fichier dans un dossier
-        // "Privé" ne le protégerait pas, et le verrou ne vaudrait plus rien.
+        // Partage individuel d'un fichier (icône sur sa vignette) : ne dépend
+        // JAMAIS de son dossier parent. Le fichier se suffit à lui-même.
         $folder = $this->makeFolder(Folder::VISIBILITY_PRIVATE);
         $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED, $folder);
+
+        $checker = new VisibilityChecker();
+
+        $this->assertTrue($checker->isPubliclyShareable($file));
+    }
+
+    public function testPrivateFileInLinkAllowedFolderIsPubliclyShareable(): void
+    {
+        // Partage de dossier (cascade) : un fichier private hérite de
+        // l'autorisation de son dossier — c'est le mécanisme "partager un
+        // dossier rend accessible tout son contenu", vérifié dynamiquement
+        // à chaque requête (pas de mise à jour en masse au moment du clic).
+        $folder = $this->makeFolder(Folder::VISIBILITY_LINK_ALLOWED);
+        $file = $this->makeFile(File::VISIBILITY_PRIVATE, $folder);
+
+        $checker = new VisibilityChecker();
+
+        $this->assertTrue($checker->isPubliclyShareable($file));
+    }
+
+    public function testPrivateFileInPrivateFolderUnderLinkAllowedGrandparentIsPubliclyShareable(): void
+    {
+        // La remontée doit parcourir toute la chaîne des parents, pas
+        // seulement le parent direct : partager Docs/ rend accessible
+        // Docs/Sous/fichier.txt même si Sous/ lui-même est private.
+        $grandParent = $this->makeFolder(Folder::VISIBILITY_LINK_ALLOWED);
+        $parent = $this->makeFolder(Folder::VISIBILITY_PRIVATE, $grandParent);
+        $file = $this->makeFile(File::VISIBILITY_PRIVATE, $parent);
+
+        $checker = new VisibilityChecker();
+
+        $this->assertTrue($checker->isPubliclyShareable($file));
+    }
+
+    public function testPrivateFileInPrivateFolderWithoutAnyLinkAllowedAncestorIsNotPubliclyShareable(): void
+    {
+        // Aucun opt-in nulle part dans la chaîne : reste refusé.
+        $grandParent = $this->makeFolder(Folder::VISIBILITY_PRIVATE);
+        $parent = $this->makeFolder(Folder::VISIBILITY_PRIVATE, $grandParent);
+        $file = $this->makeFile(File::VISIBILITY_PRIVATE, $parent);
 
         $checker = new VisibilityChecker();
 
         $this->assertFalse($checker->isPubliclyShareable($file));
     }
 
-    public function testLinkAllowedFileInLinkAllowedSubfolderOfPrivateFolderIsNotPubliclyShareable(): void
+    public function testLinkAllowedSubfolderIsPubliclyShareableEvenUnderPrivateGrandparent(): void
     {
-        // La remontée doit parcourir toute la chaîne des parents, pas seulement
-        // le parent direct.
+        // Un sous-dossier link_allowed est un point d'entrée de partage
+        // indépendant : partager Docs/Factures/ sans jamais toucher à Docs/.
         $grandParent = $this->makeFolder(Folder::VISIBILITY_PRIVATE);
-        $parent = $this->makeFolder(Folder::VISIBILITY_LINK_ALLOWED, $grandParent);
-        $file = $this->makeFile(File::VISIBILITY_LINK_ALLOWED, $parent);
+        $subfolder = $this->makeFolder(Folder::VISIBILITY_LINK_ALLOWED, $grandParent);
 
         $checker = new VisibilityChecker();
 
-        $this->assertFalse($checker->isPubliclyShareable($file));
+        $this->assertTrue($checker->isPubliclyShareable($subfolder));
     }
 
     public function testDenyUnlessPubliclyShareableThrowsOnPrivateResource(): void

--- a/tests/Unit/Service/FolderServiceTest.php
+++ b/tests/Unit/Service/FolderServiceTest.php
@@ -14,6 +14,7 @@ use App\Interface\FilenameValidatorInterface;
 use App\Interface\FolderRepositoryInterface;
 use App\Interface\OwnershipCheckerInterface;
 use App\Interface\SharedResourceCleanerInterface;
+use App\Security\GuestRestrictionChecker;
 use App\Service\FolderService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -67,6 +68,7 @@ final class FolderServiceTest extends TestCase
             logger:                $this->createMock(LoggerInterface::class),
             stopwatch:             new Stopwatch(),
             sharedResourceCleaner: $this->sharedResourceCleaner,
+            guestRestrictionChecker: new GuestRestrictionChecker(),
         );
     }
 
@@ -91,6 +93,15 @@ final class FolderServiceTest extends TestCase
 
         $this->expectException(BadRequestHttpException::class);
         $this->service->createFolder($owner, 'mon-dossier', $parent, FolderMediaType::General);
+    }
+
+    public function testCreateFolderThrowsForGuestAccount(): void
+    {
+        $guest = new User('guest@example.com', 'Guest');
+        $guest->markAsGuest();
+
+        $this->expectException(\App\Exception\GuestNotAllowedException::class);
+        $this->service->createFolder($guest, 'mon-dossier', null, FolderMediaType::General);
     }
 
     public function testCreateFolderPersistsAndReturnsFolder(): void

--- a/tests/Unit/Service/FolderServiceTest.php
+++ b/tests/Unit/Service/FolderServiceTest.php
@@ -13,7 +13,7 @@ use App\Interface\DefaultFolderServiceInterface;
 use App\Interface\FilenameValidatorInterface;
 use App\Interface\FolderRepositoryInterface;
 use App\Interface\OwnershipCheckerInterface;
-use App\Interface\ShareRepositoryInterface;
+use App\Interface\SharedResourceCleanerInterface;
 use App\Service\FolderService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -42,8 +42,8 @@ final class FolderServiceTest extends TestCase
     /** @var EntityManagerInterface&MockObject */
     private EntityManagerInterface $em;
 
-    /** @var ShareRepositoryInterface&MockObject */
-    private ShareRepositoryInterface $shareRepository;
+    /** @var SharedResourceCleanerInterface&MockObject */
+    private SharedResourceCleanerInterface $sharedResourceCleaner;
 
     private FolderService $service;
 
@@ -55,18 +55,18 @@ final class FolderServiceTest extends TestCase
         $this->authResolver        = $this->createMock(AuthenticationResolverInterface::class);
         $this->defaultFolderService = $this->createMock(DefaultFolderServiceInterface::class);
         $this->em                  = $this->createMock(EntityManagerInterface::class);
-        $this->shareRepository     = $this->createMock(ShareRepositoryInterface::class);
+        $this->sharedResourceCleaner = $this->createMock(SharedResourceCleanerInterface::class);
 
         $this->service = new FolderService(
-            folderRepository:     $this->folderRepository,
-            filenameValidator:    $this->filenameValidator,
-            ownershipChecker:     $this->ownershipChecker,
-            authResolver:         $this->authResolver,
-            defaultFolderService: $this->defaultFolderService,
-            em:                   $this->em,
-            logger:               $this->createMock(LoggerInterface::class),
-            stopwatch:            new Stopwatch(),
-            shareRepository:      $this->shareRepository,
+            folderRepository:      $this->folderRepository,
+            filenameValidator:     $this->filenameValidator,
+            ownershipChecker:      $this->ownershipChecker,
+            authResolver:          $this->authResolver,
+            defaultFolderService:  $this->defaultFolderService,
+            em:                    $this->em,
+            logger:                $this->createMock(LoggerInterface::class),
+            stopwatch:             new Stopwatch(),
+            sharedResourceCleaner: $this->sharedResourceCleaner,
         );
     }
 

--- a/tests/Unit/Service/GuestAccountCreatorTest.php
+++ b/tests/Unit/Service/GuestAccountCreatorTest.php
@@ -62,6 +62,7 @@ final class GuestAccountCreatorTest extends TestCase
         $this->assertSame('nouvel-invite@example.com', $user->getEmail());
         $this->assertSame('', $user->getPassword());
         $this->assertSame('Nouvel-invite', $user->getDisplayName());
+        $this->assertTrue($user->isGuest(), 'Le compte créé par GuestAccountCreator doit être marqué invité (statut permanent)');
     }
 
     public function testSendsAnEmailToTheGuestWithTheActivationLink(): void

--- a/tests/Unit/Service/GuestAccountCreatorTest.php
+++ b/tests/Unit/Service/GuestAccountCreatorTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\User;
+use App\Service\GuestAccountCreator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
+
+final class GuestAccountCreatorTest extends TestCase
+{
+    private function makeCreator(
+        ?EntityManagerInterface $em = null,
+        ?ResetPasswordHelperInterface $resetPasswordHelper = null,
+        ?MailerInterface $mailer = null,
+        ?UrlGeneratorInterface $urlGenerator = null,
+    ): GuestAccountCreator {
+        $em ??= $this->createMock(EntityManagerInterface::class);
+        $resetPasswordHelper ??= $this->makeResetPasswordHelperStub();
+        $mailer ??= $this->createMock(MailerInterface::class);
+        $urlGenerator ??= $this->makeUrlGeneratorStub();
+
+        return new GuestAccountCreator($em, $resetPasswordHelper, $mailer, $urlGenerator);
+    }
+
+    private function makeResetPasswordHelperStub(): ResetPasswordHelperInterface
+    {
+        $stub = $this->createMock(ResetPasswordHelperInterface::class);
+        $stub->method('generateResetToken')
+            ->willReturn(new ResetPasswordToken('fake-token', new \DateTimeImmutable('+1 hour'), time()));
+
+        return $stub;
+    }
+
+    private function makeUrlGeneratorStub(): UrlGeneratorInterface
+    {
+        $stub = $this->createMock(UrlGeneratorInterface::class);
+        $stub->method('generate')->willReturn('https://example.test/reset-password/fake-token');
+
+        return $stub;
+    }
+
+    public function testCreatesUserWithEmptyPasswordAndDisplayNameDerivedFromEmail(): void
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('persist')->with($this->isInstanceOf(User::class));
+        $em->expects($this->once())->method('flush');
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects($this->once())->method('send');
+
+        $creator = $this->makeCreator(em: $em, mailer: $mailer);
+
+        $user = $creator->create('nouvel-invite@example.com');
+
+        $this->assertSame('nouvel-invite@example.com', $user->getEmail());
+        $this->assertSame('', $user->getPassword());
+        $this->assertSame('Nouvel-invite', $user->getDisplayName());
+    }
+
+    public function testSendsAnEmailToTheGuestWithTheActivationLink(): void
+    {
+        $sentEmail = null;
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects($this->once())->method('send')->willReturnCallback(
+            function ($message) use (&$sentEmail) {
+                $sentEmail = $message;
+            }
+        );
+
+        $creator = $this->makeCreator(mailer: $mailer);
+
+        $creator->create('nouvel-invite@example.com');
+
+        $this->assertNotNull($sentEmail);
+        $this->assertSame('nouvel-invite@example.com', $sentEmail->getTo()[0]->getAddress());
+        $this->assertSame(
+            'https://example.test/reset-password/fake-token',
+            $sentEmail->getContext()['activationUrl'],
+        );
+    }
+}

--- a/tests/Web/FileShareButtonWebTest.php
+++ b/tests/Web/FileShareButtonWebTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Un fichier isolé (hors album) n'avait aucun bouton de partage dans
+ * l'explorateur, alors que le backend (ShareLinkFactory, Share entre
+ * comptes) supporte Share::RESOURCE_FILE depuis le début du chantier.
+ */
+final class FileShareButtonWebTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM share_links');
+        $conn->executeStatement('DELETE FROM shares');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createOwner(): User
+    {
+        return $this->createWebUser('file-share-owner@example.com', 'secret123', 'Owner');
+    }
+
+    private function createFile(User $owner): array
+    {
+        $folder = new Folder('Docs', $owner);
+        $this->em->persist($folder);
+        $file = new File('photo.jpg', 'image/jpeg', 1024, 'test/photo.jpg', $folder, $owner);
+        $this->em->persist($file);
+        $this->em->flush();
+
+        return [$file, $folder];
+    }
+
+    public function testExplorerHasShareButtonAndModalForAStandaloneFile(): void
+    {
+        $owner = $this->createOwner();
+        [$file, $folder] = $this->createFile($owner);
+        $this->loginAs('file-share-owner@example.com');
+
+        $this->client->request('GET', '/explorer?folder=' . $folder->getId()->toRfc4122());
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-testid="share-file-btn-' . $file->getId() . '"]');
+        $this->assertSelectorExists('form[action*="/share-create"] input[value="file"]');
+    }
+}

--- a/tests/Web/GuestManagementWebTest.php
+++ b/tests/Web/GuestManagementWebTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Gestion CRUD des comptes invités (créer/éditer/supprimer) — HomeCloud
+ * étant mono-owner par instance, la page liste tous les User accountType=guest,
+ * sans notion de propriétaire de l'invitation.
+ */
+final class GuestManagementWebTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM share_links');
+        $conn->executeStatement('DELETE FROM shares');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createOwner(): User
+    {
+        return $this->createWebUser('guest-mgmt-owner@example.com', 'secret123', 'Owner');
+    }
+
+    private function createGuest(string $email = 'invite@example.com', string $displayName = 'Invite'): User
+    {
+        $guest = new User($email, $displayName);
+        $guest->markAsGuest();
+        $this->em->persist($guest);
+        $this->em->flush();
+
+        return $guest;
+    }
+
+    public function testGuestsPageRequiresLogin(): void
+    {
+        $this->client->request('GET', '/invites');
+
+        $this->assertResponseRedirects('/login');
+    }
+
+    public function testGuestsPageListsGuestAccountsOnly(): void
+    {
+        $this->createOwner();
+        $this->createGuest('invite1@example.com', 'Invite One');
+        $fullAccount = $this->createWebUser('full-account@example.com', 'secret123', 'Full Account');
+
+        $this->loginAs('guest-mgmt-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/invites');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertStringContainsString('invite1@example.com', $crawler->filter('body')->text());
+        $this->assertStringNotContainsString('full-account@example.com', $crawler->filter('body')->text());
+    }
+
+    public function testEditGuestDisplayName(): void
+    {
+        $this->createOwner();
+        $guest = $this->createGuest();
+        $this->loginAs('guest-mgmt-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/invites');
+        $token = $crawler->filter('form[action*="/invites/' . $guest->getId() . '/edit"] input[name="_token"]')
+            ->first()->attr('value');
+
+        $this->client->request('POST', '/invites/' . $guest->getId() . '/edit', [
+            '_token'      => $token,
+            'displayName' => 'Nouveau Nom',
+        ]);
+
+        $this->assertResponseRedirects('/invites');
+
+        $this->em->clear();
+        $reloaded = $this->em->getRepository(User::class)->find($guest->getId());
+        $this->assertSame('Nouveau Nom', $reloaded->getDisplayName());
+    }
+
+    public function testDeleteGuestAccount(): void
+    {
+        $this->createOwner();
+        $guest = $this->createGuest();
+        $this->loginAs('guest-mgmt-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/invites');
+        $token = $crawler->filter('form[action*="/invites/' . $guest->getId() . '/delete"] input[name="_token"]')
+            ->first()->attr('value');
+
+        $this->client->request('POST', '/invites/' . $guest->getId() . '/delete', [
+            '_token' => $token,
+        ]);
+
+        $this->assertResponseRedirects('/invites');
+
+        $this->em->clear();
+        $this->assertNull($this->em->getRepository(User::class)->find($guest->getId()));
+    }
+
+    public function testCannotEditOrDeleteAFullAccountViaGuestManagement(): void
+    {
+        $this->createOwner();
+        $fullAccount = $this->createWebUser('full-account2@example.com', 'secret123', 'Full Account');
+        $this->loginAs('guest-mgmt-owner@example.com');
+
+        // Le token CSRF "guest-edit" n'est pas lié à un id précis, seul le
+        // contrôleur vérifie que la cible est bien accountType=guest.
+        $guest = $this->createGuest('other-invite@example.com');
+        $crawler = $this->client->request('GET', '/invites');
+        $token = $crawler->filter('form[action*="/invites/' . $guest->getId() . '/edit"] input[name="_token"]')
+            ->first()->attr('value');
+
+        $this->client->request('POST', '/invites/' . $fullAccount->getId() . '/edit', [
+            '_token'      => $token,
+            'displayName' => 'Hacked',
+        ]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+}

--- a/tests/Web/GuestManagementWebTest.php
+++ b/tests/Web/GuestManagementWebTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace App\Tests\Web;
 
+use App\Entity\ResetPasswordRequest;
 use App\Entity\User;
 use App\Tests\Web\Fixtures\WebFixturesTrait;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
 
 /**
  * Gestion CRUD des comptes invités (créer/éditer/supprimer) — HomeCloud
@@ -27,6 +29,7 @@ final class GuestManagementWebTest extends WebTestCase
         $this->em = static::getContainer()->get(EntityManagerInterface::class);
         $conn = $this->em->getConnection();
         $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM reset_password_request');
         $conn->executeStatement('DELETE FROM share_links');
         $conn->executeStatement('DELETE FROM shares');
         $conn->executeStatement('DELETE FROM users');
@@ -97,6 +100,39 @@ final class GuestManagementWebTest extends WebTestCase
     {
         $this->createOwner();
         $guest = $this->createGuest();
+        $this->loginAs('guest-mgmt-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/invites');
+        $token = $crawler->filter('form[action*="/invites/' . $guest->getId() . '/delete"] input[name="_token"]')
+            ->first()->attr('value');
+
+        $this->client->request('POST', '/invites/' . $guest->getId() . '/delete', [
+            '_token' => $token,
+        ]);
+
+        $this->assertResponseRedirects('/invites');
+
+        $this->em->clear();
+        $this->assertNull($this->em->getRepository(User::class)->find($guest->getId()));
+    }
+
+    public function testDeleteGuestAccountWithPendingActivationRequestSucceeds(): void
+    {
+        // Reproduit le bug réel : un invité créé via GuestAccountCreator a
+        // toujours une ResetPasswordRequest tant que le token d'activation
+        // n'a pas expiré/été utilisé. La supprimer sans nettoyer cette ligne
+        // violait la contrainte FK (500 ForeignKeyConstraintViolationException).
+        $this->createOwner();
+        $guest = $this->createGuest();
+
+        $resetPasswordHelper = static::getContainer()->get(ResetPasswordHelperInterface::class);
+        $resetPasswordHelper->generateResetToken($guest);
+
+        $this->assertNotNull(
+            $this->em->getRepository(ResetPasswordRequest::class)->findOneBy(['user' => $guest]),
+            'précondition : une ResetPasswordRequest doit exister pour ce guest',
+        );
+
         $this->loginAs('guest-mgmt-owner@example.com');
 
         $crawler = $this->client->request('GET', '/invites');

--- a/tests/Web/GuestUploadRestrictionWebTest.php
+++ b/tests/Web/GuestUploadRestrictionWebTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Un compte invité (accountType=guest) est exclusivement lecture/téléchargement :
+ * pas d'upload, quelle que soit la permission du Share qu'il a reçu.
+ */
+final class GuestUploadRestrictionWebTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createGuestWithPassword(string $email, string $password): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $guest = new User($email, 'Guest');
+        $guest->markAsGuest();
+        $guest->setPassword($hasher->hashPassword($guest, $password));
+        $this->em->persist($guest);
+        $this->em->flush();
+
+        return $guest;
+    }
+
+    private function login(string $email, string $password): void
+    {
+        $crawler = $this->client->request('GET', '/login');
+        $form = $crawler->selectButton('Se connecter')->form([
+            'email'    => $email,
+            'password' => $password,
+        ]);
+        $this->client->submit($form);
+        $this->client->followRedirect();
+    }
+
+    public function testGuestCannotUploadAFile(): void
+    {
+        $this->createGuestWithPassword('guest-upload@example.com', 'secret123');
+        $this->login('guest-upload@example.com', 'secret123');
+
+        $crawler = $this->client->request('GET', '/explorer');
+        $token = $crawler->filter('#main-upload-form input[name="_token"]')->attr('value');
+
+        $tmp = tempnam(sys_get_temp_dir(), 'guest_upload');
+        file_put_contents($tmp, 'contenu');
+        $upload = new UploadedFile($tmp, 'photo.jpg', 'image/jpeg', null, true);
+
+        $this->client->request('POST', '/files/upload', ['_token' => $token], ['file' => $upload]);
+        @unlink($tmp);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+}

--- a/tests/Web/PublicShareAlbumViewerWebTest.php
+++ b/tests/Web/PublicShareAlbumViewerWebTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Media;
+use App\Entity\Share;
+use App\Entity\ShareLink;
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * La page publique d'un album partagé doit afficher une grille de vignettes
+ * et permettre d'ouvrir la visionneuse (lightbox), pas seulement un résumé
+ * textuel ("3 médias") — signalé en usage réel : le contenu était invisible.
+ * Sans sidebar, sans icônes d'action (visiteur anonyme, lecture seule).
+ */
+final class PublicShareAlbumViewerWebTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+    private string $storageDir;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $this->storageDir = static::getContainer()->getParameter('app.storage_dir');
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM share_links');
+        $conn->executeStatement('DELETE FROM shares');
+        $conn->executeStatement('DELETE FROM album_media');
+        $conn->executeStatement('DELETE FROM albums');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createOwner(): User
+    {
+        return $this->createWebUser('public-album-owner@example.com', 'secret123', 'Owner');
+    }
+
+    private function createAlbumWithMedia(User $owner): array
+    {
+        $album = new Album('Vacances', $owner);
+        $album->setVisibility(Album::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($album);
+
+        $folder = new Folder('Photos', $owner);
+        $this->em->persist($folder);
+
+        $rel = 'public-album/' . uniqid() . '.jpg';
+        @mkdir($this->storageDir . '/public-album', 0777, true);
+        file_put_contents($this->storageDir . '/' . $rel, 'contenu de test');
+
+        $file = new File('photo1.jpg', 'image/jpeg', 16, $rel, $folder, $owner);
+        $this->em->persist($file);
+
+        $media = new Media($file, 'photo');
+        $thumbRel = 'public-album/' . uniqid() . '.thumb.jpg';
+        file_put_contents($this->storageDir . '/' . $thumbRel, 'thumb contenu');
+        $media->setThumbnailPath($thumbRel);
+        $this->em->persist($media);
+
+        $album->addMedia($media);
+        $this->em->flush();
+
+        return [$album, $media];
+    }
+
+    private function createLink(User $owner, Album $album, string $plainToken = 'valid-plain-token'): ShareLink
+    {
+        $link = new ShareLink(
+            $owner,
+            Share::RESOURCE_ALBUM,
+            $album->getId(),
+            bin2hex(random_bytes(16)),
+            hash('sha256', $plainToken),
+            new \DateTimeImmutable('+7 days'),
+        );
+        $this->em->persist($link);
+        $this->em->flush();
+
+        return $link;
+    }
+
+    public function testPublicAlbumPageShowsMediaThumbnailGrid(): void
+    {
+        $owner = $this->createOwner();
+        [$album, $media] = $this->createAlbumWithMedia($owner);
+        $link = $this->createLink($owner, $album);
+
+        $crawler = $this->client->request('GET', '/p/' . $link->getSelector() . '/valid-plain-token');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-lightbox]');
+        $this->assertSelectorExists('img[src*="/thumbnail"]');
+    }
+
+    public function testPublicAlbumPageHasNoSidebarOrActionIcons(): void
+    {
+        $owner = $this->createOwner();
+        [$album, ] = $this->createAlbumWithMedia($owner);
+        $link = $this->createLink($owner, $album);
+
+        $crawler = $this->client->request('GET', '/p/' . $link->getSelector() . '/valid-plain-token');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorNotExists('.hc-sidebar');
+        $this->assertSelectorNotExists('[data-testid="share-open-btn"]');
+        $this->assertStringContainsString('Vacances', $crawler->filter('body')->text());
+    }
+
+    public function testPublicThumbnailStreamsSuccessfully(): void
+    {
+        $owner = $this->createOwner();
+        [$album, $media] = $this->createAlbumWithMedia($owner);
+        $link = $this->createLink($owner, $album);
+
+        $this->client->request(
+            'GET',
+            '/p/' . $link->getSelector() . '/valid-plain-token/media/' . $media->getId()->toRfc4122() . '/thumbnail'
+        );
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testPublicFullMediaStreamsSuccessfully(): void
+    {
+        $owner = $this->createOwner();
+        [$album, $media] = $this->createAlbumWithMedia($owner);
+        $link = $this->createLink($owner, $album);
+
+        $this->client->request(
+            'GET',
+            '/p/' . $link->getSelector() . '/valid-plain-token/media/' . $media->getId()->toRfc4122() . '/full'
+        );
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testPublicThumbnailOfMediaOutsideLinkScopeReturns403(): void
+    {
+        $owner = $this->createOwner();
+        [$album, ] = $this->createAlbumWithMedia($owner);
+        $link = $this->createLink($owner, $album);
+
+        // Média hors de l'album partagé : ne doit pas être accessible via ce lien.
+        $otherFolder = new Folder('Autre', $owner);
+        $this->em->persist($otherFolder);
+        $otherFile = new File('secret.jpg', 'image/jpeg', 16, 'public-album/other.jpg', $otherFolder, $owner);
+        $this->em->persist($otherFile);
+        $otherMedia = new Media($otherFile, 'photo');
+        $this->em->persist($otherMedia);
+        $this->em->flush();
+
+        $this->client->request(
+            'GET',
+            '/p/' . $link->getSelector() . '/valid-plain-token/media/' . $otherMedia->getId()->toRfc4122() . '/thumbnail'
+        );
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+}

--- a/tests/Web/PublicShareDownloadWebTest.php
+++ b/tests/Web/PublicShareDownloadWebTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Share;
+use App\Entity\ShareLink;
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Téléchargement via un lien de partage public.
+ *
+ * Le test qui compte : un fichier hors du périmètre du lien doit renvoyer
+ * 403, pour vérifier qu'on ne peut pas pivoter vers une autre ressource de
+ * l'owner en changeant l'id de fichier dans l'URL (même logique IDOR que
+ * FileDownloadOwnershipTest côté API authentifiée).
+ */
+final class PublicShareDownloadWebTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+    private string $storageDir;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $this->storageDir = static::getContainer()->getParameter('app.storage_dir');
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM share_links');
+        $conn->executeStatement('DELETE FROM shares');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createOwner(string $email = 'public-dl-owner@example.com'): User
+    {
+        return $this->createWebUser($email, 'secret123', 'Owner');
+    }
+
+    private function makeStoredFile(User $owner, Folder $folder, string $name): File
+    {
+        $rel = 'public-dl/' . uniqid() . '.txt';
+        @mkdir($this->storageDir . '/public-dl', 0777, true);
+        file_put_contents($this->storageDir . '/' . $rel, 'contenu de test');
+
+        $file = new File($name, 'text/plain', 16, $rel, $folder, $owner);
+        $file->setVisibility(File::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($file);
+        $this->em->flush();
+
+        return $file;
+    }
+
+    private function createLink(User $owner, string $resourceType, \Symfony\Component\Uid\Uuid $resourceId, string $plainToken = 'valid-plain-token'): ShareLink
+    {
+        $link = new ShareLink(
+            $owner,
+            $resourceType,
+            $resourceId,
+            bin2hex(random_bytes(16)),
+            hash('sha256', $plainToken),
+            new \DateTimeImmutable('+7 days'),
+        );
+        $this->em->persist($link);
+        $this->em->flush();
+
+        return $link;
+    }
+
+    public function testHolderOfFileLinkCanDownloadTheFile(): void
+    {
+        $owner = $this->createOwner();
+        $folder = new Folder('Docs', $owner);
+        $folder->setVisibility(Folder::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($folder);
+        $this->em->flush();
+        $file = $this->makeStoredFile($owner, $folder, 'rapport.txt');
+        $link = $this->createLink($owner, Share::RESOURCE_FILE, $file->getId());
+
+        $this->client->request(
+            'GET',
+            '/p/' . $link->getSelector() . '/valid-plain-token/download/' . $file->getId()->toRfc4122()
+        );
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testHolderOfFolderLinkCanDownloadAFileInsideThatFolder(): void
+    {
+        $owner = $this->createOwner();
+        $folder = new Folder('Docs', $owner);
+        $folder->setVisibility(Folder::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($folder);
+        $this->em->flush();
+        $file = $this->makeStoredFile($owner, $folder, 'rapport.txt');
+        $link = $this->createLink($owner, Share::RESOURCE_FOLDER, $folder->getId());
+
+        $this->client->request(
+            'GET',
+            '/p/' . $link->getSelector() . '/valid-plain-token/download/' . $file->getId()->toRfc4122()
+        );
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testFileOutsideLinkScopeReturns403(): void
+    {
+        $owner = $this->createOwner();
+        $sharedFolder = new Folder('Partagé', $owner);
+        $sharedFolder->setVisibility(Folder::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($sharedFolder);
+        $otherFolder = new Folder('Privé', $owner);
+        $this->em->persist($otherFolder);
+        $this->em->flush();
+
+        $sharedFile = $this->makeStoredFile($owner, $sharedFolder, 'partage.txt');
+        $secretFile = $this->makeStoredFile($owner, $otherFolder, 'secret.txt');
+
+        // Le lien porte sur sharedFolder, pas sur otherFolder : secretFile
+        // n'est pas dans son périmètre bien qu'appartenant au même owner.
+        $link = $this->createLink($owner, Share::RESOURCE_FOLDER, $sharedFolder->getId());
+
+        $this->client->request(
+            'GET',
+            '/p/' . $link->getSelector() . '/valid-plain-token/download/' . $secretFile->getId()->toRfc4122()
+        );
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testWrongTokenReturns404EvenForAFileInScope(): void
+    {
+        $owner = $this->createOwner();
+        $folder = new Folder('Docs', $owner);
+        $folder->setVisibility(Folder::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($folder);
+        $this->em->flush();
+        $file = $this->makeStoredFile($owner, $folder, 'rapport.txt');
+        $link = $this->createLink($owner, Share::RESOURCE_FILE, $file->getId());
+
+        $this->client->request(
+            'GET',
+            '/p/' . $link->getSelector() . '/wrong-token/download/' . $file->getId()->toRfc4122()
+        );
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+}

--- a/tests/Web/PublicShareWebTest.php
+++ b/tests/Web/PublicShareWebTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\ShareLink;
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class PublicShareWebTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM share_links');
+        $conn->executeStatement('DELETE FROM shares');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createOwner(): User
+    {
+        return $this->createWebUser('public-share-owner@example.com', 'secret123', 'Owner');
+    }
+
+    private function createSharedFile(User $owner, string $name = 'photo.jpg'): File
+    {
+        $folder = new Folder('Docs', $owner);
+        $folder->setVisibility(Folder::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($folder);
+        $file = new File($name, 'image/jpeg', 1024, "test/{$name}", $folder, $owner);
+        $file->setVisibility(File::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($file);
+        $this->em->flush();
+
+        return $file;
+    }
+
+    private function createLink(User $owner, File $file, string $plainToken = 'valid-plain-token', ?\DateTimeImmutable $expiresAt = null): ShareLink
+    {
+        $link = new ShareLink(
+            $owner,
+            \App\Entity\Share::RESOURCE_FILE,
+            $file->getId(),
+            bin2hex(random_bytes(16)),
+            hash('sha256', $plainToken),
+            $expiresAt ?? new \DateTimeImmutable('+7 days'),
+        );
+        $this->em->persist($link);
+        $this->em->flush();
+
+        return $link;
+    }
+
+    public function testValidLinkIsAccessibleWithoutBeingLoggedIn(): void
+    {
+        $owner = $this->createOwner();
+        $file  = $this->createSharedFile($owner);
+        $link  = $this->createLink($owner, $file);
+
+        $this->client->request('GET', '/p/' . $link->getSelector() . '/valid-plain-token');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertStringContainsString($file->getOriginalName(), $this->client->getResponse()->getContent());
+    }
+
+    public function testWrongTokenReturns404(): void
+    {
+        $owner = $this->createOwner();
+        $file  = $this->createSharedFile($owner);
+        $link  = $this->createLink($owner, $file);
+
+        $this->client->request('GET', '/p/' . $link->getSelector() . '/wrong-token');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testUnknownSelectorReturns404(): void
+    {
+        $this->client->request('GET', '/p/00000000000000000000000000000000/whatever-token');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testExpiredLinkReturns404(): void
+    {
+        $owner = $this->createOwner();
+        $file  = $this->createSharedFile($owner);
+        $link  = $this->createLink($owner, $file, expiresAt: new \DateTimeImmutable('-1 second'));
+
+        $this->client->request('GET', '/p/' . $link->getSelector() . '/valid-plain-token');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testRevokedLinkReturns404(): void
+    {
+        $owner = $this->createOwner();
+        $file  = $this->createSharedFile($owner);
+        $link  = $this->createLink($owner, $file);
+        $link->revoke();
+        $this->em->flush();
+
+        $this->client->request('GET', '/p/' . $link->getSelector() . '/valid-plain-token');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testResponseHasNoindexHeader(): void
+    {
+        $owner = $this->createOwner();
+        $file  = $this->createSharedFile($owner);
+        $link  = $this->createLink($owner, $file);
+
+        $this->client->request('GET', '/p/' . $link->getSelector() . '/valid-plain-token');
+
+        $this->assertResponseHeaderSame('X-Robots-Tag', 'noindex, nofollow');
+    }
+
+    public function testPageDoesNotExposeAnyWriteAction(): void
+    {
+        $owner = $this->createOwner();
+        $file  = $this->createSharedFile($owner);
+        $link  = $this->createLink($owner, $file);
+
+        $crawler = $this->client->request('GET', '/p/' . $link->getSelector() . '/valid-plain-token');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorNotExists('form');
+        $this->assertSelectorNotExists('[data-testid*="rename"]');
+        $this->assertSelectorNotExists('[data-testid*="delete"]');
+    }
+}

--- a/tests/Web/ResourceVisibilityWebTest.php
+++ b/tests/Web/ResourceVisibilityWebTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Web;
 
+use App\Entity\Album;
 use App\Entity\File;
 use App\Entity\Folder;
 use App\Entity\Share;
@@ -129,6 +130,33 @@ final class ResourceVisibilityWebTest extends WebTestCase
         $this->em->clear();
         $reloaded = $this->em->getRepository(File::class)->find($file->getId());
         $this->assertSame(File::VISIBILITY_LINK_ALLOWED, $reloaded->getVisibility());
+    }
+
+    public function testAllowingLinkSharingOnAnAlbumRedirectsBackToTheAlbumPage(): void
+    {
+        // Referrer-Policy: no-referrer (posé pour protéger les tokens de
+        // ShareLink) fait que le navigateur n'envoie jamais l'en-tête Referer :
+        // le contrôleur ne peut donc PAS s'appuyer dessus pour revenir à la
+        // bonne page, il doit dériver l'URL depuis resourceType/resourceId.
+        $owner = $this->createOwner();
+        $album = new Album('Vacances', $owner);
+        $this->em->persist($album);
+        $this->em->flush();
+
+        $this->loginAs('visibility-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/albums/' . $album->getId()->toRfc4122());
+        $csrfToken = $crawler->filter('form[action*="/resource-visibility-update"] input[name="_token"]')
+            ->first()->attr('value');
+
+        $this->client->request('POST', '/resource-visibility-update', [
+            '_token'       => $csrfToken,
+            'resourceType' => 'album',
+            'resourceId'   => $album->getId()->toRfc4122(),
+            'visibility'   => 'link_allowed',
+        ]);
+
+        $this->assertResponseRedirects('/albums/' . $album->getId()->toRfc4122());
     }
 
     public function testNonOwnerCannotChangeVisibility(): void

--- a/tests/Web/ResourceVisibilityWebTest.php
+++ b/tests/Web/ResourceVisibilityWebTest.php
@@ -97,6 +97,40 @@ final class ResourceVisibilityWebTest extends WebTestCase
         $this->assertSame(File::VISIBILITY_PRIVATE, $reloadedFile->getVisibility());
     }
 
+    public function testMakingResourceLinkAllowedEnablesPublicShareLinkCreation(): void
+    {
+        // Une ressource est private par défaut : basculer en link_allowed est
+        // le préalable indispensable avant que l'onglet "Lien" de ShareModal
+        // puisse créer un ShareLink (sinon 403 via VisibilityChecker).
+        $owner = $this->createOwner();
+        $folder = new Folder('Docs', $owner);
+        $folder->setVisibility(Folder::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($folder);
+        $file = new File('photo.jpg', 'image/jpeg', 1024, 'test/photo.jpg', $folder, $owner);
+        $this->em->persist($file);
+        $this->em->flush();
+        $this->assertSame(File::VISIBILITY_PRIVATE, $file->getVisibility(), 'private par défaut');
+
+        $this->loginAs('visibility-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/explorer');
+        $csrfToken = $crawler->filter('form[action*="/resource-visibility-update"] input[name="_token"]')
+            ->first()->attr('value');
+
+        $this->client->request('POST', '/resource-visibility-update', [
+            '_token'       => $csrfToken,
+            'resourceType' => 'file',
+            'resourceId'   => $file->getId()->toRfc4122(),
+            'visibility'   => 'link_allowed',
+        ]);
+
+        $this->assertResponseRedirects();
+
+        $this->em->clear();
+        $reloaded = $this->em->getRepository(File::class)->find($file->getId());
+        $this->assertSame(File::VISIBILITY_LINK_ALLOWED, $reloaded->getVisibility());
+    }
+
     public function testNonOwnerCannotChangeVisibility(): void
     {
         $owner = $this->createOwner();

--- a/tests/Web/ResourceVisibilityWebTest.php
+++ b/tests/Web/ResourceVisibilityWebTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Share;
+use App\Entity\ShareLink;
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Bascule de visibilité d'une ressource — le "bouton d'arrêt d'urgence" :
+ * repasser une ressource en private doit révoquer immédiatement tous ses
+ * liens de partage actifs, pas seulement empêcher la création de nouveaux.
+ */
+final class ResourceVisibilityWebTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM share_links');
+        $conn->executeStatement('DELETE FROM shares');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createOwner(): User
+    {
+        return $this->createWebUser('visibility-owner@example.com', 'secret123', 'Owner');
+    }
+
+    private function createShareableFileWithActiveLink(User $owner): array
+    {
+        $folder = new Folder('Docs', $owner);
+        $folder->setVisibility(Folder::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($folder);
+        $file = new File('photo.jpg', 'image/jpeg', 1024, 'test/photo.jpg', $folder, $owner);
+        $file->setVisibility(File::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($file);
+        $this->em->flush();
+
+        $link = new ShareLink(
+            $owner,
+            Share::RESOURCE_FILE,
+            $file->getId(),
+            bin2hex(random_bytes(16)),
+            hash('sha256', 'valid-plain-token'),
+            new \DateTimeImmutable('+7 days'),
+        );
+        $this->em->persist($link);
+        $this->em->flush();
+
+        return [$file, $link];
+    }
+
+    public function testMakingResourcePrivateRevokesActiveShareLinks(): void
+    {
+        $owner = $this->createOwner();
+        [$file, $link] = $this->createShareableFileWithActiveLink($owner);
+        $this->loginAs('visibility-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/explorer');
+        $csrfToken = $crawler->filter('form[action*="/resource-visibility-update"] input[name="_token"]')
+            ->first()->attr('value');
+
+        $this->client->request('POST', '/resource-visibility-update', [
+            '_token'       => $csrfToken,
+            'resourceType' => 'file',
+            'resourceId'   => $file->getId()->toRfc4122(),
+            'visibility'   => 'private',
+        ]);
+
+        $this->assertResponseRedirects();
+
+        $this->em->clear();
+        $reloadedLink = $this->em->getRepository(ShareLink::class)->find($link->getId());
+        $this->assertNotNull($reloadedLink->getRevokedAt(), 'Le lien actif doit avoir été révoqué');
+
+        $reloadedFile = $this->em->getRepository(File::class)->find($file->getId());
+        $this->assertSame(File::VISIBILITY_PRIVATE, $reloadedFile->getVisibility());
+    }
+
+    public function testNonOwnerCannotChangeVisibility(): void
+    {
+        $owner = $this->createOwner();
+        [$file, ] = $this->createShareableFileWithActiveLink($owner);
+        $attacker = $this->createWebUser('visibility-attacker@example.com', 'secret123', 'Attacker');
+        // L'attaquant a son propre dossier partageable, pour obtenir un
+        // token CSRF valide dans SA session (le token est lié à la session,
+        // pas global) sans dépendre d'une ressource de la victime.
+        $attackerFolder = new Folder('AttackerDocs', $attacker);
+        $attackerFolder->setVisibility(Folder::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($attackerFolder);
+        $this->em->flush();
+
+        $this->loginAs('visibility-attacker@example.com');
+        $crawler = $this->client->request('GET', '/explorer');
+        $csrfToken = $crawler->filter('form[action*="/resource-visibility-update"] input[name="_token"]')
+            ->first()->attr('value');
+
+        $this->client->request('POST', '/resource-visibility-update', [
+            '_token'       => $csrfToken,
+            'resourceType' => 'file',
+            'resourceId'   => $file->getId()->toRfc4122(),
+            'visibility'   => 'private',
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+}

--- a/tests/Web/ShareLinkCreateWebTest.php
+++ b/tests/Web/ShareLinkCreateWebTest.php
@@ -82,8 +82,11 @@ final class ShareLinkCreateWebTest extends WebTestCase
         $this->assertNotNull($link);
     }
 
-    public function testCreateShareLinkOnPrivateFileReturns403(): void
+    public function testCreateShareLinkOnPrivateFileRedirectsWithErrorFlash(): void
     {
+        // Le verrou de visibilité doit tenir (comportement de sécurité
+        // inchangé), mais l'échec doit être une redirection avec message
+        // explicite plutôt qu'une page d'exception Symfony brute.
         $owner = $this->createOwner();
         $file = $this->createFile($owner, File::VISIBILITY_PRIVATE);
         $this->loginAs('sharelink-owner@example.com');
@@ -96,7 +99,9 @@ final class ShareLinkCreateWebTest extends WebTestCase
             'resourceId'   => $file->getId()->toRfc4122(),
         ]);
 
-        $this->assertResponseStatusCodeSame(403);
+        $this->assertResponseRedirects();
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('.flash-error', 'privée');
 
         $link = $this->em->getRepository(ShareLink::class)->findOneBy(['resourceId' => $file->getId()]);
         $this->assertNull($link);

--- a/tests/Web/ShareLinkCreateWebTest.php
+++ b/tests/Web/ShareLinkCreateWebTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\ShareLink;
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class ShareLinkCreateWebTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM share_links');
+        $conn->executeStatement('DELETE FROM shares');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createOwner(): User
+    {
+        return $this->createWebUser('sharelink-owner@example.com', 'secret123', 'Owner');
+    }
+
+    private function createFile(User $owner, string $visibility, string $name = 'photo.jpg'): File
+    {
+        $folder = new Folder('Docs', $owner);
+        $folder->setVisibility(Folder::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($folder);
+        $file = new File($name, 'image/jpeg', 1024, "test/{$name}", $folder, $owner);
+        $file->setVisibility($visibility);
+        $this->em->persist($file);
+        $this->em->flush();
+
+        return $file;
+    }
+
+    private function shareLinkCreateToken(): string
+    {
+        $crawler = $this->client->request('GET', '/explorer');
+
+        return $crawler->filter('form[action*="/share-link-create"] input[name="_token"]')->first()->attr('value');
+    }
+
+    public function testCreateShareLinkOnPubliclyShareableFileRedirectsWithLink(): void
+    {
+        $owner = $this->createOwner();
+        $file = $this->createFile($owner, File::VISIBILITY_LINK_ALLOWED);
+        $this->loginAs('sharelink-owner@example.com');
+
+        $token = $this->shareLinkCreateToken();
+
+        $this->client->request('POST', '/share-link-create', [
+            '_token'       => $token,
+            'resourceType' => 'file',
+            'resourceId'   => $file->getId()->toRfc4122(),
+        ]);
+
+        $this->assertResponseRedirects();
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('.flash-success', '/p/');
+
+        $link = $this->em->getRepository(ShareLink::class)->findOneBy(['resourceId' => $file->getId()]);
+        $this->assertNotNull($link);
+    }
+
+    public function testCreateShareLinkOnPrivateFileReturns403(): void
+    {
+        $owner = $this->createOwner();
+        $file = $this->createFile($owner, File::VISIBILITY_PRIVATE);
+        $this->loginAs('sharelink-owner@example.com');
+
+        $token = $this->shareLinkCreateToken();
+
+        $this->client->request('POST', '/share-link-create', [
+            '_token'       => $token,
+            'resourceType' => 'file',
+            'resourceId'   => $file->getId()->toRfc4122(),
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+
+        $link = $this->em->getRepository(ShareLink::class)->findOneBy(['resourceId' => $file->getId()]);
+        $this->assertNull($link);
+    }
+
+    public function testCreateShareLinkWithInvalidCsrfTokenReturns403(): void
+    {
+        $owner = $this->createOwner();
+        $file = $this->createFile($owner, File::VISIBILITY_LINK_ALLOWED);
+        $this->loginAs('sharelink-owner@example.com');
+
+        $this->client->request('POST', '/share-link-create', [
+            '_token'       => 'invalid-token',
+            'resourceType' => 'file',
+            'resourceId'   => $file->getId()->toRfc4122(),
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testCreateShareLinkByNonOwnerReturns403(): void
+    {
+        $owner = $this->createOwner();
+        $file = $this->createFile($owner, File::VISIBILITY_LINK_ALLOWED);
+        $this->createWebUser('sharelink-attacker@example.com', 'secret123', 'Attacker');
+
+        // Le token CSRF nommé "share-link-create" n'est pas lié à une ressource
+        // ni à un utilisateur précis : le récupérer en tant qu'owner (qui a un
+        // dossier visible sur /explorer) est valide pour n'importe quel compte.
+        $this->loginAs('sharelink-owner@example.com');
+        $token = $this->shareLinkCreateToken();
+
+        $this->client->request('GET', '/logout');
+        $this->loginAs('sharelink-attacker@example.com');
+
+        $this->client->request('POST', '/share-link-create', [
+            '_token'       => $token,
+            'resourceType' => 'file',
+            'resourceId'   => $file->getId()->toRfc4122(),
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+}

--- a/tests/Web/ShareLinkCreateWebTest.php
+++ b/tests/Web/ShareLinkCreateWebTest.php
@@ -121,16 +121,16 @@ final class ShareLinkCreateWebTest extends WebTestCase
     {
         $owner = $this->createOwner();
         $file = $this->createFile($owner, File::VISIBILITY_LINK_ALLOWED);
-        $this->createWebUser('sharelink-attacker@example.com', 'secret123', 'Attacker');
+        $attacker = $this->createWebUser('sharelink-attacker@example.com', 'secret123', 'Attacker');
+        // Le token CSRF est lié à la session : l'attaquant doit le récupérer
+        // dans SA propre session, via sa propre ressource partageable.
+        $attackerFolder = new Folder('AttackerDocs', $attacker);
+        $attackerFolder->setVisibility(Folder::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($attackerFolder);
+        $this->em->flush();
 
-        // Le token CSRF nommé "share-link-create" n'est pas lié à une ressource
-        // ni à un utilisateur précis : le récupérer en tant qu'owner (qui a un
-        // dossier visible sur /explorer) est valide pour n'importe quel compte.
-        $this->loginAs('sharelink-owner@example.com');
-        $token = $this->shareLinkCreateToken();
-
-        $this->client->request('GET', '/logout');
         $this->loginAs('sharelink-attacker@example.com');
+        $token = $this->shareLinkCreateToken();
 
         $this->client->request('POST', '/share-link-create', [
             '_token'       => $token,

--- a/tests/Web/ShareLinkCreateWebTest.php
+++ b/tests/Web/ShareLinkCreateWebTest.php
@@ -129,6 +129,53 @@ final class ShareLinkCreateWebTest extends WebTestCase
         $this->assertResponseStatusCodeSame(403);
     }
 
+    public function testCreateShareLinkWithOneDayDuration(): void
+    {
+        $owner = $this->createOwner();
+        $file = $this->createFile($owner, File::VISIBILITY_LINK_ALLOWED);
+        $this->loginAs('sharelink-owner@example.com');
+
+        $token = $this->shareLinkCreateToken();
+
+        $this->client->request('POST', '/share-link-create', [
+            '_token'       => $token,
+            'resourceType' => 'file',
+            'resourceId'   => $file->getId()->toRfc4122(),
+            'duration'     => '1d',
+        ]);
+
+        $this->assertResponseRedirects();
+
+        $link = $this->em->getRepository(ShareLink::class)->findOneBy(['resourceId' => $file->getId()]);
+        $this->assertNotNull($link);
+        $expected = new \DateTimeImmutable('+1 day');
+        $this->assertEqualsWithDelta($expected->getTimestamp(), $link->getExpiresAt()->getTimestamp(), 5);
+    }
+
+    public function testCreateShareLinkWithPermanentDurationHasNoExpiration(): void
+    {
+        $owner = $this->createOwner();
+        $file = $this->createFile($owner, File::VISIBILITY_LINK_ALLOWED);
+        $this->loginAs('sharelink-owner@example.com');
+
+        $token = $this->shareLinkCreateToken();
+
+        $this->client->request('POST', '/share-link-create', [
+            '_token'       => $token,
+            'resourceType' => 'file',
+            'resourceId'   => $file->getId()->toRfc4122(),
+            'duration'     => 'permanent',
+        ]);
+
+        $this->assertResponseRedirects();
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('.flash-success', '/p/');
+
+        $link = $this->em->getRepository(ShareLink::class)->findOneBy(['resourceId' => $file->getId()]);
+        $this->assertNotNull($link);
+        $this->assertNull($link->getExpiresAt());
+    }
+
     public function testCreateShareLinkByNonOwnerReturns403(): void
     {
         $owner = $this->createOwner();

--- a/tests/Web/ShareLinkCreateWebTest.php
+++ b/tests/Web/ShareLinkCreateWebTest.php
@@ -87,8 +87,15 @@ final class ShareLinkCreateWebTest extends WebTestCase
         // Le verrou de visibilité doit tenir (comportement de sécurité
         // inchangé), mais l'échec doit être une redirection avec message
         // explicite plutôt qu'une page d'exception Symfony brute.
+        // Dossier ET fichier private : depuis le passage à la règle OU, un
+        // fichier private hérite de l'autorisation d'un dossier link_allowed
+        // — pour tester le refus, aucun des deux ne doit être autorisé.
         $owner = $this->createOwner();
-        $file = $this->createFile($owner, File::VISIBILITY_PRIVATE);
+        $folder = new Folder('DocsPrivate', $owner);
+        $this->em->persist($folder);
+        $file = new File('photo.jpg', 'image/jpeg', 1024, 'test/photo.jpg', $folder, $owner);
+        $this->em->persist($file);
+        $this->em->flush();
         $this->loginAs('sharelink-owner@example.com');
 
         $token = $this->shareLinkCreateToken();

--- a/tests/Web/ShareLinkRevokeWebTest.php
+++ b/tests/Web/ShareLinkRevokeWebTest.php
@@ -164,4 +164,55 @@ final class ShareLinkRevokeWebTest extends WebTestCase
         $this->assertResponseIsSuccessful();
         $this->assertSelectorExists('[data-testid="share-link-row"] img[src*="/thumbnail"]');
     }
+
+    public function testSharesPageShowsThumbnailOfFirstMediaThatActuallyHasOne(): void
+    {
+        // Bug réel : le premier média par position n'a pas toujours de
+        // thumbnail (traitement async pas encore terminé, échec, etc.).
+        // Il faut afficher la vignette du premier média QUI EN A UNE,
+        // pas planter/rien afficher juste parce que le tout premier n'en a pas.
+        $owner = $this->createOwner();
+
+        $folder = new Folder('Photos', $owner);
+        $folder->setVisibility(Folder::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($folder);
+
+        $fileWithoutThumb = new File('sans-vignette.jpg', 'image/jpeg', 1024, 'test/a.jpg', $folder, $owner);
+        $this->em->persist($fileWithoutThumb);
+        $mediaWithoutThumb = new \App\Entity\Media($fileWithoutThumb, 'photo');
+        $this->em->persist($mediaWithoutThumb);
+
+        $fileWithThumb = new File('avec-vignette.jpg', 'image/jpeg', 1024, 'test/b.jpg', $folder, $owner);
+        $this->em->persist($fileWithThumb);
+        $mediaWithThumb = new \App\Entity\Media($fileWithThumb, 'photo');
+        $mediaWithThumb->setThumbnailPath('thumbs/b.thumb.jpg');
+        $this->em->persist($mediaWithThumb);
+
+        $album = new \App\Entity\Album('Vacances', $owner);
+        $album->setVisibility(\App\Entity\Album::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($album);
+        $album->addMedia($mediaWithoutThumb);
+        $album->addMedia($mediaWithThumb);
+        $this->em->flush();
+
+        $link = new ShareLink(
+            $owner,
+            Share::RESOURCE_ALBUM,
+            $album->getId(),
+            bin2hex(random_bytes(16)),
+            hash('sha256', 'valid-plain-token'),
+            new \DateTimeImmutable('+7 days'),
+        );
+        $this->em->persist($link);
+        $this->em->flush();
+
+        $this->loginAs('revoke-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/partages');
+
+        $this->assertResponseIsSuccessful();
+        $img = $crawler->filter('[data-testid="share-link-row"] img[src*="/thumbnail"]');
+        $this->assertGreaterThan(0, $img->count());
+        $this->assertStringContainsString((string) $mediaWithThumb->getId(), $img->attr('src'));
+    }
 }

--- a/tests/Web/ShareLinkRevokeWebTest.php
+++ b/tests/Web/ShareLinkRevokeWebTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Share;
+use App\Entity\ShareLink;
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class ShareLinkRevokeWebTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM share_links');
+        $conn->executeStatement('DELETE FROM shares');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createOwner(string $email = 'revoke-owner@example.com'): User
+    {
+        return $this->createWebUser($email, 'secret123', 'Owner');
+    }
+
+    private function createLink(User $owner): ShareLink
+    {
+        $folder = new Folder('Docs', $owner);
+        $folder->setVisibility(Folder::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($folder);
+        $file = new File('photo.jpg', 'image/jpeg', 1024, 'test/photo.jpg', $folder, $owner);
+        $file->setVisibility(File::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($file);
+        $this->em->flush();
+
+        $link = new ShareLink(
+            $owner,
+            Share::RESOURCE_FILE,
+            $file->getId(),
+            bin2hex(random_bytes(16)),
+            hash('sha256', 'valid-plain-token'),
+            new \DateTimeImmutable('+7 days'),
+        );
+        $this->em->persist($link);
+        $this->em->flush();
+
+        return $link;
+    }
+
+    private function revokeToken(): string
+    {
+        $crawler = $this->client->request('GET', '/partages');
+
+        return $crawler->filter('form[action*="/share-link-revoke"] input[name="_token"]')->first()->attr('value');
+    }
+
+    public function testOwnerCanRevokeTheirLink(): void
+    {
+        $owner = $this->createOwner();
+        $link = $this->createLink($owner);
+        $this->loginAs('revoke-owner@example.com');
+
+        $token = $this->revokeToken();
+
+        $this->client->request('POST', '/share-link-revoke', [
+            '_token'   => $token,
+            'linkId'   => $link->getId()->toRfc4122(),
+        ]);
+
+        $this->assertResponseRedirects('/partages');
+
+        // Le lien renvoie 404 à la requête suivante, révocation effective.
+        $this->client->request('GET', '/logout');
+        $this->client->request('GET', '/p/' . $link->getSelector() . '/valid-plain-token');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testNonOwnerCannotRevokeLink(): void
+    {
+        $owner = $this->createOwner();
+        $link = $this->createLink($owner);
+        $attacker = $this->createWebUser('revoke-attacker@example.com', 'secret123', 'Attacker');
+        // Le token CSRF est lié à la session : l'attaquant doit avoir son
+        // propre lien pour obtenir un token valide dans SA session.
+        $this->createLink($attacker);
+
+        $this->loginAs('revoke-attacker@example.com');
+        $token = $this->revokeToken();
+
+        $this->client->request('POST', '/share-link-revoke', [
+            '_token' => $token,
+            'linkId' => $link->getId()->toRfc4122(),
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testSharesPageListsShareLinksWithExpirationAndRevokeButton(): void
+    {
+        $owner = $this->createOwner();
+        $link = $this->createLink($owner);
+        $this->loginAs('revoke-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/partages');
+
+        $this->assertResponseIsSuccessful();
+        $row = $crawler->filter('[data-testid="share-link-row"]')->text();
+        $this->assertStringContainsString($link->getExpiresAt()->format('d/m/Y'), $row);
+        $this->assertSelectorExists('form[action*="/share-link-revoke"] button[type="submit"]');
+    }
+}

--- a/tests/Web/ShareLinkRevokeWebTest.php
+++ b/tests/Web/ShareLinkRevokeWebTest.php
@@ -126,4 +126,42 @@ final class ShareLinkRevokeWebTest extends WebTestCase
         $this->assertStringContainsString($link->getExpiresAt()->format('d/m/Y'), $row);
         $this->assertSelectorExists('form[action*="/share-link-revoke"] button[type="submit"]');
     }
+
+    public function testSharesPageShowsThumbnailForLinkOnAlbumWithMedia(): void
+    {
+        $owner = $this->createOwner();
+
+        $folder = new Folder('Photos', $owner);
+        $folder->setVisibility(Folder::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($folder);
+        $file = new File('photo.jpg', 'image/jpeg', 1024, 'test/photo.jpg', $folder, $owner);
+        $this->em->persist($file);
+        $media = new \App\Entity\Media($file, 'photo');
+        $media->setThumbnailPath('thumbs/photo.thumb.jpg');
+        $this->em->persist($media);
+
+        $album = new \App\Entity\Album('Vacances', $owner);
+        $album->setVisibility(\App\Entity\Album::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($album);
+        $album->addMedia($media);
+        $this->em->flush();
+
+        $link = new ShareLink(
+            $owner,
+            Share::RESOURCE_ALBUM,
+            $album->getId(),
+            bin2hex(random_bytes(16)),
+            hash('sha256', 'valid-plain-token'),
+            new \DateTimeImmutable('+7 days'),
+        );
+        $this->em->persist($link);
+        $this->em->flush();
+
+        $this->loginAs('revoke-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/partages');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-testid="share-link-row"] img[src*="/thumbnail"]');
+    }
 }

--- a/tests/Web/ShareLinkVisibleOnDashboardWebTest.php
+++ b/tests/Web/ShareLinkVisibleOnDashboardWebTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Reproduit le parcours réel signalé en usage : autoriser le partage par
+ * lien, créer le lien via l'UI (POST /share-link-create, pas une insertion
+ * directe en base), puis vérifier qu'il apparaît sur /partages.
+ */
+final class ShareLinkVisibleOnDashboardWebTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM share_links');
+        $conn->executeStatement('DELETE FROM shares');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createOwner(): User
+    {
+        return $this->createWebUser('dashboard-owner@example.com', 'secret123', 'Owner');
+    }
+
+    public function testLinkCreatedViaUiAppearsOnSharesDashboard(): void
+    {
+        $owner = $this->createOwner();
+        $folder = new Folder('Docs', $owner);
+        $this->em->persist($folder);
+        $file = new File('photo.jpg', 'image/jpeg', 1024, 'test/photo.jpg', $folder, $owner);
+        $this->em->persist($file);
+        $this->em->flush();
+
+        $this->loginAs('dashboard-owner@example.com');
+
+        // Étape 1 — autoriser le partage par lien (private -> link_allowed)
+        $crawler = $this->client->request('GET', '/explorer');
+        $visibilityToken = $crawler->filter('form[action*="/resource-visibility-update"] input[name="_token"]')
+            ->first()->attr('value');
+
+        $this->client->request('POST', '/resource-visibility-update', [
+            '_token'       => $visibilityToken,
+            'resourceType' => 'file',
+            'resourceId'   => $file->getId()->toRfc4122(),
+            'visibility'   => 'link_allowed',
+        ]);
+        $this->assertResponseRedirects();
+        $this->client->followRedirect();
+
+        // Étape 2 — créer le lien via le vrai contrôleur (pas une insertion directe)
+        $crawler = $this->client->request('GET', '/explorer');
+        $linkToken = $crawler->filter('form[action*="/share-link-create"] input[name="_token"]')
+            ->first()->attr('value');
+
+        $this->client->request('POST', '/share-link-create', [
+            '_token'       => $linkToken,
+            'resourceType' => 'file',
+            'resourceId'   => $file->getId()->toRfc4122(),
+        ]);
+        $this->assertResponseRedirects();
+
+        // Étape 3 — vérifier la présence sur le dashboard
+        $crawler = $this->client->request('GET', '/partages');
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-testid="share-link-row"]');
+        $this->assertStringContainsString('photo.jpg', $crawler->filter('[data-testid="share-link-row"]')->text());
+    }
+}

--- a/tests/Web/ShareWebTest.php
+++ b/tests/Web/ShareWebTest.php
@@ -248,4 +248,84 @@ final class ShareWebTest extends WebTestCase
         $this->assertSelectorExists('[data-testid="share-open-btn"]');
         $this->assertSelectorExists('form[action*="/share-create"]');
     }
+
+    // ─── Partage multi-emails (séparés par virgule) ─────────────────────────
+
+    public function testCreateShareWithMultipleValidEmailsSharesWithAll(): void
+    {
+        $owner = $this->createUser();
+        $this->createUser('multi1@example.com');
+        $this->createUser('multi2@example.com');
+        $album = $this->createAlbum($owner);
+
+        $this->login();
+        $token = $this->shareCreateToken($album->getId()->toRfc4122());
+
+        $this->client->request('POST', '/share-create', [
+            '_token'       => $token,
+            'guestEmail'   => 'multi1@example.com, multi2@example.com',
+            'resourceType' => 'album',
+            'resourceId'   => $album->getId()->toRfc4122(),
+            'permission'   => 'read',
+        ]);
+
+        $this->assertResponseRedirects('/albums/' . $album->getId()->toRfc4122());
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('.flash-success', 'multi1@example.com');
+        $this->assertSelectorTextContains('.flash-success', 'multi2@example.com');
+
+        $shares = $this->em->getRepository(Share::class)->findBy(['resourceId' => $album->getId()]);
+        $this->assertCount(2, $shares);
+    }
+
+    public function testCreateShareWithMixOfValidAndUnknownEmailsSharesWithValidAndListsUnknown(): void
+    {
+        $owner = $this->createUser();
+        $this->createUser('valid-multi@example.com');
+        $album = $this->createAlbum($owner);
+
+        $this->login();
+        $token = $this->shareCreateToken($album->getId()->toRfc4122());
+
+        $this->client->request('POST', '/share-create', [
+            '_token'       => $token,
+            'guestEmail'   => 'valid-multi@example.com, inconnu-multi@example.com',
+            'resourceType' => 'album',
+            'resourceId'   => $album->getId()->toRfc4122(),
+            'permission'   => 'read',
+        ]);
+
+        $this->assertResponseRedirects('/albums/' . $album->getId()->toRfc4122());
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('.flash-success', 'valid-multi@example.com');
+        $this->assertSelectorTextContains('.flash-error', 'inconnu-multi@example.com');
+
+        $shares = $this->em->getRepository(Share::class)->findBy(['resourceId' => $album->getId()]);
+        $this->assertCount(1, $shares);
+    }
+
+    public function testCreateShareWithMultipleEmailsIgnoresEmptyEntries(): void
+    {
+        $owner = $this->createUser();
+        $this->createUser('spaced@example.com');
+        $album = $this->createAlbum($owner);
+
+        $this->login();
+        $token = $this->shareCreateToken($album->getId()->toRfc4122());
+
+        $this->client->request('POST', '/share-create', [
+            '_token'       => $token,
+            'guestEmail'   => ' spaced@example.com ,, ',
+            'resourceType' => 'album',
+            'resourceId'   => $album->getId()->toRfc4122(),
+            'permission'   => 'read',
+        ]);
+
+        $this->assertResponseRedirects('/albums/' . $album->getId()->toRfc4122());
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('.flash-success', 'spaced@example.com');
+
+        $shares = $this->em->getRepository(Share::class)->findBy(['resourceId' => $album->getId()]);
+        $this->assertCount(1, $shares);
+    }
 }

--- a/tests/Web/ShareWebTest.php
+++ b/tests/Web/ShareWebTest.php
@@ -126,21 +126,21 @@ final class ShareWebTest extends WebTestCase
         $this->assertStringContainsString($expiresAt->format('d/m/Y'), $row);
     }
 
-    public function testSharesPageListsIncomingShares(): void
+    public function testSharesPageDoesNotShowIncomingSection(): void
     {
-        $owner = $this->createUser('owner-in@example.com');
-        $guest = $this->createUser(); // shares@example.com, celui qui se connecte
-        $file  = $this->createFile($owner, 'partage-entrant.jpg');
-        $share = new Share($owner, $guest, Share::RESOURCE_FILE, $file->getId(), Share::PERMISSION_READ);
-        $this->em->persist($share);
-        $this->em->flush();
-
+        // HomeCloud est mono-owner par instance : il n'y a jamais qu'un seul
+        // compte "full" possible, qui ne peut donc jamais recevoir de partage
+        // d'un autre compte "full" (les invités n'ont pas accès à /partages).
+        // La section "Partagés avec moi" n'a donc aucun sens et est retirée.
+        $this->createUser();
         $this->login();
 
         $crawler = $this->client->request('GET', '/partages');
 
         $this->assertResponseIsSuccessful();
-        $this->assertStringContainsString('partage-entrant.jpg', $crawler->filter('body')->text());
+        $this->assertSelectorNotExists('[data-testid="shares-incoming-list"]');
+        $this->assertSelectorNotExists('[data-testid="shares-incoming-empty"]');
+        $this->assertStringNotContainsString('Partagés avec moi', $crawler->filter('body')->text());
     }
 
     public function testSidebarLinkPointsToSharesPage(): void

--- a/tests/Web/ShareWebTest.php
+++ b/tests/Web/ShareWebTest.php
@@ -196,8 +196,12 @@ final class ShareWebTest extends WebTestCase
         $this->assertSelectorTextContains('.flash-success', 'partagé');
     }
 
-    public function testCreateShareWithUnknownEmailShowsErrorFlash(): void
+    public function testCreateShareWithUnknownEmailCreatesGuestAccountAndShares(): void
     {
+        // Depuis l'introduction de GuestAccountCreator, un email inconnu ne
+        // fait plus échouer le partage : un compte sans mot de passe est créé
+        // et un email d'activation part (intercepté en test, jamais envoyé
+        // réellement — MAILER_DSN=null://null).
         $owner = $this->createUser();
         $album = $this->createAlbum($owner);
 
@@ -206,15 +210,27 @@ final class ShareWebTest extends WebTestCase
 
         $this->client->request('POST', '/share-create', [
             '_token'       => $token,
-            'guestEmail'   => 'inconnu@example.com',
+            'guestEmail'   => 'nouvel-invite@example.com',
             'resourceType' => 'album',
             'resourceId'   => $album->getId()->toRfc4122(),
             'permission'   => 'read',
         ]);
 
         $this->assertResponseRedirects('/albums/' . $album->getId()->toRfc4122());
+        // Vérifié AVANT followRedirect() : la seconde requête HTTP déclenchée
+        // par followRedirect() réinitialise le collecteur d'événements mailer.
+        self::assertEmailCount(1);
+
         $this->client->followRedirect();
-        $this->assertSelectorTextContains('.flash-error', 'Aucun compte HomeCloud');
+        $this->assertSelectorTextContains('.flash-success', 'nouvel-invite@example.com');
+
+        $guest = $this->em->getRepository(User::class)->findOneBy(['email' => 'nouvel-invite@example.com']);
+        $this->assertNotNull($guest, 'Le compte invité doit avoir été créé');
+        $this->assertSame('', $guest->getPassword(), 'Le compte invité ne doit pas avoir de mot de passe utilisable');
+
+        $share = $this->em->getRepository(Share::class)->findOneBy(['resourceId' => $album->getId()]);
+        $this->assertNotNull($share);
+        $this->assertTrue($share->getGuest()->getId()->equals($guest->getId()));
     }
 
     public function testCreateShareWithoutCsrfTokenReturns403(): void
@@ -278,8 +294,10 @@ final class ShareWebTest extends WebTestCase
         $this->assertCount(2, $shares);
     }
 
-    public function testCreateShareWithMixOfValidAndUnknownEmailsSharesWithValidAndListsUnknown(): void
+    public function testCreateShareWithMixOfExistingAndUnknownEmailsSharesWithBoth(): void
     {
+        // Un email inconnu crée désormais un compte invité (GuestAccountCreator)
+        // au lieu d'échouer : les deux emails de la liste reçoivent un Share.
         $owner = $this->createUser();
         $this->createUser('valid-multi@example.com');
         $album = $this->createAlbum($owner);
@@ -298,10 +316,10 @@ final class ShareWebTest extends WebTestCase
         $this->assertResponseRedirects('/albums/' . $album->getId()->toRfc4122());
         $this->client->followRedirect();
         $this->assertSelectorTextContains('.flash-success', 'valid-multi@example.com');
-        $this->assertSelectorTextContains('.flash-error', 'inconnu-multi@example.com');
+        $this->assertSelectorTextContains('.flash-success', 'inconnu-multi@example.com');
 
         $shares = $this->em->getRepository(Share::class)->findBy(['resourceId' => $album->getId()]);
-        $this->assertCount(1, $shares);
+        $this->assertCount(2, $shares);
     }
 
     public function testCreateShareWithMultipleEmailsIgnoresEmptyEntries(): void
@@ -327,5 +345,32 @@ final class ShareWebTest extends WebTestCase
 
         $shares = $this->em->getRepository(Share::class)->findBy(['resourceId' => $album->getId()]);
         $this->assertCount(1, $shares);
+    }
+
+    public function testCreateShareWithMalformedEmailShowsErrorAndDoesNotCreateAccount(): void
+    {
+        // Une chaîne sans @ ne doit jamais atteindre GuestAccountCreator :
+        // ça créerait un compte avec un email invalide.
+        $owner = $this->createUser();
+        $album = $this->createAlbum($owner);
+
+        $this->login();
+        $token = $this->shareCreateToken($album->getId()->toRfc4122());
+
+        $this->client->request('POST', '/share-create', [
+            '_token'       => $token,
+            'guestEmail'   => 'ronan.lenouvel',
+            'resourceType' => 'album',
+            'resourceId'   => $album->getId()->toRfc4122(),
+            'permission'   => 'read',
+        ]);
+
+        $this->assertResponseRedirects('/albums/' . $album->getId()->toRfc4122());
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('.flash-error', 'ronan.lenouvel');
+
+        $this->assertNull($this->em->getRepository(User::class)->findOneBy(['email' => 'ronan.lenouvel']));
+        $shares = $this->em->getRepository(Share::class)->findBy(['resourceId' => $album->getId()]);
+        $this->assertCount(0, $shares);
     }
 }


### PR DESCRIPTION
## Résumé

Chantier complet du partage par lien public (sans compte), construit en TDD strict à partir de `feat-partage.md`, plus le sous-chantier de gestion des comptes invités qui en a découlé.

### Partage par lien public
- Verrou `visibility` (`private` par défaut) sur `File`/`Folder`/`Album` : opt-in explicite avant tout partage par lien
- `ShareLink` : entité dédiée (selector + hash de token, jamais le secret en clair), expiration obligatoire à la création (1j/7j/30j/permanent, choix explicite de l'owner)
- Route publique `/p/{selector}/{token}` : consultation, téléchargement, visionneuse (grille + lightbox) pour un album, sans compte ni session
- `VisibilityChecker` : règle OU sur la remontée des dossiers parents (partager un fichier isolé ne dépend jamais de son dossier ; partager un dossier rend accessible tout son contenu, dynamiquement)
- `SharedFileScopeChecker` : empêche qu'un porteur de lien pivote vers une autre ressource de l'owner
- Bascule `private ↔ link_allowed` depuis `ShareModal`, bouton d'arrêt d'urgence (révocation en cascade des liens actifs)
- Nettoyage (`SharedResourceCleaner`) branché aux 6 points de suppression réels

### Gestion des invités
- Partage entre comptes avec plusieurs emails séparés par virgule
- Création automatique d'un compte invité (sans mot de passe utilisable) si l'email est inconnu, email d'activation réutilisant le mécanisme `ResetPasswordRequest` existant
- Statut permanent `accountType` (full/guest) distinct de l'état transitoire "mot de passe non défini"
- Page CRUD `/invites` (créer/éditer/supprimer), restriction fonctionnelle (un invité ne peut jamais uploader ni créer de contenu)

### Fixes découverts en usage réel
- CSP bloquait tout le JS (`data:` manquant sur `script-src`)
- CASCADE manquant sur `ResetPasswordRequest` → 500 à la suppression d'un invité en attente d'activation
- Redirection post-bascule dépendant de `Referer`, jamais envoyé (`Referrer-Policy: no-referrer`)
- Vignette manquante sur `/partages` pour un album partiellement traité (thumbnails async)
- 8 contrôleurs rangés dans `Api/`/`Web/` (aucun fichier à la racine de `src/Controller/`)

## Test plan
- [x] 658 tests, tous verts (`./vendor/bin/phpunit`)
- [x] Vérifié en navigateur réel : création de lien, consultation sans compte, révocation, bascule de visibilité, création/suppression d'invité
- [x] Diff relu intégralement, aucun secret commité

🤖 Generated with [Claude Code](https://claude.com/claude-code)