### PR TITLE
NewAlbumModal : retirer style/JS inline (SRP)

### DIFF
--- a/assets/controllers/modal_toggle_controller.js
+++ b/assets/controllers/modal_toggle_controller.js
@@ -2,9 +2,11 @@ import { Controller } from '@hotwired/stimulus';
 
 /* Ouverture/fermeture générique d'une modale : bouton déclencheur externe
  * (par id, car hors du scope du contrôleur), bouton de fermeture, clic sur
- * l'overlay, touche Échap. Réutilisable par toute modale qui suit le pattern
- * hidden + display:flex (ShareModal, futures modales similaires). */
+ * l'overlay, touche Échap, focus optionnel d'un champ à l'ouverture.
+ * Réutilisable par toute modale qui suit le pattern hidden + display:flex
+ * (ShareModal, NewAlbumModal, futures modales similaires). */
 export default class extends Controller {
+    static targets = ['focusOnOpen'];
     static values = { openButtonId: String };
 
     connect() {
@@ -24,6 +26,9 @@ export default class extends Controller {
     open() {
         this.element.classList.remove('hidden');
         this.element.style.display = 'flex';
+        if (this.hasFocusOnOpenTarget) {
+            setTimeout(() => this.focusOnOpenTarget.focus(), 50);
+        }
     }
 
     close() {

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -15,6 +15,7 @@
 @import "./upload.css";
 @import "./settings.css";
 @import "./share-modal.css";
+@import "./new-album-modal.css";
 @import "./main.css";
 
 nav .navbar-logo .navbar-logo-cloud {

--- a/assets/styles/new-album-modal.css
+++ b/assets/styles/new-album-modal.css
@@ -1,0 +1,92 @@
+/*
+ * assets/styles/new-album-modal.css
+ * Styles pour la modale de création d'album (templates/components/NewAlbumModal.html.twig)
+ */
+
+.hc-new-album-card {
+  background: var(--hc-surface);
+  color: var(--hc-text);
+  border: 1px solid var(--hc-border);
+  border-radius: 1rem;
+  box-shadow: var(--hc-shadow-crisp);
+  width: 100%;
+  max-width: 560px;
+  margin: 1rem;
+  max-height: 85vh;
+}
+
+.hc-new-album-header {
+  border-bottom: 1px solid var(--hc-border);
+}
+
+.hc-new-album-close {
+  background: var(--hc-surface-2);
+  color: var(--hc-text-2);
+  border: none;
+  cursor: pointer;
+}
+
+.hc-new-album-label {
+  color: var(--hc-text-3);
+}
+
+.hc-new-album-input {
+  border: 1px solid var(--hc-border);
+  background: var(--hc-bg);
+  color: var(--hc-text);
+}
+
+.hc-new-album-media-section {
+  overflow-y: auto;
+}
+
+.hc-new-album-media-empty {
+  color: var(--hc-text-3);
+}
+
+.hc-new-album-media-grid {
+  grid-template-columns: repeat(auto-fill, minmax(88px, 1fr));
+}
+
+.hc-new-album-media-item {
+  aspect-ratio: 1;
+  border: 2px solid var(--hc-border);
+}
+
+.hc-new-album-media-checkbox {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  z-index: 1;
+  width: 18px;
+  height: 18px;
+}
+
+.hc-new-album-media-checkbox:checked + img,
+.hc-new-album-media-checkbox:checked ~ .hc-new-album-media-fallback {
+  outline: 3px solid var(--hc-accent);
+  outline-offset: -3px;
+}
+
+.hc-new-album-media-fallback {
+  background: var(--hc-surface-2);
+  color: var(--hc-text-3);
+}
+
+.hc-new-album-footer {
+  border-top: 1px solid var(--hc-border);
+}
+
+.hc-new-album-cancel {
+  background: none;
+  border: none;
+  color: var(--hc-text-2);
+  cursor: pointer;
+}
+
+.hc-new-album-submit {
+  background: var(--hc-accent);
+  color: var(--hc-accent-contrast, #fff);
+  border: none;
+  cursor: pointer;
+}

--- a/templates/components/NewAlbumModal.html.twig
+++ b/templates/components/NewAlbumModal.html.twig
@@ -4,59 +4,56 @@
    cohérent avec le flux existant de la page /albums. #}
 <div id="new-album-modal"
      data-testid="new-album-modal"
+     data-controller="modal-toggle"
+     data-modal-toggle-open-button-id-value="new-album-open-btn"
+     data-action="click->modal-toggle#closeOnOverlayClick"
      class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/45"
      tabindex="-1"
      aria-modal="true"
      role="dialog">
 
   <form method="post" action="{{ path('app_album_create') }}"
-        class="flex flex-col"
-        style="background: var(--hc-surface); color: var(--hc-text); border: 1px solid var(--hc-border);
-               border-radius: 1rem; box-shadow: var(--hc-shadow-crisp); width: 100%; max-width: 560px;
-               margin: 1rem; max-height: 85vh;">
+        class="hc-new-album-card flex flex-col">
     <input type="hidden" name="_token" value="{{ csrf_token('album-create') }}">
 
     {# Header #}
-    <div class="flex items-center justify-between px-6 py-4" style="border-bottom: 1px solid var(--hc-border);">
+    <div class="hc-new-album-header flex items-center justify-between px-6 py-4">
       <h2 class="text-base font-semibold m-0">Nouvel album</h2>
-      <button type="button" id="new-album-modal-close" aria-label="Fermer"
-              class="flex items-center justify-center w-8 h-8 rounded-full"
-              style="background: var(--hc-surface-2); color: var(--hc-text-2); border: none; cursor: pointer;">×</button>
+      <button type="button" aria-label="Fermer" data-action="click->modal-toggle#close"
+              class="hc-new-album-close flex items-center justify-center w-8 h-8 rounded-full">×</button>
     </div>
 
     {# Nom #}
     <div class="px-6 pt-4">
-      <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
+      <label class="hc-new-album-label block text-xs font-semibold uppercase tracking-wide mb-1.5">
         Nom de l'album
       </label>
-      <input type="text" name="name" id="new-album-name-input" data-testid="new-album-name"
+      <input type="text" name="name" data-testid="new-album-name"
+             data-modal-toggle-target="focusOnOpen"
              placeholder="Vacances d'été…" required
-             class="w-full px-3 py-2 rounded-md text-sm"
-             style="border: 1px solid var(--hc-border); background: var(--hc-bg); color: var(--hc-text);">
+             class="hc-new-album-input w-full px-3 py-2 rounded-md text-sm">
     </div>
 
     {# Sélection des médias #}
-    <div class="px-6 pt-4 pb-2" style="overflow-y: auto;">
-      <label class="block text-xs font-semibold uppercase tracking-wide mb-1.5" style="color: var(--hc-text-3);">
+    <div class="hc-new-album-media-section px-6 pt-4 pb-2">
+      <label class="hc-new-album-label block text-xs font-semibold uppercase tracking-wide mb-1.5">
         Photos à ajouter {% if medias|length %}({{ medias|length }}){% endif %}
       </label>
 
       {% if medias is empty %}
-        <p class="text-sm" style="color: var(--hc-text-3);">Aucun média disponible pour le moment.</p>
+        <p class="hc-new-album-media-empty text-sm">Aucun média disponible pour le moment.</p>
       {% else %}
-        <div class="grid gap-2" style="grid-template-columns: repeat(auto-fill, minmax(88px, 1fr));">
+        <div class="hc-new-album-media-grid grid gap-2">
           {% for media in medias %}
-            <label class="relative block rounded-md overflow-hidden cursor-pointer"
-                   style="aspect-ratio: 1; border: 2px solid var(--hc-border);">
+            <label class="hc-new-album-media-item relative block rounded-md overflow-hidden cursor-pointer">
               <input type="checkbox" name="mediaIds[]" value="{{ media.id }}"
-                     class="hc-album-media-checkbox"
-                     style="position: absolute; top: 6px; left: 6px; z-index: 1; width: 18px; height: 18px;">
+                     class="hc-new-album-media-checkbox">
               {% if media.thumbnailPath %}
                 <img src="{{ path('app_media_thumbnail', {id: media.id}) }}"
                      alt="{{ media.file.originalName }}" loading="lazy"
                      class="w-full h-full object-cover">
               {% else %}
-                <div class="w-full h-full flex items-center justify-center" style="background: var(--hc-surface-2); color: var(--hc-text-3);">
+                <div class="hc-new-album-media-fallback w-full h-full flex items-center justify-center">
                   <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5z"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
                 </div>
               {% endif %}
@@ -67,58 +64,15 @@
     </div>
 
     {# Actions #}
-    <div class="flex gap-2 justify-end px-6 py-4" style="border-top: 1px solid var(--hc-border);">
-      <button type="button" id="new-album-modal-cancel"
-              class="px-4 py-2 rounded-md text-sm font-medium"
-              style="background: none; border: none; color: var(--hc-text-2); cursor: pointer;">
+    <div class="hc-new-album-footer flex gap-2 justify-end px-6 py-4">
+      <button type="button" data-action="click->modal-toggle#close"
+              class="hc-new-album-cancel px-4 py-2 rounded-md text-sm font-medium">
         Annuler
       </button>
       <button type="submit" data-testid="new-album-submit"
-              class="px-4 py-2 rounded-md text-sm font-semibold"
-              style="background: var(--hc-accent); color: var(--hc-accent-contrast, #fff); border: none; cursor: pointer;">
+              class="hc-new-album-submit px-4 py-2 rounded-md text-sm font-semibold">
         Créer
       </button>
     </div>
   </form>
 </div>
-
-<style>
-  .hc-album-media-checkbox:checked + img,
-  .hc-album-media-checkbox:checked ~ div {
-    outline: 3px solid var(--hc-accent);
-    outline-offset: -3px;
-  }
-</style>
-
-<script>
-(function () {
-    var openBtn   = document.getElementById('new-album-open-btn');
-    var modal     = document.getElementById('new-album-modal');
-    var closeBtn  = document.getElementById('new-album-modal-close');
-    var cancelBtn = document.getElementById('new-album-modal-cancel');
-    var nameInput = document.getElementById('new-album-name-input');
-
-    if (!openBtn || !modal) return;
-
-    function open() {
-        modal.classList.remove('hidden');
-        modal.style.display = 'flex';
-        setTimeout(function () { nameInput.focus(); }, 50);
-    }
-
-    function close() {
-        modal.classList.add('hidden');
-        modal.style.display = 'none';
-    }
-
-    openBtn.addEventListener('click', open);
-    closeBtn.addEventListener('click', close);
-    cancelBtn.addEventListener('click', close);
-    modal.addEventListener('click', function (e) {
-        if (e.target === modal) close();
-    });
-    document.addEventListener('keydown', function (e) {
-        if (e.key === 'Escape' && modal.style.display === 'flex') close();
-    });
-}());
-</script>


### PR DESCRIPTION
## Summary
- 15 `style="..."` + le bloc `<style>` inline (outline sur checkbox cochée) extraits vers `assets/styles/new-album-modal.css`.
- Le `<script>` de 32 lignes (ouverture/fermeture/focus) est retiré, remplacé par la réutilisation de `modal_toggle_controller.js` (créé pour `ShareModal` dans #225) — étendu avec un target `focusOnOpen` générique (focus un champ à l'ouverture), dont `NewAlbumModal` a besoin (focus le nom de l'album) mais pas `ShareModal`.

Dépend de #225 (mergée) qui a introduit `modal_toggle_controller.js`.

## Test plan
- [x] `./vendor/bin/phpunit` — 685 tests, 0 échec
- [x] `npm test` (Jest) — 71 tests, 0 échec
- [ ] **Vérification manuelle nécessaire** (pas de navigateur headless disponible) : sur `/albums`, bouton "Nouvel album" → vérifier le focus automatique sur le champ nom, la sélection de médias (surbrillance au clic sur les cases à cocher), la création effective, et la fermeture (×, Annuler, clic sur l'overlay, Échap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)