### PR TITLE
Couverture explicite d'album

### DIFF
--- a/.github/avancement.md
+++ b/.github/avancement.md
@@ -1,8 +1,21 @@
 # 📋 Avancement — HomeCloud API
 
-> Dernière mise à jour : 2026-07-12
+> Dernière mise à jour : 2026-07-15
 
-> **Status git :** branche `feat/gallery-sort` — 383 tests ✅
+> **Status git :** branche `feat/album-explicit-cover` — 677 tests ✅
+
+---
+
+## ✨ Couverture explicite d'album (2026-07-15)
+
+Après le merge de la fonctionnalité de partage par lien public (PR #216), ajout du choix explicite de la vignette de couverture d'un album — jusqu'ici uniquement un fallback automatique (premier média avec thumbnail).
+
+- `Album::coverMedia` (ManyToOne nullable vers `Media`, `ON DELETE SET NULL`) — migration `Version20260715110348`
+- `Album::setCoverMedia()` valide que le média appartient à l'album (`InvalidArgumentException` sinon) ; `removeMedia()` réinitialise la couverture si le média retiré était la couverture actuelle
+- `Album::resolveCoverMedia()` centralise la logique d'affichage : couverture explicite si elle a un thumbnail, sinon fallback sur le premier média par position qui en a un — réutilisable partout où une vignette d'album est nécessaire
+- Route `POST /albums/{id}/set-cover` (CSRF + `AlbumVoter::VIEW`, 400 si le média n'appartient pas à l'album), suit le pattern des routes POST dédiées déjà en place (`reorder`, `remove-media`)
+- Bouton "définir comme couverture" sur chaque vignette de `album_detail.html.twig` (masqué si déjà couverture) + badge visuel sur la couverture actuelle — design du badge volontairement minimal pour l'instant, à retravailler
+- Cartes de `/albums` affichent désormais une vraie vignette (`resolveCoverMedia()`) au lieu de systématiquement l'icône générique
 
 ---
 

--- a/assets/styles/albums.css
+++ b/assets/styles/albums.css
@@ -17,3 +17,11 @@
   text-decoration: none;
   cursor: pointer;
 }
+
+.hc-album-card-thumb {
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  display: block;
+}

--- a/migrations/Version20260715110348.php
+++ b/migrations/Version20260715110348.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260715110348 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Ajoute cover_media_id sur albums — couverture explicite choisie par l\'utilisateur.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE albums ADD cover_media_id BINARY(16) DEFAULT NULL');
+        $this->addSql(<<<'SQL'
+            ALTER TABLE
+              albums
+            ADD
+              CONSTRAINT FK_F4E2474F329A1B2E FOREIGN KEY (cover_media_id) REFERENCES medias (id) ON DELETE
+            SET
+              NULL
+        SQL);
+        $this->addSql('CREATE INDEX IDX_F4E2474F329A1B2E ON albums (cover_media_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE albums DROP FOREIGN KEY FK_F4E2474F329A1B2E');
+        $this->addSql('DROP INDEX IDX_F4E2474F329A1B2E ON albums');
+        $this->addSql('ALTER TABLE albums DROP cover_media_id');
+    }
+}

--- a/src/Controller/Web/AlbumWebController.php
+++ b/src/Controller/Web/AlbumWebController.php
@@ -107,6 +107,30 @@ final class AlbumWebController extends AbstractController
         return $this->redirectToRoute('app_album_detail', ['id' => $album->getId()->toRfc4122()]);
     }
 
+    #[Route('/albums/{id}/set-cover', name: 'app_album_set_cover', methods: ['POST'], requirements: ['id' => '[0-9a-f\-]+'])]
+    public function setCover(string $id, Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('album-set-cover', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Jeton CSRF invalide.');
+        }
+
+        $album = $this->albumRepository->findById(Uuid::fromString($id))
+            ?? throw $this->createNotFoundException('Album introuvable.');
+
+        $this->denyAccessUnlessGranted(AlbumVoter::VIEW, $album);
+
+        $media = $this->mediaRepository->findById(Uuid::fromString((string) $request->request->get('mediaId', '')))
+            ?? throw $this->createNotFoundException('Média introuvable.');
+
+        try {
+            $this->albumService->setCoverMedia($album, $media);
+        } catch (\InvalidArgumentException $e) {
+            throw new BadRequestHttpException($e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_album_detail', ['id' => $album->getId()->toRfc4122()]);
+    }
+
     #[Route('/albums/{id}/reorder', name: 'app_album_reorder', methods: ['POST'], requirements: ['id' => '[0-9a-f\-]+'])]
     public function reorder(string $id, Request $request): Response
     {

--- a/src/Entity/Album.php
+++ b/src/Entity/Album.php
@@ -58,6 +58,10 @@ class Album
     #[ORM\Column(type: 'string', length: 12, options: ['default' => self::VISIBILITY_PRIVATE])]
     private string $visibility = self::VISIBILITY_PRIVATE;
 
+    #[ORM\ManyToOne(targetEntity: Media::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?Media $coverMedia = null;
+
     public function __construct(string $name, User $owner)
     {
         $trimmed = trim($name);
@@ -131,6 +135,48 @@ class Album
         if ($albumMedia !== null) {
             $this->albumMedias->removeElement($albumMedia);
         }
+
+        if ($this->coverMedia === $media) {
+            $this->coverMedia = null;
+        }
+    }
+
+    public function getCoverMedia(): ?Media
+    {
+        return $this->coverMedia;
+    }
+
+    /**
+     * @throws \InvalidArgumentException si le média ne fait pas partie de l'album.
+     */
+    public function setCoverMedia(Media $media): void
+    {
+        if ($this->findAlbumMedia($media) === null) {
+            throw new \InvalidArgumentException('Ce média ne fait pas partie de l\'album.');
+        }
+
+        $this->coverMedia = $media;
+    }
+
+    /**
+     * Couverture effective à afficher : la couverture explicite si définie
+     * (et pourvue d'un thumbnail), sinon le premier média par position ayant
+     * un thumbnail — cf. le premier média n'a pas toujours de thumbnail
+     * (traitement async pas terminé, échec de génération...).
+     */
+    public function resolveCoverMedia(): ?Media
+    {
+        if ($this->coverMedia !== null && $this->coverMedia->getThumbnailPath() !== null) {
+            return $this->coverMedia;
+        }
+
+        foreach ($this->getMedias() as $media) {
+            if ($media->getThumbnailPath() !== null) {
+                return $media;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Service/AlbumService.php
+++ b/src/Service/AlbumService.php
@@ -99,6 +99,17 @@ final class AlbumService implements AlbumServiceInterface
     }
 
     /**
+     * Définit le média servant de couverture (vignette) pour l'album.
+     *
+     * @throws \InvalidArgumentException si le média ne fait pas partie de l'album.
+     */
+    public function setCoverMedia(Album $album, Media $media): void
+    {
+        $album->setCoverMedia($media);
+        $this->repository->save($album);
+    }
+
+    /**
      * Supprime un album (et ses associations album_media — pas les médias eux-mêmes).
      */
     public function delete(Album $album): void

--- a/templates/components/MediaThumbActions.html.twig
+++ b/templates/components/MediaThumbActions.html.twig
@@ -1,8 +1,10 @@
-{# Actions flottantes sur une vignette média (visibles au survol) : renommer
-   et retirer. Réutilisé par gallery.html.twig et album_detail.html.twig.
-   Props attendues : media, renameUrl, removeUrl (null pour masquer le
-   bouton de retrait — ex. dans la galerie, "retirer" n'a pas de sens hors
-   contexte d'un album). La suppression définitive se fait désormais via la
+{# Actions flottantes sur une vignette média (visibles au survol) : renommer,
+   définir comme couverture et retirer. Réutilisé par gallery.html.twig et
+   album_detail.html.twig. Props attendues : media, renameUrl, removeUrl
+   (null pour masquer le bouton de retrait — ex. dans la galerie, "retirer"
+   n'a pas de sens hors contexte d'un album), setCoverUrl (null hors contexte
+   d'un album), isCover (booléen, masque le bouton si le média est déjà la
+   couverture actuelle). La suppression définitive se fait désormais via la
    sélection multiple (case à cocher + barre "Supprimer la sélection"), pas
    par vignette — voir gallery_selection_controller.js. Le renommage se fait
    en place (fetch), sans navigation — voir rename_media_controller.js. Le
@@ -15,6 +17,18 @@
           title="Renommer" aria-label="Renommer">
     <svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
   </button>
+
+  {% if setCoverUrl is defined and setCoverUrl and not isCover %}
+    <form method="post" action="{{ setCoverUrl }}" class="hc-media-thumb-action-form-cover">
+      <input type="hidden" name="_token" value="{{ csrf_token('album-set-cover') }}">
+      <input type="hidden" name="mediaId" value="{{ media.id }}">
+      <button type="submit" class="hc-media-thumb-action hc-media-thumb-action--cover"
+              data-testid="set-album-cover" title="Définir comme couverture" aria-label="Définir comme couverture"
+              draggable="true" data-action="dragstart->album-reorder#preventDrag">
+        <svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 17.75l-6.16 3.24 1.18-6.88L2 9.24l6.92-1L12 2l3.08 6.24 6.92 1-5.02 4.87 1.18 6.88z"/></svg>
+      </button>
+    </form>
+  {% endif %}
 
   {% if removeUrl is defined and removeUrl %}
     <form method="post" action="{{ removeUrl }}"

--- a/templates/web/album_detail.html.twig
+++ b/templates/web/album_detail.html.twig
@@ -86,7 +86,14 @@
           <twig:MediaThumbActions
             :media="media"
             removeUrl="{{ path('app_album_remove_media', {id: album.id, mediaId: media.id}) }}"
+            setCoverUrl="{{ path('app_album_set_cover', {id: album.id}) }}"
+            isCover="{{ album.coverMedia and album.coverMedia.id == media.id }}"
           />
+          {% if album.coverMedia and album.coverMedia.id == media.id %}
+            <span class="hc-media-thumb-cover-badge" data-testid="album-cover-badge" data-media-id="{{ media.id }}" title="Couverture de l'album">
+              <svg width="13" height="13" fill="currentColor" viewBox="0 0 24 24"><path d="M12 17.75l-6.16 3.24 1.18-6.88L2 9.24l6.92-1L12 2l3.08 6.24 6.92 1-5.02 4.87 1.18 6.88z"/></svg>
+            </span>
+          {% endif %}
           <a href="{{ path('app_media_view', {id: media.id}) }}"
              data-lightbox
              data-media-type="{{ media.mediaType }}"

--- a/templates/web/albums.html.twig
+++ b/templates/web/albums.html.twig
@@ -37,8 +37,16 @@
   {% else %}
     <div class="hc-album-grid">
       {% for album in albums %}
+        {% set coverMedia = album.resolveCoverMedia() %}
         <a href="{{ path('app_album_detail', {id: album.id}) }}" data-testid="album-card" class="hc-item-card hc-album-card">
-          <div class="hc-item-icon hc-item-icon--folder mb-2">{{ icons.icon('album', 16) }}</div>
+          {% if coverMedia %}
+            <img src="{{ path('app_media_thumbnail', {id: coverMedia.id}) }}"
+                 alt="" loading="lazy"
+                 class="hc-album-card-thumb mb-2"
+                 data-testid="album-card-thumbnail">
+          {% else %}
+            <div class="hc-item-icon hc-item-icon--folder mb-2">{{ icons.icon('album', 16) }}</div>
+          {% endif %}
           <div class="hc-item-name">{{ album.name }}</div>
           <div class="hc-item-meta">
             {{ album.medias|length }} média{{ album.medias|length != 1 ? 's' : '' }}

--- a/tests/Entity/AlbumCoverTest.php
+++ b/tests/Entity/AlbumCoverTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Media;
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires — couverture explicite d'un album (Album::coverMedia).
+ * TDD RED → GREEN.
+ */
+final class AlbumCoverTest extends TestCase
+{
+    private function makeMedia(User $owner, string $name): Media
+    {
+        $folder = new Folder('Photos', $owner);
+        $file   = new File($name, 'image/jpeg', 1024, '2026/' . $name, $folder, $owner);
+
+        return new Media($file, 'photo');
+    }
+
+    public function testAlbumHasNoCoverByDefault(): void
+    {
+        $owner = new User('test@example.com', 'Test');
+        $album = new Album('Vacances', $owner);
+
+        $this->assertNull($album->getCoverMedia());
+    }
+
+    public function testSetCoverMediaAssignsCoverWhenMediaBelongsToAlbum(): void
+    {
+        $owner = new User('test@example.com', 'Test');
+        $album = new Album('Vacances', $owner);
+        $media = $this->makeMedia($owner, 'a.jpg');
+        $album->addMedia($media);
+
+        $album->setCoverMedia($media);
+
+        $this->assertSame($media, $album->getCoverMedia());
+    }
+
+    public function testSetCoverMediaRejectsMediaNotInAlbum(): void
+    {
+        $owner = new User('test@example.com', 'Test');
+        $album = new Album('Vacances', $owner);
+        $foreignMedia = $this->makeMedia($owner, 'foreign.jpg');
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $album->setCoverMedia($foreignMedia);
+    }
+
+    public function testRemovingCoverMediaFromAlbumResetsCover(): void
+    {
+        $owner = new User('test@example.com', 'Test');
+        $album = new Album('Vacances', $owner);
+        $media = $this->makeMedia($owner, 'a.jpg');
+        $album->addMedia($media);
+        $album->setCoverMedia($media);
+
+        $album->removeMedia($media);
+
+        $this->assertNull($album->getCoverMedia());
+    }
+
+    public function testRemovingOtherMediaDoesNotResetCover(): void
+    {
+        $owner = new User('test@example.com', 'Test');
+        $album = new Album('Vacances', $owner);
+        $m1 = $this->makeMedia($owner, 'a.jpg');
+        $m2 = $this->makeMedia($owner, 'b.jpg');
+        $album->addMedia($m1);
+        $album->addMedia($m2);
+        $album->setCoverMedia($m1);
+
+        $album->removeMedia($m2);
+
+        $this->assertSame($m1, $album->getCoverMedia());
+    }
+
+    // --- resolveCoverMedia() ---
+
+    public function testResolveCoverMediaReturnsNullForEmptyAlbum(): void
+    {
+        $owner = new User('test@example.com', 'Test');
+        $album = new Album('Vacances', $owner);
+
+        $this->assertNull($album->resolveCoverMedia());
+    }
+
+    public function testResolveCoverMediaReturnsExplicitCoverWhenSet(): void
+    {
+        $owner = new User('test@example.com', 'Test');
+        $album = new Album('Vacances', $owner);
+        $m1 = $this->makeMedia($owner, 'a.jpg');
+        $m1->setThumbnailPath('thumbs/a.jpg');
+        $m2 = $this->makeMedia($owner, 'b.jpg');
+        $m2->setThumbnailPath('thumbs/b.jpg');
+        $album->addMedia($m1);
+        $album->addMedia($m2);
+        $album->setCoverMedia($m2);
+
+        $this->assertSame($m2, $album->resolveCoverMedia());
+    }
+
+    public function testResolveCoverMediaFallsBackToFirstMediaWithThumbnailWhenNoCoverSet(): void
+    {
+        $owner = new User('test@example.com', 'Test');
+        $album = new Album('Vacances', $owner);
+        $withoutThumb = $this->makeMedia($owner, 'a.jpg');
+        $withThumb = $this->makeMedia($owner, 'b.jpg');
+        $withThumb->setThumbnailPath('thumbs/b.jpg');
+        $album->addMedia($withoutThumb);
+        $album->addMedia($withThumb);
+
+        $this->assertSame($withThumb, $album->resolveCoverMedia());
+    }
+
+    public function testResolveCoverMediaReturnsNullWhenNoMediaHasThumbnail(): void
+    {
+        $owner = new User('test@example.com', 'Test');
+        $album = new Album('Vacances', $owner);
+        $media = $this->makeMedia($owner, 'a.jpg');
+        $album->addMedia($media);
+
+        $this->assertNull($album->resolveCoverMedia());
+    }
+}

--- a/tests/Service/AlbumServiceTest.php
+++ b/tests/Service/AlbumServiceTest.php
@@ -185,6 +185,38 @@ final class AlbumServiceTest extends TestCase
         $this->service->create('Vacances', $guest);
     }
 
+    // --- setCoverMedia() ---
+
+    public function testSetCoverMediaSetsCoverAndSaves(): void
+    {
+        $user  = $this->makeUser();
+        $album = new Album('Vacances', $user);
+        $media = $this->makeMedia($user);
+        $album->addMedia($media);
+
+        $this->repository
+            ->expects($this->once())
+            ->method('save')
+            ->with($album);
+
+        $this->service->setCoverMedia($album, $media);
+
+        $this->assertSame($media, $album->getCoverMedia());
+    }
+
+    public function testSetCoverMediaThrowsWhenMediaNotInAlbum(): void
+    {
+        $user         = $this->makeUser();
+        $album        = new Album('Vacances', $user);
+        $foreignMedia = $this->makeMedia($user);
+
+        $this->repository->expects($this->never())->method('save');
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->service->setCoverMedia($album, $foreignMedia);
+    }
+
     // --- delete() ---
 
     public function testDeleteCallsRepositoryRemove(): void

--- a/tests/Web/AlbumListCoverThumbnailWebTest.php
+++ b/tests/Web/AlbumListCoverThumbnailWebTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\Album;
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Tests fonctionnels — vignette de couverture sur les cartes de /albums.
+ * TDD RED → GREEN.
+ */
+final class AlbumListCoverThumbnailWebTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM album_media');
+        $conn->executeStatement('DELETE FROM albums');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createUser(string $email = 'cover-list@example.com'): User
+    {
+        return $this->createWebUser($email, 'secret123', 'Cover List User');
+    }
+
+    private function createAlbum(User $user, string $name = 'Mon Album'): Album
+    {
+        $album = new Album($name, $user);
+        $this->em->persist($album);
+        $this->em->flush();
+
+        return $album;
+    }
+
+    private function createMedia(User $user, string $name = 'photo.jpg'): \App\Entity\Media
+    {
+        return $this->createMediaFile($user, $name, 'photo');
+    }
+
+    public function testAlbumCardShowsCoverThumbnailWhenAlbumHasMediaWithThumbnail(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $media = $this->createMedia($user, 'photo.jpg');
+        $media->setThumbnailPath('thumbs/photo.jpg');
+        $album->addMedia($media);
+        $this->em->flush();
+        $this->loginAs('cover-list@example.com');
+
+        $crawler = $this->client->request('GET', '/albums');
+
+        $this->assertResponseIsSuccessful();
+        $img = $crawler->filter('[data-testid="album-card-thumbnail"]');
+        $this->assertGreaterThan(0, $img->count());
+        $this->assertStringContainsString((string) $media->getId(), $img->attr('src'));
+    }
+
+    public function testAlbumCardShowsGenericIconWhenAlbumHasNoMediaWithThumbnail(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $media = $this->createMedia($user, 'photo.jpg');
+        $media->setThumbnailPath(null);
+        $album->addMedia($media);
+        $this->em->flush();
+        $this->loginAs('cover-list@example.com');
+
+        $crawler = $this->client->request('GET', '/albums');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(0, $crawler->filter('[data-testid="album-card-thumbnail"]')->count());
+    }
+
+    public function testAlbumCardShowsExplicitCoverOverFirstMediaWithThumbnail(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $m1 = $this->createMedia($user, 'a.jpg');
+        $m1->setThumbnailPath('thumbs/a.jpg');
+        $m2 = $this->createMedia($user, 'b.jpg');
+        $m2->setThumbnailPath('thumbs/b.jpg');
+        $album->addMedia($m1);
+        $album->addMedia($m2);
+        $album->setCoverMedia($m2);
+        $this->em->flush();
+        $this->loginAs('cover-list@example.com');
+
+        $crawler = $this->client->request('GET', '/albums');
+
+        $img = $crawler->filter('[data-testid="album-card-thumbnail"]');
+        $this->assertStringContainsString((string) $m2->getId(), $img->attr('src'));
+    }
+}

--- a/tests/Web/AlbumSetCoverWebTest.php
+++ b/tests/Web/AlbumSetCoverWebTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\Album;
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Tests fonctionnels — choix explicite de la couverture d'un album.
+ * TDD RED → GREEN.
+ */
+final class AlbumSetCoverWebTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM album_media');
+        $conn->executeStatement('DELETE FROM albums');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createUser(string $email = 'cover@example.com'): User
+    {
+        return $this->createWebUser($email, 'secret123', 'Cover User');
+    }
+
+    private function createAlbum(User $user, string $name = 'Mon Album'): Album
+    {
+        $album = new Album($name, $user);
+        $this->em->persist($album);
+        $this->em->flush();
+
+        return $album;
+    }
+
+    private function createMedia(User $user, string $name = 'photo.jpg'): \App\Entity\Media
+    {
+        return $this->createMediaFile($user, $name, 'photo');
+    }
+
+    private function setCoverToken(string $albumId): string
+    {
+        $crawler = $this->client->request('GET', '/albums/' . $albumId);
+
+        return $crawler->filter('form[action*="/set-cover"] input[name="_token"]')->first()->attr('value');
+    }
+
+    public function testSetCoverRedirectsToAlbumDetail(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $media = $this->createMedia($user, 'photo.jpg');
+        $album->addMedia($media);
+        $this->em->flush();
+        $this->loginAs('cover@example.com');
+        $token = $this->setCoverToken($album->getId()->toRfc4122());
+
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/set-cover', [
+            '_token'  => $token,
+            'mediaId' => $media->getId()->toRfc4122(),
+        ]);
+
+        $this->assertResponseRedirects('/albums/' . $album->getId()->toRfc4122());
+    }
+
+    public function testSetCoverMarksSelectedMediaAsCoverOnNextPageLoad(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $media = $this->createMedia($user, 'photo.jpg');
+        $album->addMedia($media);
+        $this->em->flush();
+        $this->loginAs('cover@example.com');
+        $token = $this->setCoverToken($album->getId()->toRfc4122());
+
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/set-cover', [
+            '_token'  => $token,
+            'mediaId' => $media->getId()->toRfc4122(),
+        ]);
+
+        $crawler = $this->client->request('GET', '/albums/' . $album->getId()->toRfc4122());
+        $this->assertSelectorExists('[data-testid="album-cover-badge"][data-media-id="' . $media->getId()->toRfc4122() . '"]');
+    }
+
+    public function testSetCoverWithoutCsrfTokenThrows403(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $media = $this->createMedia($user, 'photo.jpg');
+        $album->addMedia($media);
+        $this->em->flush();
+        $this->loginAs('cover@example.com');
+
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/set-cover', [
+            'mediaId' => $media->getId()->toRfc4122(),
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testSetCoverForbiddenForOtherUser(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob   = $this->createUser('bob@example.com');
+        $album = $this->createAlbum($alice, 'Album Alice');
+        $media = $this->createMedia($alice, 'photo.jpg');
+        $album->addMedia($media);
+        $this->em->flush();
+        $bobAlbum = $this->createAlbum($bob, 'Album Bob');
+        $bobMedia = $this->createMedia($bob, 'bob.jpg');
+        $bobAlbum->addMedia($bobMedia);
+        $this->em->flush();
+
+        $this->loginAs('bob@example.com');
+        $token = $this->setCoverToken($bobAlbum->getId()->toRfc4122());
+
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/set-cover', [
+            '_token'  => $token,
+            'mediaId' => $media->getId()->toRfc4122(),
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testSetCoverWithMediaNotInAlbumReturns400(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $inAlbumMedia = $this->createMedia($user, 'in-album.jpg');
+        $album->addMedia($inAlbumMedia);
+        $foreignMedia = $this->createMedia($user, 'foreign.jpg');
+        $this->em->flush();
+        $this->loginAs('cover@example.com');
+        $token = $this->setCoverToken($album->getId()->toRfc4122());
+
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/set-cover', [
+            '_token'  => $token,
+            'mediaId' => $foreignMedia->getId()->toRfc4122(),
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+}


### PR DESCRIPTION
## Summary
- Ajoute `Album::coverMedia` (nullable, FK `medias`, `ON DELETE SET NULL`) permettant de choisir explicitement la vignette de couverture d'un album, avec fallback automatique sur le premier média ayant un thumbnail si aucune couverture n'est définie (`Album::resolveCoverMedia()`).
- Nouvelle route `POST /albums/{id}/set-cover` (CSRF + `AlbumVoter::VIEW`, 400 si le média ne fait pas partie de l'album), et bouton dédié sur chaque vignette de `album_detail.html.twig`.
- Les cartes de `/albums` affichent désormais une vraie vignette de couverture au lieu de l'icône générique systématique.

## Test plan
- [x] `./vendor/bin/phpunit` — 677 tests, 0 échec
- [x] Migration appliquée en dev et en environnement de test
- [ ] Vérification visuelle manuelle sur `/albums` et `/albums/{id}` (bouton "définir comme couverture", badge, vignette de liste)

🤖 Generated with [Claude Code](https://claude.com/claude-code)