### PR TITLE
Albums toujours en lecture seule dans ShareModal

### DIFF
--- a/templates/components/ShareModal.html.twig
+++ b/templates/components/ShareModal.html.twig
@@ -79,19 +79,25 @@
       </div>
 
       <div class="px-6 pt-4">
-        <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
-          Permission
-        </label>
-        <div class="flex gap-3 text-sm">
-          <label class="flex items-center gap-1.5 cursor-pointer">
-            <input type="radio" name="permission" value="read" checked>
-            Lecture seule
+        {% if resourceType == 'album' %}
+          {# Édition en ligne d'un album abandonnée — un album partagé est
+             toujours en lecture seule, aucun autre choix proposé. #}
+          <input type="hidden" name="permission" value="read">
+        {% else %}
+          <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
+            Permission
           </label>
-          <label class="flex items-center gap-1.5 cursor-pointer">
-            <input type="radio" name="permission" value="write">
-            Lecture/écriture
-          </label>
-        </div>
+          <div class="flex gap-3 text-sm">
+            <label class="flex items-center gap-1.5 cursor-pointer">
+              <input type="radio" name="permission" value="read" checked>
+              Lecture seule
+            </label>
+            <label class="flex items-center gap-1.5 cursor-pointer">
+              <input type="radio" name="permission" value="write">
+              Lecture/écriture
+            </label>
+          </div>
+        {% endif %}
       </div>
 
       <div class="flex gap-2 justify-end px-6 py-4 mt-2" style="border-top: 1px solid var(--hc-border);">

--- a/tests/Web/ShareModalAlbumReadOnlyWebTest.php
+++ b/tests/Web/ShareModalAlbumReadOnlyWebTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\Album;
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * L'édition en ligne d'un album partagé a été abandonnée : un album partagé
+ * est toujours en lecture seule, ShareModal ne doit proposer aucun autre
+ * choix de permission pour ce type de ressource. TDD RED → GREEN.
+ */
+final class ShareModalAlbumReadOnlyWebTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM album_media');
+        $conn->executeStatement('DELETE FROM albums');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createOwner(): User
+    {
+        return $this->createWebUser('album-readonly-owner@example.com', 'secret123', 'Owner');
+    }
+
+    private function createAlbum(User $user): Album
+    {
+        $album = new Album('Vacances', $user);
+        $this->em->persist($album);
+        $this->em->flush();
+
+        return $album;
+    }
+
+    public function testShareModalForAlbumHasNoWritePermissionOption(): void
+    {
+        $owner = $this->createOwner();
+        $album = $this->createAlbum($owner);
+        $this->loginAs('album-readonly-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/albums/' . $album->getId()->toRfc4122());
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorNotExists('input[name="permission"][value="write"]');
+    }
+
+    public function testShareModalForAlbumSendsReadPermissionAsHiddenField(): void
+    {
+        $owner = $this->createOwner();
+        $album = $this->createAlbum($owner);
+        $this->loginAs('album-readonly-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/albums/' . $album->getId()->toRfc4122());
+
+        $this->assertResponseIsSuccessful();
+        $hiddenPermission = $crawler->filter('form[action*="/share-create"] input[type="hidden"][name="permission"]');
+        $this->assertGreaterThan(0, $hiddenPermission->count());
+        $this->assertSame('read', $hiddenPermission->attr('value'));
+    }
+}


### PR DESCRIPTION
## Summary
- L'édition en ligne d'un album partagé a été abandonnée — le choix "Lecture/écriture" n'a donc plus de sens pour un album.
- `ShareModal` masque désormais l'ensemble du bloc de sélection de permission pour `resourceType == 'album'` et envoie `permission=read` via un champ caché. Les autres types de ressources (fichier, dossier) gardent le choix read/write existant, aucune modification là.

## Test plan
- [x] `./vendor/bin/phpunit` — 686 tests, 0 échec, TDD RED→GREEN confirmé (stash du template pour vérifier l'échec des 2 nouveaux tests avant implémentation)
- [ ] **Pas de vérification navigateur réelle** — aucun outil headless/Playwright n'est disponible dans cet environnement ; seuls les tests fonctionnels PHPUnit (KernelBrowser + DomCrawler) ont validé le rendu HTML. Vérification visuelle manuelle recommandée avant merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)