### PR TITLE
Notification email pour un nouveau partage vers un invité existant

### DIFF
--- a/src/Controller/Web/ShareWebController.php
+++ b/src/Controller/Web/ShareWebController.php
@@ -15,6 +15,7 @@ use App\Interface\UserRepositoryInterface;
 use App\Security\OwnershipChecker;
 use App\Security\ResourceLocator;
 use App\Service\GuestAccountCreator;
+use App\Service\ShareNotificationMailer;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -42,6 +43,7 @@ final class ShareWebController extends AbstractController
         private readonly OwnershipChecker $ownershipChecker,
         private readonly EntityManagerInterface $em,
         private readonly GuestAccountCreator $guestAccountCreator,
+        private readonly ShareNotificationMailer $shareNotificationMailer,
     ) {}
 
     #[Route('/partages', name: 'app_shares')]
@@ -128,6 +130,7 @@ final class ShareWebController extends AbstractController
 
         foreach ($emails as $email) {
             $guest = $this->userRepository->findOneBy(['email' => $email]);
+            $isNewGuestAccount = false;
 
             if ($guest === null) {
                 if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
@@ -139,6 +142,7 @@ final class ShareWebController extends AbstractController
                 // un compte invité (sans mot de passe utilisable, cf.
                 // GuestAccountCreator) et on partage avec ce nouveau compte.
                 $guest = $this->guestAccountCreator->create($email);
+                $isNewGuestAccount = true;
             }
 
             if ($guest->getId()->equals($owner->getId())) {
@@ -155,6 +159,12 @@ final class ShareWebController extends AbstractController
                 $this->em->detach($share);
                 $failed[] = $email . ' (partage déjà existant)';
                 continue;
+            }
+
+            // Un compte tout juste créé a déjà reçu son email d'activation
+            // (GuestAccountCreator) — ne pas doubler la notification.
+            if (!$isNewGuestAccount) {
+                $this->shareNotificationMailer->notify($share, $this->resolveResourceName($share));
             }
 
             $shared[] = $email;

--- a/src/Service/ShareNotificationMailer.php
+++ b/src/Service/ShareNotificationMailer.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Share;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Notifie un invité déjà actif d'un nouveau partage (nom de la ressource +
+ * URL d'accès). Distinct de GuestAccountCreator : celui-ci n'envoie un email
+ * qu'à la création du tout premier compte (activation) — un invité qui a
+ * déjà un compte actif ne recevait jusqu'ici aucune notification pour les
+ * partages suivants.
+ */
+final readonly class ShareNotificationMailer
+{
+    public function __construct(
+        private MailerInterface $mailer,
+        private UrlGeneratorInterface $urlGenerator,
+    ) {}
+
+    public function notify(Share $share, string $resourceName): void
+    {
+        $accessUrl = $this->resolveAccessUrl($share);
+
+        $email = (new TemplatedEmail())
+            ->from(new Address('no-reply@homecloud.fr'))
+            ->to($share->getGuest()->getEmail())
+            ->subject(sprintf('%s a partagé « %s » avec vous', $share->getOwner()->getDisplayName(), $resourceName))
+            ->htmlTemplate('emails/share_notification.html.twig')
+            ->context([
+                'resourceName' => $resourceName,
+                'accessUrl'    => $accessUrl,
+            ]);
+
+        $this->mailer->send($email);
+    }
+
+    private function resolveAccessUrl(Share $share): string
+    {
+        return match ($share->getResourceType()) {
+            Share::RESOURCE_ALBUM => $this->urlGenerator->generate(
+                'app_album_detail',
+                ['id' => $share->getResourceId()->toRfc4122()],
+                UrlGeneratorInterface::ABSOLUTE_URL,
+            ),
+            Share::RESOURCE_FOLDER => $this->urlGenerator->generate(
+                'app_explorer',
+                ['folder' => $share->getResourceId()->toRfc4122()],
+                UrlGeneratorInterface::ABSOLUTE_URL,
+            ),
+            default => $this->urlGenerator->generate('app_explorer', [], UrlGeneratorInterface::ABSOLUTE_URL),
+        };
+    }
+}

--- a/templates/emails/share_notification.html.twig
+++ b/templates/emails/share_notification.html.twig
@@ -1,0 +1,11 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Nouveau partage HomeCloud{% endblock %}
+
+{% block body %}
+<p>Bonjour,</p>
+
+<p>Une nouvelle ressource a été partagée avec vous sur HomeCloud : <strong>{{ resourceName }}</strong>.</p>
+
+<p><a href="{{ accessUrl }}">Cliquez ici pour y accéder</a></p>
+{% endblock %}

--- a/tests/Unit/Service/ShareNotificationMailerTest.php
+++ b/tests/Unit/Service/ShareNotificationMailerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\Folder;
+use App\Entity\Share;
+use App\Entity\User;
+use App\Service\ShareNotificationMailer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * TDD RED → GREEN : notifie un invité déjà actif d'un nouveau partage
+ * (nom de la ressource + URL d'accès), là où seul le tout premier partage
+ * (création de compte) envoyait un email jusqu'ici.
+ */
+final class ShareNotificationMailerTest extends TestCase
+{
+    private function makeMailer(
+        ?MailerInterface $mailer = null,
+        ?UrlGeneratorInterface $urlGenerator = null,
+    ): ShareNotificationMailer {
+        $mailer ??= $this->createMock(MailerInterface::class);
+        $urlGenerator ??= $this->makeUrlGeneratorStub();
+
+        return new ShareNotificationMailer($mailer, $urlGenerator);
+    }
+
+    private function makeUrlGeneratorStub(): UrlGeneratorInterface
+    {
+        $stub = $this->createMock(UrlGeneratorInterface::class);
+        $stub->method('generate')->willReturn('https://example.test/explorer?folder=some-id');
+
+        return $stub;
+    }
+
+    public function testSendsEmailToGuestWithResourceNameAndAccessUrl(): void
+    {
+        $owner = new User('owner@example.com', 'Owner');
+        $guest = new User('guest@example.com', 'Guest');
+        $folder = new Folder('Vacances', $owner);
+        $share = new Share($owner, $guest, Share::RESOURCE_FOLDER, $folder->getId(), Share::PERMISSION_READ);
+
+        $sentEmail = null;
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects($this->once())->method('send')->willReturnCallback(
+            function ($message) use (&$sentEmail) {
+                $sentEmail = $message;
+            }
+        );
+
+        $notifier = $this->makeMailer(mailer: $mailer);
+        $notifier->notify($share, 'Vacances');
+
+        $this->assertNotNull($sentEmail);
+        $this->assertSame('guest@example.com', $sentEmail->getTo()[0]->getAddress());
+        $this->assertSame('Vacances', $sentEmail->getContext()['resourceName']);
+        $this->assertSame('https://example.test/explorer?folder=some-id', $sentEmail->getContext()['accessUrl']);
+    }
+
+    public function testAlbumResourceUsesAlbumDetailRoute(): void
+    {
+        $owner = new User('owner@example.com', 'Owner');
+        $guest = new User('guest@example.com', 'Guest');
+        $albumId = \Symfony\Component\Uid\Uuid::v7();
+        $share = new Share($owner, $guest, Share::RESOURCE_ALBUM, $albumId, Share::PERMISSION_READ);
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects($this->once())
+            ->method('generate')
+            ->with('app_album_detail', ['id' => $albumId->toRfc4122()], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://example.test/albums/' . $albumId->toRfc4122());
+
+        $notifier = $this->makeMailer(urlGenerator: $urlGenerator);
+        $notifier->notify($share, 'Mon Album');
+    }
+}

--- a/tests/Web/ShareWebTest.php
+++ b/tests/Web/ShareWebTest.php
@@ -196,6 +196,34 @@ final class ShareWebTest extends WebTestCase
         $this->assertSelectorTextContains('.flash-success', 'partagé');
     }
 
+    public function testCreateShareWithExistingGuestSendsNotificationEmail(): void
+    {
+        // Un invité qui a déjà un compte actif (créé lors d'un partage
+        // antérieur) ne recevait jusqu'ici aucun email pour les partages
+        // suivants — seul le tout premier email (activation) était envoyé.
+        $owner = $this->createUser();
+        $this->createUser('invite@example.com');
+        $album = $this->createAlbum($owner, 'Vacances');
+
+        $this->login();
+        $token = $this->shareCreateToken($album->getId()->toRfc4122());
+
+        $this->client->request('POST', '/share-create', [
+            '_token'       => $token,
+            'guestEmail'   => 'invite@example.com',
+            'resourceType' => 'album',
+            'resourceId'   => $album->getId()->toRfc4122(),
+            'permission'   => 'read',
+        ]);
+
+        $this->assertResponseRedirects('/albums/' . $album->getId()->toRfc4122());
+        self::assertEmailCount(1);
+
+        $email = self::getMailerMessage();
+        $this->assertStringContainsString('invite@example.com', $email->getTo()[0]->toString());
+        $this->assertStringContainsString('Vacances', $email->getHtmlBody());
+    }
+
     public function testCreateShareWithUnknownEmailCreatesGuestAccountAndShares(): void
     {
         // Depuis l'introduction de GuestAccountCreator, un email inconnu ne


### PR DESCRIPTION
## Summary
- Jusqu'ici, un invité qui avait déjà un compte actif (créé lors d'un partage antérieur) ne recevait aucun email pour les partages suivants — seul `GuestAccountCreator` envoyait un email, et uniquement à la création du tout premier compte (activation).
- `ShareNotificationMailer` (nouveau service) envoie une notification — nom de la ressource + URL d'accès directe (`app_album_detail` pour un album, `app_explorer?folder=` pour un dossier/fichier) — à chaque nouveau partage vers un invité déjà existant.
- Pas de doublon : un compte tout juste créé via `GuestAccountCreator` a déjà reçu son email d'activation, la notification n'est envoyée que si le guest existait déjà avant ce partage.

## Test plan
- [x] `./vendor/bin/phpunit` — 687 tests, 0 échec (nouveaux tests unitaires `ShareNotificationMailerTest` + fonctionnel `ShareWebTest::testCreateShareWithExistingGuestSendsNotificationEmail`, TDD RED→GREEN confirmé)
- [x] `npm test` (Jest) — 71 tests, 0 échec
- [ ] Vérification manuelle : partager une ressource avec un invité qui a déjà un compte actif, vérifier la réception de l'email (en dev `MAILER_DSN=null://null`, donc uniquement vérifiable via les logs/le profiler Symfony, pas une vraie boîte mail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)