### PR TITLE
NewFolderModal : retirer style/JS inline (SRP)

### DIFF
--- a/assets/controllers/new_folder_modal_controller.js
+++ b/assets/controllers/new_folder_modal_controller.js
@@ -1,0 +1,92 @@
+import { Controller } from '@hotwired/stimulus';
+
+/* Modale de création de dossier : ouverture (écoute new-menu:open-folder-modal
+ * émis par NewMenu), sélection du type de média, soumission POST /api/v1/folders
+ * via le token bridge (window.HC.getToken), fermeture (bouton, overlay, Échap). */
+export default class extends Controller {
+    static targets = ['nameInput', 'parentSelect', 'mediaTypeLabel', 'mediaTypeRadio', 'submitButton', 'submitLabel'];
+    static values = { createUrl: String, ownerId: String };
+
+    connect() {
+        this._onOpenRequest = () => this.open();
+        document.addEventListener('new-menu:open-folder-modal', this._onOpenRequest);
+    }
+
+    disconnect() {
+        document.removeEventListener('new-menu:open-folder-modal', this._onOpenRequest);
+    }
+
+    open() {
+        this.nameInputTarget.value = '';
+        if (this.hasParentSelectTarget) this.parentSelectTarget.value = '';
+        this.mediaTypeRadioTargets.forEach((radio) => {
+            radio.checked = radio.value === 'general';
+        });
+        this.updateMediaTypeStyles();
+        this.element.classList.remove('hidden');
+        setTimeout(() => this.nameInputTarget.focus(), 50);
+    }
+
+    close() {
+        this.element.classList.add('hidden');
+    }
+
+    closeOnOverlayClick(event) {
+        if (event.target === this.element) this.close();
+    }
+
+    handleNameKeydown(event) {
+        if (event.key === 'Enter') this.submit();
+        if (event.key === 'Escape') this.close();
+    }
+
+    selectMediaType() {
+        this.updateMediaTypeStyles();
+    }
+
+    updateMediaTypeStyles() {
+        this.mediaTypeLabelTargets.forEach((label) => {
+            const radio = label.querySelector('input[type="radio"]');
+            label.classList.toggle('hc-new-folder-media-type--active', !!radio?.checked);
+        });
+    }
+
+    async submit() {
+        const name = this.nameInputTarget.value.trim();
+        if (!name) {
+            this.nameInputTarget.focus();
+            return;
+        }
+
+        const checked = this.mediaTypeRadioTargets.find((r) => r.checked);
+        const mediaType = checked ? checked.value : 'general';
+        const parentId = this.hasParentSelectTarget ? (this.parentSelectTarget.value || null) : null;
+
+        this.submitButtonTarget.disabled = true;
+        this.submitLabelTarget.textContent = '…';
+
+        const token = await window.HC.getToken();
+        const res = await fetch(this.createUrlValue, {
+            method: 'POST',
+            headers: {
+                'Authorization': 'Bearer ' + token,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                name,
+                ownerId: this.ownerIdValue,
+                mediaType,
+                parentId,
+            }),
+        });
+
+        if (res.ok) {
+            this.close();
+            window.location.reload();
+        } else {
+            this.submitButtonTarget.disabled = false;
+            this.submitLabelTarget.textContent = 'Créer';
+            window.alert('Erreur lors de la création du dossier.');
+        }
+    }
+}

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -15,6 +15,7 @@
 @import "./upload.css";
 @import "./settings.css";
 @import "./share-modal.css";
+@import "./new-folder-modal.css";
 @import "./main.css";
 
 nav .navbar-logo .navbar-logo-cloud {

--- a/assets/styles/new-folder-modal.css
+++ b/assets/styles/new-folder-modal.css
@@ -1,0 +1,166 @@
+/*
+ * assets/styles/new-folder-modal.css
+ * Styles pour la modale de création de dossier (templates/components/NewFolderModal.html.twig)
+ */
+
+.hc-new-folder-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9998;
+  background: rgba(0, 0, 0, 0.45);
+  align-items: center;
+  justify-content: center;
+}
+
+.hc-new-folder-card {
+  background: var(--hc-surface);
+  color: var(--hc-text);
+  border-radius: 1rem;
+  box-shadow: var(--hc-shadow-lg);
+  width: 100%;
+  max-width: 440px;
+  margin: 1rem;
+  padding: 1.5rem;
+  border: 1px solid var(--hc-border);
+}
+
+.hc-new-folder-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+.hc-new-folder-header h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.hc-new-folder-close {
+  background: none;
+  border: none;
+  color: var(--hc-text-3);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.hc-new-folder-field {
+  margin-bottom: 1.1rem;
+}
+
+.hc-new-folder-label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--hc-text-2);
+  margin-bottom: 0.4rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.hc-new-folder-input,
+.hc-new-folder-select {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.55rem 0.85rem;
+  border: 1px solid var(--hc-border);
+  border-radius: 0.6rem;
+  font-size: 0.875rem;
+  color: var(--hc-text);
+  background: var(--hc-surface);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.hc-new-folder-input:focus {
+  border-color: var(--hc-accent);
+}
+
+.hc-new-folder-select {
+  cursor: pointer;
+}
+
+.hc-new-folder-media-types {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+}
+
+.hc-new-folder-media-type {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.5rem 0.25rem;
+  border: 1.5px solid var(--hc-border);
+  border-radius: 0.6rem;
+  cursor: pointer;
+  font-size: 0.75rem;
+  color: var(--hc-text-2);
+  transition: all 0.15s;
+}
+
+.hc-new-folder-media-type:hover {
+  background: var(--hc-surface-2);
+}
+
+.hc-new-folder-media-type--active,
+.hc-new-folder-media-type--active:hover {
+  background: var(--hc-accent-soft);
+  border-color: var(--hc-accent);
+}
+
+.hc-new-folder-media-type input[type="radio"] {
+  display: none;
+}
+
+.hc-new-folder-media-type-icon {
+  font-size: 1.3rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hc-new-folder-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.hc-new-folder-cancel {
+  padding: 0.5rem 1rem;
+  border: none;
+  background: none;
+  font-size: 0.875rem;
+  color: var(--hc-text-2);
+  cursor: pointer;
+  border-radius: 0.6rem;
+  transition: background 0.15s;
+}
+
+.hc-new-folder-cancel:hover {
+  background: var(--hc-surface-2);
+}
+
+.hc-new-folder-submit {
+  padding: 0.5rem 1.25rem;
+  background: var(--hc-accent);
+  color: #fff;
+  border: none;
+  border-radius: 0.6rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.hc-new-folder-submit:hover {
+  background: var(--hc-accent-2);
+}

--- a/templates/components/NewFolderModal.html.twig
+++ b/templates/components/NewFolderModal.html.twig
@@ -1,45 +1,45 @@
 {# === NewFolderModal component === #}
 {% import 'macros/icon.html.twig' as icons %}
 <div data-testid="new-folder-modal"
-     style="display:none; position:fixed; inset:0; z-index:9998; background:rgba(0,0,0,0.45);
-            align-items:center; justify-content:center;">
+     class="hc-new-folder-overlay hidden"
+     data-controller="new-folder-modal"
+     data-new-folder-modal-create-url-value="{{ path('_api_/v1/folders_post') }}"
+     data-new-folder-modal-owner-id-value="{{ app.user ? app.user.id : '' }}"
+     data-action="click->new-folder-modal#closeOnOverlayClick">
 
-    <div style="background:var(--hc-surface); color:var(--hc-text); border-radius:1rem;
-                box-shadow:var(--hc-shadow-lg); width:100%; max-width:440px;
-                margin:1rem; padding:1.5rem; border:1px solid var(--hc-border);">
+    <div class="hc-new-folder-card">
 
         {# Header #}
-        <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:1.25rem;">
-            <h2 style="font-size:1rem; font-weight:600; margin:0;">Nouveau dossier</h2>
+        <div class="hc-new-folder-header">
+            <h2>Nouveau dossier</h2>
             <button id="new-folder-modal-close"
                     type="button"
-                    style="background:none; border:none; color:var(--hc-text-3); cursor:pointer;
-                           display:inline-flex; align-items:center; justify-content:center; padding:0;">
+                    class="hc-new-folder-close"
+                    data-action="click->new-folder-modal#close">
                 {{ icons.icon('x', 18) }}
             </button>
         </div>
 
         {# Nom #}
-        <div style="margin-bottom:1.1rem;">
-            <label style="display:block; font-size:0.8rem; font-weight:500; color:var(--hc-text-2); margin-bottom:0.4rem; text-transform:uppercase; letter-spacing:0.05em;">
+        <div class="hc-new-folder-field">
+            <label class="hc-new-folder-label">
                 Nom du dossier
             </label>
             <input type="text"
                    id="new-folder-name-input"
                    data-testid="new-folder-name"
+                   data-new-folder-modal-target="nameInput"
+                   data-action="keydown->new-folder-modal#handleNameKeydown"
                    placeholder="Mon dossier…"
-                   style="width:100%; box-sizing:border-box; padding:0.55rem 0.85rem; border:1px solid var(--hc-border);
-                          border-radius:0.6rem; font-size:0.875rem; color:var(--hc-text); background:var(--hc-surface);
-                          outline:none; transition:border-color 0.15s;"
-                   onfocus="this.style.borderColor='var(--hc-accent)'" onblur="this.style.borderColor='var(--hc-border)'">
+                   class="hc-new-folder-input">
         </div>
 
         {# Type de contenu #}
-        <div style="margin-bottom:1.1rem;">
-            <label style="display:block; font-size:0.8rem; font-weight:500; color:var(--hc-text-2); margin-bottom:0.6rem; text-transform:uppercase; letter-spacing:0.05em;">
+        <div class="hc-new-folder-field">
+            <label class="hc-new-folder-label">
                 Type de contenu
             </label>
-            <div style="display:grid; grid-template-columns:repeat(3,1fr); gap:0.5rem;">
+            <div class="hc-new-folder-media-types">
                 {% set media_types = [
                     { value: 'general',  icon: 'folder', label: 'Général'   },
                     { value: 'photo',    icon: 'images', label: 'Photos'    },
@@ -50,19 +50,15 @@
                 ] %}
                 {% for mt in media_types %}
                     <label data-testid="media-type-{{ mt.value }}"
-                           style="display:flex; flex-direction:column; align-items:center; gap:0.25rem;
-                                  padding:0.5rem 0.25rem; border:1.5px solid var(--hc-border); border-radius:0.6rem;
-                                  cursor:pointer; font-size:0.75rem; color:var(--hc-text-2); transition:all 0.15s;
-                                  {% if mt.value == 'general' %}background:var(--hc-accent-soft); border-color:var(--hc-accent);{% endif %}"
-                           onmouseover="if(!this.querySelector('input').checked){this.style.background='var(--hc-surface-2)'}"
-                           onmouseout="if(!this.querySelector('input').checked){this.style.background=''; this.style.borderColor='var(--hc-border)';}">
+                           data-new-folder-modal-target="mediaTypeLabel"
+                           class="hc-new-folder-media-type{{ mt.value == 'general' ? ' hc-new-folder-media-type--active' : '' }}">
                         <input type="radio"
                                name="folder-media-type"
                                value="{{ mt.value }}"
                                {% if mt.value == 'general' %}checked{% endif %}
-                               style="display:none;"
-                               onchange="updateMediaTypeStyle()">
-                        <span style="font-size:1.3rem; display:inline-flex; align-items:center; justify-content:center;">{{ icons.icon(mt.icon, 20) }}</span>
+                               data-new-folder-modal-target="mediaTypeRadio"
+                               data-action="change->new-folder-modal#selectMediaType">
+                        <span class="hc-new-folder-media-type-icon">{{ icons.icon(mt.icon, 20) }}</span>
                         {{ mt.label }}
                     </label>
                 {% endfor %}
@@ -70,16 +66,15 @@
         </div>
 
         {# Emplacement #}
-        <div style="margin-bottom:1.25rem;">
-            <label style="display:block; font-size:0.8rem; font-weight:500; color:var(--hc-text-2); margin-bottom:0.4rem; text-transform:uppercase; letter-spacing:0.05em;">
+        <div class="hc-new-folder-field">
+            <label class="hc-new-folder-label">
                 Emplacement
             </label>
             <select id="new-folder-parent-select"
                     data-testid="parent-folder-select"
                     data-root-label="root"
-                    style="width:100%; padding:0.55rem 0.85rem; border:1px solid var(--hc-border);
-                           border-radius:0.6rem; font-size:0.875rem; color:var(--hc-text); background:var(--hc-surface);
-                           outline:none; cursor:pointer;">
+                    data-new-folder-modal-target="parentSelect"
+                    class="hc-new-folder-select">
                 <option value="">Racine (mes fichiers)</option>
                 {% for folder in folders %}
                     <option value="{{ folder.id }}">→ {{ folder.name }}</option>
@@ -88,115 +83,22 @@
         </div>
 
         {# Actions #}
-        <div style="display:flex; gap:0.5rem; justify-content:flex-end;">
+        <div class="hc-new-folder-actions">
             <button id="new-folder-modal-cancel"
                     type="button"
-                    style="padding:0.5rem 1rem; border:none; background:none; font-size:0.875rem;
-                           color:var(--hc-text-2); cursor:pointer; border-radius:0.6rem; transition:background 0.15s;"
-                    onmouseover="this.style.background='var(--hc-surface-2)'" onmouseout="this.style.background='none'">
+                    class="hc-new-folder-cancel"
+                    data-action="click->new-folder-modal#close">
                 Annuler
             </button>
             <button id="new-folder-submit-btn"
                     data-testid="new-folder-submit"
                     type="button"
-                    style="padding:0.5rem 1.25rem; background:var(--hc-accent); color:#fff; border:none;
-                           border-radius:0.6rem; font-size:0.875rem; font-weight:600; cursor:pointer;
-                           transition:background 0.15s; display:inline-flex; align-items:center; gap:0.4rem;"
-                    onmouseover="this.style.background='var(--hc-accent-2)'" onmouseout="this.style.background='var(--hc-accent)'">
+                    class="hc-new-folder-submit"
+                    data-new-folder-modal-target="submitButton"
+                    data-action="click->new-folder-modal#submit">
                 {{ icons.icon('check', 16) }}
-                <span id="new-folder-submit-label">Créer</span>
+                <span id="new-folder-submit-label" data-new-folder-modal-target="submitLabel">Créer</span>
             </button>
         </div>
     </div>
 </div>
-
-<script>
-(function () {
-    var modal      = document.querySelector('[data-testid="new-folder-modal"]');
-    var nameInput  = document.getElementById('new-folder-name-input');
-    var parentSel  = document.getElementById('new-folder-parent-select');
-    var submitBtn  = document.getElementById('new-folder-submit-btn');
-    var submitLabel = document.getElementById('new-folder-submit-label');
-    var closeBtn   = document.getElementById('new-folder-modal-close');
-    var cancelBtn  = document.getElementById('new-folder-modal-cancel');
-
-    function openModal() {
-        nameInput.value = '';
-        if (parentSel) parentSel.value = '';
-        var radios = document.querySelectorAll('[name="folder-media-type"]');
-        radios.forEach(function(r){ r.checked = r.value === 'general'; });
-        updateMediaTypeStyle();
-        modal.style.display = 'flex';
-        setTimeout(function(){ nameInput.focus(); }, 50);
-    }
-
-    function closeModal() {
-        modal.style.display = 'none';
-    }
-
-    window.updateMediaTypeStyle = function () {
-        document.querySelectorAll('[data-testid^="media-type-"]').forEach(function (lbl) {
-            var radio = lbl.querySelector('input[type="radio"]');
-            if (radio && radio.checked) {
-                lbl.style.background = 'var(--hc-accent-soft)';
-                lbl.style.borderColor = 'var(--hc-accent)';
-            } else {
-                lbl.style.background = '';
-                lbl.style.borderColor = 'var(--hc-border)';
-            }
-        });
-    };
-
-    closeBtn.addEventListener('click', closeModal);
-    cancelBtn.addEventListener('click', closeModal);
-    modal.addEventListener('click', function (e) {
-        if (e.target === modal) closeModal();
-    });
-
-    nameInput.addEventListener('keydown', function (e) {
-        if (e.key === 'Enter')  submitBtn.click();
-        if (e.key === 'Escape') closeModal();
-    });
-
-    submitBtn.addEventListener('click', async function () {
-        var name = nameInput.value.trim();
-        if (!name) { nameInput.focus(); return; }
-
-        var mediaType = 'general';
-        var checked = document.querySelector('[name="folder-media-type"]:checked');
-        if (checked) mediaType = checked.value;
-
-        var parentId = parentSel ? (parentSel.value || null) : null;
-
-        submitBtn.disabled = true;
-        submitLabel.textContent = '…';
-
-        var token = await window.HC.getToken();
-        var res = await fetch('{{ path('_api_/v1/folders_post') }}', {
-            method: 'POST',
-            headers: {
-                'Authorization': 'Bearer ' + token,
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                name:      name,
-                ownerId:   '{{ app.user ? app.user.id : '' }}',
-                mediaType: mediaType,
-                parentId:  parentId,
-            }),
-        });
-
-        if (res.ok) {
-            closeModal();
-            window.location.reload();
-        } else {
-            submitBtn.disabled = false;
-            submitLabel.textContent = 'Créer';
-            alert('Erreur lors de la création du dossier.');
-        }
-    });
-
-    // Écoute l'event du NewMenu
-    document.addEventListener('new-menu:open-folder-modal', openModal);
-}());
-</script>

--- a/tests/Web/Component/NewFolderModalTest.php
+++ b/tests/Web/Component/NewFolderModalTest.php
@@ -23,7 +23,7 @@ class NewFolderModalTest extends KernelTestCase
     {
         $node = $this->crawl()->filter('[data-testid="new-folder-modal"]');
         $this->assertCount(1, $node);
-        $this->assertStringContainsString('display:none', $node->attr('style') ?? '');
+        $this->assertStringContainsString('hidden', $node->attr('class') ?? '');
     }
 
     public function testHasNameInput(): void
@@ -90,9 +90,9 @@ class NewFolderModalTest extends KernelTestCase
         $this->assertCount(1, $this->crawl()->filter('[data-testid="new-folder-submit"]'));
     }
 
-    public function testHasInlineScript(): void
+    public function testHasNewFolderModalController(): void
     {
-        $html = (string) $this->renderTwigComponent('NewFolderModal');
-        $this->assertStringContainsString('<script>', $html);
+        $node = $this->crawl()->filter('[data-testid="new-folder-modal"]');
+        $this->assertStringContainsString('new-folder-modal', $node->attr('data-controller') ?? '');
     }
 }


### PR DESCRIPTION
## Summary
- 20 `style="..."` + 6 handlers `onclick`/`onmouseover`/`onfocus`/`onchange` extraits vers `assets/styles/new-folder-modal.css` (classes `.hc-new-folder-*`).
- Le `<script>` de 90 lignes (ouverture/fermeture, sélection du type de média, soumission API `/api/v1/folders`) est retiré, remplacé par `new_folder_modal_controller.js`.
- La modale masquée par défaut passe de `style="display:none"` à la classe utilitaire `hidden` (cohérent avec `ShareModal`, PR #225).
- Tests adaptés en conséquence : `testModalIsHiddenByDefault` vérifie la classe plutôt que le style inline, `testHasInlineScript` remplacé par `testHasNewFolderModalController`.

## Test plan
- [x] `./vendor/bin/phpunit` — 685 tests, 0 échec
- [x] `npm test` (Jest) — 71 tests, 0 échec
- [ ] **Vérification manuelle nécessaire** (pas de navigateur headless disponible) : bouton "Nouveau" → "Nouveau dossier", vérifier la sélection du type de média (surbrillance au clic), la sélection de l'emplacement, la création effective d'un dossier, et la fermeture (×, Annuler, clic sur l'overlay, Échap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)