### PR TITLE
fix(services): exclure DataFixtures du scan de services en prod

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -76,6 +76,8 @@ services:
     # this creates a service per class whose id is the fully-qualified class name
     App\:
         resource: '../src/'
+        exclude:
+            - '../src/DataFixtures/'
 
     App\Factory\FolderTreeFactory:
         arguments:
@@ -113,11 +115,6 @@ services:
             $storageDir: '%app.storage_dir%'
             $rawPreviewExtractor: '@RonanLenouvel\RawPreviewExtractor\RawPreviewExtractorInterface'
 
-    App\DataFixtures\AppFixtures:
-        arguments:
-            $storageDir: '%app.storage_dir%'
-            $projectDir: '%kernel.project_dir%'
-
     App\EventListener\SecurityHeadersListener:
         arguments:
             $env: '%kernel.environment%'
@@ -129,6 +126,13 @@ services:
     App\State\ShareProcessor:
         arguments:
             $shareCreationLimiter: '@limiter.share_creation'
+
+when@dev:
+    services:
+        App\DataFixtures\AppFixtures:
+            arguments:
+                $storageDir: '%app.storage_dir%'
+                $projectDir: '%kernel.project_dir%'
 
 when@test:
     services:


### PR DESCRIPTION
## Problème

`AppFixtures` étend `Fixture` de `DoctrineFixturesBundle`, un paquet `require-dev` absent après `composer install --no-dev` en production. Le container Symfony échoue à compiler en prod avec :

```
Service id "App\DataFixtures\AppFixtures" looks like a FQCN but no corresponding class or interface exists.
```

## Solution

- Exclut `src/DataFixtures/` de la découverte automatique globale dans `services.yaml`
- Déplace la déclaration explicite `AppFixtures` sous `when@dev:` uniquement

## Test plan

- [ ] `php bin/console cache:clear --env=prod` passe sans erreur en local ✅
- [ ] La CI passe (tests PHPUnit)
- [ ] `deploy.sh --update` sur ronan.lenouvel.me se termine sans erreur