### PR TITLE
ShareModal : retirer style/JS inline (SRP)

### DIFF
--- a/assets/controllers/modal_toggle_controller.js
+++ b/assets/controllers/modal_toggle_controller.js
@@ -1,0 +1,41 @@
+import { Controller } from '@hotwired/stimulus';
+
+/* Ouverture/fermeture générique d'une modale : bouton déclencheur externe
+ * (par id, car hors du scope du contrôleur), bouton de fermeture, clic sur
+ * l'overlay, touche Échap. Réutilisable par toute modale qui suit le pattern
+ * hidden + display:flex (ShareModal, futures modales similaires). */
+export default class extends Controller {
+    static values = { openButtonId: String };
+
+    connect() {
+        this._onKeydown = (e) => {
+            if (e.key === 'Escape' && this.isOpen()) this.close();
+        };
+        document.addEventListener('keydown', this._onKeydown);
+
+        const openBtn = document.getElementById(this.openButtonIdValue);
+        if (openBtn) openBtn.addEventListener('click', () => this.open());
+    }
+
+    disconnect() {
+        document.removeEventListener('keydown', this._onKeydown);
+    }
+
+    open() {
+        this.element.classList.remove('hidden');
+        this.element.style.display = 'flex';
+    }
+
+    close() {
+        this.element.classList.add('hidden');
+        this.element.style.display = 'none';
+    }
+
+    closeOnOverlayClick(event) {
+        if (event.target === this.element) this.close();
+    }
+
+    isOpen() {
+        return this.element.style.display === 'flex';
+    }
+}

--- a/assets/controllers/tabs_controller.js
+++ b/assets/controllers/tabs_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from '@hotwired/stimulus';
+
+/* Bascule entre panneaux via des boutons d'onglets — chaque bouton porte
+ * data-tab="xxx", chaque panneau data-tab-panel="xxx". Réutilisable par
+ * toute UI à onglets simple (ShareModal, futures UI similaires). */
+export default class extends Controller {
+    static targets = ['button', 'panel'];
+    static classes = ['active'];
+
+    select(event) {
+        const target = event.currentTarget.dataset.tab;
+
+        this.buttonTargets.forEach((btn) => {
+            btn.classList.toggle(this.activeClass, btn.dataset.tab === target);
+        });
+        this.panelTargets.forEach((panel) => {
+            panel.classList.toggle('hidden', panel.dataset.tabPanel !== target);
+        });
+    }
+}

--- a/assets/styles/share-modal.css
+++ b/assets/styles/share-modal.css
@@ -3,9 +3,95 @@
  * Styles pour la modale de partage (templates/components/ShareModal.html.twig)
  */
 
+.hc-share-modal-card {
+  background: var(--hc-surface);
+  color: var(--hc-text);
+  border: 1px solid var(--hc-border);
+  border-radius: 1rem;
+  box-shadow: var(--hc-shadow-crisp);
+  width: 100%;
+  max-width: 440px;
+  margin: 1rem;
+}
+
+.hc-share-modal-header {
+  border-bottom: 1px solid var(--hc-border);
+}
+
+.hc-share-modal-close {
+  background: var(--hc-surface-2);
+  color: var(--hc-text-2);
+  border: none;
+  cursor: pointer;
+}
+
+.hc-share-tabs {
+  gap: 4px;
+  border-bottom: 1px solid var(--hc-border);
+}
+
+.hc-share-tab-btn {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  background: none;
+  border: none;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  color: var(--hc-text-2);
+}
+
+.hc-share-tab-btn--active {
+  border-bottom-color: var(--hc-accent);
+  color: var(--hc-text);
+}
+
+.hc-share-label {
+  color: var(--hc-text-3);
+}
+
+.hc-share-input {
+  border: 1px solid var(--hc-border);
+  background: var(--hc-bg);
+  color: var(--hc-text);
+}
+
 .hc-share-guest-option {
   border: 1px solid transparent;
   background: var(--hc-accent-soft);
   color: var(--hc-accent);
   cursor: pointer;
+}
+
+.hc-share-footer {
+  border-top: 1px solid var(--hc-border);
+}
+
+.hc-share-btn-cancel {
+  background: none;
+  border: none;
+  color: var(--hc-text-2);
+  cursor: pointer;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.hc-share-btn-primary {
+  background: var(--hc-accent);
+  color: var(--hc-accent-contrast, #fff);
+  border: none;
+  cursor: pointer;
+}
+
+.hc-share-btn-secondary {
+  background: var(--hc-surface-2);
+  color: var(--hc-text);
+  border: 1px solid var(--hc-border);
+  cursor: pointer;
+}
+
+.hc-share-text-muted {
+  color: var(--hc-text-2);
 }

--- a/templates/components/ShareModal.html.twig
+++ b/templates/components/ShareModal.html.twig
@@ -7,58 +7,58 @@
    Props attendues : resourceType (string), resourceId (string). #}
 <div id="share-modal-{{ resourceId }}"
      data-testid="share-modal"
+     data-controller="modal-toggle tabs"
+     data-modal-toggle-open-button-id-value="share-open-btn-{{ resourceId }}"
+     data-tabs-active-class="hc-share-tab-btn--active"
+     data-action="click->modal-toggle#closeOnOverlayClick"
      class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/45"
      tabindex="-1"
      aria-modal="true"
      role="dialog">
 
-  <div class="flex flex-col"
-       style="background: var(--hc-surface); color: var(--hc-text); border: 1px solid var(--hc-border);
-              border-radius: 1rem; box-shadow: var(--hc-shadow-crisp); width: 100%; max-width: 440px;
-              margin: 1rem;">
+  <div class="hc-share-modal-card flex flex-col">
 
     {# Header #}
-    <div class="flex items-center justify-between px-6 py-4" style="border-bottom: 1px solid var(--hc-border);">
+    <div class="hc-share-modal-header flex items-center justify-between px-6 py-4">
       <h2 class="text-base font-semibold m-0">Partager</h2>
-      <button type="button" class="share-modal-close" aria-label="Fermer"
-              class="flex items-center justify-center w-8 h-8 rounded-full"
-              style="background: var(--hc-surface-2); color: var(--hc-text-2); border: none; cursor: pointer;">×</button>
+      <button type="button" data-action="click->modal-toggle#close"
+              aria-label="Fermer"
+              class="hc-share-modal-close flex items-center justify-center w-8 h-8 rounded-full">×</button>
     </div>
 
     {# Onglets #}
-    <div class="flex px-6 pt-3" style="gap: 4px; border-bottom: 1px solid var(--hc-border);">
-      <button type="button" class="share-tab-btn share-tab-btn--active" data-tab="account" data-testid="share-tab-account"
-              style="padding: 0.5rem 0.75rem; font-size: 0.8125rem; font-weight: 600; background: none; border: none; cursor: pointer; border-bottom: 2px solid var(--hc-accent);">
+    <div class="hc-share-tabs flex px-6 pt-3">
+      <button type="button" class="hc-share-tab-btn hc-share-tab-btn--active" data-tab="account" data-testid="share-tab-account"
+              data-tabs-target="button" data-action="click->tabs#select">
         Compte
       </button>
-      <button type="button" class="share-tab-btn" data-tab="link" data-testid="share-tab-link"
-              style="padding: 0.5rem 0.75rem; font-size: 0.8125rem; font-weight: 600; background: none; border: none; cursor: pointer; border-bottom: 2px solid transparent; color: var(--hc-text-2);">
+      <button type="button" class="hc-share-tab-btn" data-tab="link" data-testid="share-tab-link"
+              data-tabs-target="button" data-action="click->tabs#select">
         Lien
       </button>
     </div>
 
     {# Onglet "Compte" — partage entre comptes HomeCloud (Share) #}
-    <form method="post" action="{{ path('app_share_create') }}" class="share-tab-panel flex flex-col"
-          data-tab-panel="account" data-controller="share-guest-picker">
+    <form method="post" action="{{ path('app_share_create') }}" class="flex flex-col"
+          data-tabs-target="panel" data-tab-panel="account" data-controller="share-guest-picker">
       <input type="hidden" name="_token" value="{{ csrf_token('share-create') }}">
       <input type="hidden" name="resourceType" value="{{ resourceType }}">
       <input type="hidden" name="resourceId" value="{{ resourceId }}">
 
       <div class="px-6 pt-4">
-        <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
+        <label class="hc-share-label block text-xs font-semibold uppercase tracking-wide mb-1.5">
           Email(s) de l'invité — séparés par une virgule
         </label>
         <input type="email" name="guestEmail" data-testid="share-guest-email" multiple
                data-share-guest-picker-target="input"
                placeholder="ami@example.com, autre@example.com" required
-               class="w-full px-3 py-2 rounded-md text-sm"
-               style="border: 1px solid var(--hc-border); background: var(--hc-bg); color: var(--hc-text);">
+               class="hc-share-input w-full px-3 py-2 rounded-md text-sm">
       </div>
 
       {# Sélection directe d'un invité déjà créé — ajoute son email au champ
          ci-dessus au clic, évite de le ressaisir à chaque partage. #}
       <div class="px-6 pt-4">
-        <label class="block text-xs font-semibold uppercase tracking-wide mb-2" style="color: var(--hc-text-3);">
+        <label class="hc-share-label block text-xs font-semibold uppercase tracking-wide mb-2">
           Ou choisir un invité existant
         </label>
         {% if userGuests is defined and userGuests is not empty %}
@@ -72,7 +72,7 @@
             {% endfor %}
           </div>
         {% else %}
-          <p class="text-xs" data-testid="share-no-guests-hint" style="color: var(--hc-text-3);">
+          <p class="hc-share-label text-xs" data-testid="share-no-guests-hint">
             Aucun invité pour l'instant — saisissez un email ci-dessus pour en créer un.
           </p>
         {% endif %}
@@ -84,7 +84,7 @@
              toujours en lecture seule, aucun autre choix proposé. #}
           <input type="hidden" name="permission" value="read">
         {% else %}
-          <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
+          <label class="hc-share-label block text-xs font-semibold uppercase tracking-wide mb-1.5">
             Permission
           </label>
           <div class="flex gap-3 text-sm">
@@ -100,21 +100,20 @@
         {% endif %}
       </div>
 
-      <div class="flex gap-2 justify-end px-6 py-4 mt-2" style="border-top: 1px solid var(--hc-border);">
-        <button type="button" class="share-modal-cancel"
-                style="background: none; border: none; color: var(--hc-text-2); cursor: pointer; padding: 0.5rem 1rem; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500;">
+      <div class="hc-share-footer flex gap-2 justify-end px-6 py-4 mt-2">
+        <button type="button" data-action="click->modal-toggle#close"
+                class="hc-share-btn-cancel">
           Annuler
         </button>
         <button type="submit" data-testid="share-submit"
-                class="px-4 py-2 rounded-md text-sm font-semibold"
-                style="background: var(--hc-accent); color: var(--hc-accent-contrast, #fff); border: none; cursor: pointer;">
+                class="hc-share-btn-primary px-4 py-2 rounded-md text-sm font-semibold">
           Partager
         </button>
       </div>
     </form>
 
     {# Onglet "Lien" — lien public sans compte (ShareLink) #}
-    <div class="share-tab-panel flex flex-col hidden" data-tab-panel="link">
+    <div class="flex flex-col hidden" data-tabs-target="panel" data-tab-panel="link">
 
       {# Étape 1 — autoriser explicitement le partage par lien. Toujours
          affiché (pas de moyen simple de connaître ici l'état actuel de
@@ -127,7 +126,7 @@
         <input type="hidden" name="visibility" value="link_allowed">
 
         <div class="px-6 pt-4">
-          <p class="text-sm" style="color: var(--hc-text-2);">
+          <p class="hc-share-text-muted text-sm">
             Une ressource est privée par défaut. Autorisez le partage par lien
             avant de pouvoir en créer un.
           </p>
@@ -135,8 +134,7 @@
 
         <div class="flex justify-end px-6 pt-3">
           <button type="submit" data-testid="allow-link-sharing-submit"
-                  class="px-4 py-2 rounded-md text-sm font-semibold"
-                  style="background: var(--hc-surface-2); color: var(--hc-text); border: 1px solid var(--hc-border); cursor: pointer;">
+                  class="hc-share-btn-secondary px-4 py-2 rounded-md text-sm font-semibold">
             Autoriser le partage par lien
           </button>
         </div>
@@ -150,19 +148,18 @@
         <input type="hidden" name="resourceId" value="{{ resourceId }}">
 
         <div class="px-6 pt-4">
-          <p class="text-sm" style="color: var(--hc-text-2);">
+          <p class="hc-share-text-muted text-sm">
             Toute personne recevant ce lien pourra consulter cette ressource sans
             créer de compte, en lecture seule.
           </p>
         </div>
 
         <div class="px-6 pt-4">
-          <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
+          <label class="hc-share-label block text-xs font-semibold uppercase tracking-wide mb-1.5">
             Durée de validité
           </label>
           <select name="duration" data-testid="share-link-duration"
-                  class="w-full px-3 py-2 rounded-md text-sm"
-                  style="border: 1px solid var(--hc-border); background: var(--hc-bg); color: var(--hc-text);">
+                  class="hc-share-input w-full px-3 py-2 rounded-md text-sm">
             <option value="1d">1 jour</option>
             <option value="7d" selected>7 jours</option>
             <option value="30d">30 jours</option>
@@ -170,14 +167,13 @@
           </select>
         </div>
 
-        <div class="flex gap-2 justify-end px-6 py-4 mt-2" style="border-top: 1px solid var(--hc-border);">
-          <button type="button" class="share-modal-cancel"
-                  style="background: none; border: none; color: var(--hc-text-2); cursor: pointer; padding: 0.5rem 1rem; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500;">
+        <div class="hc-share-footer flex gap-2 justify-end px-6 py-4 mt-2">
+          <button type="button" data-action="click->modal-toggle#close"
+                  class="hc-share-btn-cancel">
             Annuler
           </button>
           <button type="submit" data-testid="share-link-submit"
-                  class="px-4 py-2 rounded-md text-sm font-semibold"
-                  style="background: var(--hc-accent); color: var(--hc-accent-contrast, #fff); border: none; cursor: pointer;">
+                  class="hc-share-btn-primary px-4 py-2 rounded-md text-sm font-semibold">
             Créer le lien
           </button>
         </div>
@@ -198,52 +194,3 @@
 
   </div>
 </div>
-
-<script>
-(function () {
-    var modal = document.getElementById('share-modal-{{ resourceId }}');
-    if (!modal) return;
-
-    var openBtn = document.getElementById('share-open-btn-{{ resourceId }}');
-    var closeBtn = modal.querySelector('.share-modal-close');
-    var cancelBtn = modal.querySelector('.share-modal-cancel');
-
-    function open() {
-        modal.classList.remove('hidden');
-        modal.style.display = 'flex';
-    }
-
-    function close() {
-        modal.classList.add('hidden');
-        modal.style.display = 'none';
-    }
-
-    if (openBtn) openBtn.addEventListener('click', open);
-    if (closeBtn) closeBtn.addEventListener('click', close);
-    modal.querySelectorAll('.share-modal-cancel').forEach(function (btn) {
-        btn.addEventListener('click', close);
-    });
-    modal.addEventListener('click', function (e) {
-        if (e.target === modal) close();
-    });
-    document.addEventListener('keydown', function (e) {
-        if (e.key === 'Escape' && modal.style.display === 'flex') close();
-    });
-
-    var tabBtns = modal.querySelectorAll('.share-tab-btn');
-    var tabPanels = modal.querySelectorAll('.share-tab-panel');
-    tabBtns.forEach(function (btn) {
-        btn.addEventListener('click', function () {
-            var target = btn.getAttribute('data-tab');
-            tabBtns.forEach(function (b) {
-                b.classList.toggle('share-tab-btn--active', b === btn);
-                b.style.borderBottomColor = b === btn ? 'var(--hc-accent)' : 'transparent';
-                b.style.color = b === btn ? '' : 'var(--hc-text-2)';
-            });
-            tabPanels.forEach(function (panel) {
-                panel.classList.toggle('hidden', panel.getAttribute('data-tab-panel') !== target);
-            });
-        });
-    });
-}());
-</script>


### PR DESCRIPTION
## Summary
- 22 `style="..."` extraits vers `assets/styles/share-modal.css` (classes `.hc-share-*`).
- Le `<script>` mélangeait 2 responsabilités (ouverture/fermeture de la modale + gestion des onglets) → séparé en 2 controllers Stimulus réutilisables : `modal_toggle_controller.js` et `tabs_controller.js`.
- Corrige un bug latent trouvé pendant le nettoyage : le bouton de fermeture avait deux attributs `class="..."` dupliqués (`class="share-modal-close" class="flex items-center..."`) — en HTML seul le premier attribut est retenu par le parseur, donc les classes de mise en forme (cercle centré) n'ont jamais été appliquées. Fusionné en une seule classe `.hc-share-modal-close`.

## Test plan
- [x] `./vendor/bin/phpunit` — 685 tests, 0 échec
- [x] `npm test` (Jest) — 71 tests, 0 échec
- [ ] **Vérification manuelle nécessaire** (pas de navigateur headless disponible) : ouvrir la modale de partage sur un fichier/dossier/album, basculer entre les onglets "Compte"/"Lien", fermer via le bouton ×, le bouton Annuler, un clic sur l'overlay, et la touche Échap — et vérifier visuellement que le bouton × est maintenant bien un cercle centré (corrigé par ce PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)