### PR TITLE
Sélection directe d'un invité existant dans ShareModal

### DIFF
--- a/assets/controllers/share_guest_picker_controller.js
+++ b/assets/controllers/share_guest_picker_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from '@hotwired/stimulus';
+
+/* Sélection directe d'un invité déjà créé dans ShareModal : ajoute son email
+ * au champ texte existant (qui accepte déjà une liste séparée par virgules
+ * côté serveur), sans le dupliquer si déjà présent. */
+export default class extends Controller {
+    static targets = ['input'];
+
+    add(event) {
+        const email = event.currentTarget.dataset.guestEmail;
+        const current = this.inputTarget.value
+            .split(',')
+            .map((e) => e.trim())
+            .filter((e) => e !== '');
+
+        if (current.includes(email)) return;
+
+        current.push(email);
+        this.inputTarget.value = current.join(', ');
+    }
+}

--- a/src/Twig/GuestGlobalsExtension.php
+++ b/src/Twig/GuestGlobalsExtension.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig;
+
+use App\Entity\User;
+use App\Interface\UserRepositoryInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\GlobalsInterface;
+
+/**
+ * Injecte `userGuests` dans tous les templates Twig pour l'utilisateur
+ * connecté. Utilisé par ShareModal pour proposer la sélection directe d'un
+ * invité déjà créé, sans ressaisir son email — même pattern que
+ * FolderGlobalsExtension (userFolders).
+ */
+final class GuestGlobalsExtension extends AbstractExtension implements GlobalsInterface
+{
+    public function __construct(
+        private readonly UserRepositoryInterface $userRepository,
+        private readonly Security $security,
+    ) {}
+
+    public function getGlobals(): array
+    {
+        $user = $this->security->getUser();
+
+        if (!$user instanceof User) {
+            return ['userGuests' => []];
+        }
+
+        return [
+            'userGuests' => $this->userRepository->findBy(
+                ['accountType' => User::ACCOUNT_TYPE_GUEST],
+                ['displayName' => 'ASC']
+            ),
+        ];
+    }
+}

--- a/templates/components/ShareModal.html.twig
+++ b/templates/components/ShareModal.html.twig
@@ -38,7 +38,8 @@
     </div>
 
     {# Onglet "Compte" — partage entre comptes HomeCloud (Share) #}
-    <form method="post" action="{{ path('app_share_create') }}" class="share-tab-panel flex flex-col" data-tab-panel="account">
+    <form method="post" action="{{ path('app_share_create') }}" class="share-tab-panel flex flex-col"
+          data-tab-panel="account" data-controller="share-guest-picker">
       <input type="hidden" name="_token" value="{{ csrf_token('share-create') }}">
       <input type="hidden" name="resourceType" value="{{ resourceType }}">
       <input type="hidden" name="resourceId" value="{{ resourceId }}">
@@ -48,9 +49,34 @@
           Email(s) de l'invité — séparés par une virgule
         </label>
         <input type="email" name="guestEmail" data-testid="share-guest-email" multiple
+               data-share-guest-picker-target="input"
                placeholder="ami@example.com, autre@example.com" required
                class="w-full px-3 py-2 rounded-md text-sm"
                style="border: 1px solid var(--hc-border); background: var(--hc-bg); color: var(--hc-text);">
+      </div>
+
+      {# Sélection directe d'un invité déjà créé — ajoute son email au champ
+         ci-dessus au clic, évite de le ressaisir à chaque partage. #}
+      <div class="px-6 pt-3">
+        <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
+          Ou choisir un invité existant
+        </label>
+        {% if userGuests is defined and userGuests is not empty %}
+          <div class="flex flex-wrap gap-1.5">
+            {% for guest in userGuests %}
+              <button type="button" data-testid="share-guest-option" data-guest-email="{{ guest.email }}"
+                      data-action="click->share-guest-picker#add"
+                      class="px-2.5 py-1 rounded-full text-xs font-medium"
+                      style="border: 1px solid var(--hc-border); background: var(--hc-surface-2); color: var(--hc-text); cursor: pointer;">
+                {{ guest.displayName }}
+              </button>
+            {% endfor %}
+          </div>
+        {% else %}
+          <p class="text-xs" data-testid="share-no-guests-hint" style="color: var(--hc-text-3);">
+            Aucun invité pour l'instant — saisissez un email ci-dessus pour en créer un.
+          </p>
+        {% endif %}
       </div>
 
       <div class="px-6 pt-4">

--- a/tests/Web/ShareModalGuestSelectionWebTest.php
+++ b/tests/Web/ShareModalGuestSelectionWebTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Sélection directe d'un invité déjà créé depuis ShareModal, pour éviter
+ * de ressaisir son email à chaque partage. TDD RED → GREEN.
+ */
+final class ShareModalGuestSelectionWebTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM share_links');
+        $conn->executeStatement('DELETE FROM shares');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createOwner(): User
+    {
+        return $this->createWebUser('modal-guest-owner@example.com', 'secret123', 'Owner');
+    }
+
+    private function createGuest(string $email = 'invite@example.com', string $displayName = 'Invite'): User
+    {
+        $guest = new User($email, $displayName);
+        $guest->markAsGuest();
+        $this->em->persist($guest);
+        $this->em->flush();
+
+        return $guest;
+    }
+
+    private function createFile(User $owner): Folder
+    {
+        $folder = new Folder('Docs', $owner);
+        $this->em->persist($folder);
+        $file = new File('photo.jpg', 'image/jpeg', 1024, 'test/photo.jpg', $folder, $owner);
+        $this->em->persist($file);
+        $this->em->flush();
+
+        return $folder;
+    }
+
+    public function testShareModalListsExistingGuestsForSelection(): void
+    {
+        $owner = $this->createOwner();
+        $folder = $this->createFile($owner);
+        $this->createGuest('alice@example.com', 'Alice');
+        $this->loginAs('modal-guest-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/explorer?folder=' . $folder->getId()->toRfc4122());
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-testid="share-guest-option"]');
+        $this->assertSelectorTextContains('[data-testid="share-guest-option"]', 'Alice');
+    }
+
+    public function testShareModalDoesNotListOwnerAsGuestOption(): void
+    {
+        $owner = $this->createOwner();
+        $folder = $this->createFile($owner);
+        $this->loginAs('modal-guest-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/explorer?folder=' . $folder->getId()->toRfc4122());
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorNotExists('[data-testid="share-guest-option"]');
+    }
+
+    public function testShareModalShowsEmptyStateHintWhenNoGuestsExist(): void
+    {
+        $owner = $this->createOwner();
+        $folder = $this->createFile($owner);
+        $this->loginAs('modal-guest-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/explorer?folder=' . $folder->getId()->toRfc4122());
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-testid="share-no-guests-hint"]');
+    }
+}


### PR DESCRIPTION
## Summary
- Jusqu'ici il fallait ressaisir l'email d'un invité à chaque partage, même quand un compte invité existait déjà pour lui.
- Ajoute une liste de sélection sous le champ email dans `ShareModal` : cliquer sur un invité ajoute son email au champ existant (qui accepte déjà une liste séparée par virgules côté serveur — aucun changement de `ShareWebController::create()` nécessaire).
- `GuestGlobalsExtension` expose `userGuests` dans tous les templates, même pattern que `FolderGlobalsExtension`/`userFolders` déjà en place pour le modal de sélection de dossier.

## Test plan
- [x] `./vendor/bin/phpunit` — 680 tests, 0 échec
- [ ] Vérification visuelle manuelle : ouvrir ShareModal avec des invités existants, cliquer pour ajouter, vérifier le message quand aucun invité n'existe

🤖 Generated with [Claude Code](https://claude.com/claude-code)