### PR TITLE
Respecter le thème système par défaut

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -10,7 +10,8 @@
         {% block stylesheets %}{% endblock %}
         <script>
             (function () {
-                var t = localStorage.getItem('hc-theme') || 'light';
+                var stored = localStorage.getItem('hc-theme');
+                var t = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
                 document.documentElement.setAttribute('data-theme', t);
             })();
         </script>


### PR DESCRIPTION
## Summary
- Au premier chargement (localStorage vide), le thème était forcé à `light` au lieu de suivre `prefers-color-scheme`, alors que la page de partage public respecte déjà cette préférence.
- Un choix déjà stocké dans `localStorage` (bascule manuelle via le toggle) reste prioritaire — seul le tout premier chargement, sans choix explicite, suit désormais le thème système.

## Test plan
- [x] `./vendor/bin/phpunit` — 677 tests, 0 échec (comportement JS inline, non couvert par la suite PHP)
- [ ] Vérification manuelle : device en dark mode + localStorage vide → thème sombre au premier chargement ; toggle manuel toujours respecté ensuite

🤖 Generated with [Claude Code](https://claude.com/claude-code)