### PR TITLE
Création directe d'invités + avatar 2 lettres

### DIFF
--- a/src/Controller/Web/GuestManagementWebController.php
+++ b/src/Controller/Web/GuestManagementWebController.php
@@ -6,6 +6,7 @@ namespace App\Controller\Web;
 
 use App\Entity\User;
 use App\Interface\UserRepositoryInterface;
+use App\Service\GuestAccountCreator;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,6 +30,7 @@ final class GuestManagementWebController extends AbstractController
     public function __construct(
         private readonly UserRepositoryInterface $userRepository,
         private readonly EntityManagerInterface $em,
+        private readonly GuestAccountCreator $guestAccountCreator,
     ) {}
 
     #[Route('/invites', name: 'app_guests')]
@@ -37,6 +39,33 @@ final class GuestManagementWebController extends AbstractController
         $guests = $this->userRepository->findBy(['accountType' => User::ACCOUNT_TYPE_GUEST], ['createdAt' => 'DESC']);
 
         return $this->render('web/guests.html.twig', ['guests' => $guests]);
+    }
+
+    #[Route('/invites/create', name: 'app_guest_create', methods: ['POST'])]
+    public function create(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('guest-create', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Jeton CSRF invalide.');
+        }
+
+        $email = trim((string) $request->request->get('email', ''));
+
+        if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+            $this->addFlash('error', 'Email invalide.');
+
+            return $this->redirect('/invites');
+        }
+
+        if ($this->userRepository->findOneBy(['email' => $email]) !== null) {
+            $this->addFlash('error', 'Un compte avec cet email existe déjà.');
+
+            return $this->redirect('/invites');
+        }
+
+        $this->guestAccountCreator->create($email);
+        $this->addFlash('success', 'Invité créé.');
+
+        return $this->redirect('/invites');
     }
 
     #[Route('/invites/{id}/edit', name: 'app_guest_edit', methods: ['POST'])]

--- a/templates/web/guests.html.twig
+++ b/templates/web/guests.html.twig
@@ -18,6 +18,25 @@
     </div>
   </div>
 
+  {# Création directe d'un invité, sans passer par un partage. #}
+  <form method="post" action="{{ path('app_guest_create') }}" class="hc-item-card flex items-end gap-2" style="padding: 1rem;">
+    <input type="hidden" name="_token" value="{{ csrf_token('guest-create') }}">
+    <div class="flex-1">
+      <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
+        Créer un invité
+      </label>
+      <input type="email" name="email" data-testid="guest-create-email" required
+             placeholder="ami@example.com"
+             class="w-full px-3 py-2 rounded-md text-sm"
+             style="border: 1px solid var(--hc-border); background: var(--hc-bg); color: var(--hc-text);">
+    </div>
+    <button type="submit" data-testid="guest-create-submit"
+            class="px-4 py-2 rounded-md text-sm font-semibold"
+            style="background: var(--hc-accent); color: var(--hc-accent-contrast, #fff); border: none; cursor: pointer;">
+      Créer
+    </button>
+  </form>
+
   {% if guests is empty %}
     <div data-testid="guests-empty">
       <twig:EmptyState

--- a/templates/web/layout.html.twig
+++ b/templates/web/layout.html.twig
@@ -124,7 +124,7 @@
                 </button>
 
                 <a href="{{ path('app_settings') }}" class="hc-user-avatar" title="Paramètres du compte — {{ app.user.displayName }}" aria-label="Compte : {{ app.user.displayName }}">
-                    {{ app.user.displayName|first|upper }}
+                    {{ app.user.displayName|slice(0, 2)|upper }}
                 </a>
 
                 <a href="{{ path('app_logout') }}" class="hc-logout-btn" title="Déconnexion" aria-label="Déconnexion">

--- a/tests/Web/GuestManagementWebTest.php
+++ b/tests/Web/GuestManagementWebTest.php
@@ -149,6 +149,83 @@ final class GuestManagementWebTest extends WebTestCase
         $this->assertNull($this->em->getRepository(User::class)->find($guest->getId()));
     }
 
+    public function testGuestsPageHasCreateGuestForm(): void
+    {
+        $this->createOwner();
+        $this->loginAs('guest-mgmt-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/invites');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('form[action*="/invites/create"] input[name="email"]');
+    }
+
+    public function testCreateGuestAccountSucceeds(): void
+    {
+        $this->createOwner();
+        $this->loginAs('guest-mgmt-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/invites');
+        $token = $crawler->filter('form[action*="/invites/create"] input[name="_token"]')
+            ->first()->attr('value');
+
+        $this->client->request('POST', '/invites/create', [
+            '_token' => $token,
+            'email'  => 'nouvel-invite@example.com',
+        ]);
+
+        $this->assertResponseRedirects('/invites');
+
+        $created = $this->userRepositoryFindByEmail('nouvel-invite@example.com');
+        $this->assertNotNull($created);
+        $this->assertTrue($created->isGuest());
+    }
+
+    public function testCreateGuestAccountWithExistingEmailFails(): void
+    {
+        $this->createOwner();
+        $this->createGuest('deja-existant@example.com');
+        $this->loginAs('guest-mgmt-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/invites');
+        $token = $crawler->filter('form[action*="/invites/create"] input[name="_token"]')
+            ->first()->attr('value');
+
+        $this->client->request('POST', '/invites/create', [
+            '_token' => $token,
+            'email'  => 'deja-existant@example.com',
+        ]);
+
+        $this->assertResponseRedirects('/invites');
+        $this->client->followRedirect();
+        $this->assertStringContainsString('existe déjà', $this->client->getResponse()->getContent());
+    }
+
+    public function testCreateGuestAccountWithInvalidEmailFails(): void
+    {
+        $this->createOwner();
+        $this->loginAs('guest-mgmt-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/invites');
+        $token = $crawler->filter('form[action*="/invites/create"] input[name="_token"]')
+            ->first()->attr('value');
+
+        $this->client->request('POST', '/invites/create', [
+            '_token' => $token,
+            'email'  => 'pas-un-email',
+        ]);
+
+        $this->assertResponseRedirects('/invites');
+        $this->client->followRedirect();
+        $this->assertStringContainsString('invalide', $this->client->getResponse()->getContent());
+    }
+
+    private function userRepositoryFindByEmail(string $email): ?User
+    {
+        return static::getContainer()->get(\App\Interface\UserRepositoryInterface::class)
+            ->findOneBy(['email' => $email]);
+    }
+
     public function testCannotEditOrDeleteAFullAccountViaGuestManagement(): void
     {
         $this->createOwner();


### PR DESCRIPTION
## Summary
- Jusqu'ici un compte invité ne pouvait se créer qu'implicitement au moment d'un partage vers un email inconnu (via `ShareModal`), ce qui obligeait à passer par un partage réel pour créer un invité.
- Ajoute `POST /invites/create` (CSRF, réutilise `GuestAccountCreator` déjà en place) avec un formulaire dédié sur `/invites` — rejette les emails invalides et les emails déjà utilisés.
- Avatar utilisateur (barre du haut) passé de 1 à 2 lettres (`displayName|slice(0,2)|upper`).

## Test plan
- [x] `./vendor/bin/phpunit` — 681 tests, 0 échec
- [ ] Vérification visuelle manuelle : créer un invité depuis /invites, vérifier l'email d'activation envoyé, vérifier l'avatar 2 lettres

🤖 Generated with [Claude Code](https://claude.com/claude-code)