### PR TITLE
Badge de couverture d'album — design cohérent

### DIFF
--- a/assets/styles/gallery.css
+++ b/assets/styles/gallery.css
@@ -171,6 +171,27 @@
   text-overflow: ellipsis;
 }
 
+/* ── Badge de couverture d'album (haut-gauche, seule zone encore libre :
+   les actions flottantes occupent le haut-droite, le badge d'appartenance
+   le bas-droite au-dessus de la légende) ── */
+.hc-media-thumb-cover-badge {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--hc-accent);
+  backdrop-filter: blur(2px);
+  color: #fff;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
 /* ── Sélection multiple (toujours visible, pour ajout à un album) ── */
 .hc-media-thumb-select {
   position: absolute;

--- a/templates/web/album_detail.html.twig
+++ b/templates/web/album_detail.html.twig
@@ -91,7 +91,8 @@
           />
           {% if album.coverMedia and album.coverMedia.id == media.id %}
             <span class="hc-media-thumb-cover-badge" data-testid="album-cover-badge" data-media-id="{{ media.id }}" title="Couverture de l'album">
-              <svg width="13" height="13" fill="currentColor" viewBox="0 0 24 24"><path d="M12 17.75l-6.16 3.24 1.18-6.88L2 9.24l6.92-1L12 2l3.08 6.24 6.92 1-5.02 4.87 1.18 6.88z"/></svg>
+              <svg width="11" height="11" fill="currentColor" viewBox="0 0 24 24"><path d="M12 17.75l-6.16 3.24 1.18-6.88L2 9.24l6.92-1L12 2l3.08 6.24 6.92 1-5.02 4.87 1.18 6.88z"/></svg>
+              Couverture
             </span>
           {% endif %}
           <a href="{{ path('app_media_view', {id: media.id}) }}"


### PR DESCRIPTION
## Summary
- Le badge "couverture" (ajouté dans #217) utilisait un span sans style dédié, rendu comme une icône brute sur fond noir opaque mal intégrée à la vignette.
- Remplacé par une pilule (fond `--hc-accent`, libellé "Couverture") reprenant le même langage visuel que `.hc-media-thumb-badge` (badge d'appartenance à un album) déjà en place, positionnée en haut-gauche pour ne pas entrer en collision avec les actions flottantes ni le badge existant.

## Test plan
- [x] `./vendor/bin/phpunit` — 677 tests, 0 échec
- [x] Rendu HTML vérifié via test fonctionnel (classe CSS correcte, cache Twig régénéré)
- [ ] Vérification visuelle manuelle dans le navigateur

🤖 Generated with [Claude Code](https://claude.com/claude-code)