### PR TITLE
fix(deploy): corriger le parsing de .deploy-targets

### DIFF
--- a/bin/deploy-all.sh
+++ b/bin/deploy-all.sh
@@ -61,7 +61,7 @@ if [[ ! -f "$TARGETS_FILE" ]]; then
     exit 1
 fi
 
-mapfile -t TARGETS < <(grep -v '^\s*#' "$TARGETS_FILE" | grep -v '^\s*$' | tr -d '[:space:]')
+mapfile -t TARGETS < <(grep -v '^\s*#' "$TARGETS_FILE" | grep -v '^\s*$' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
 if [[ ${#TARGETS[@]} -eq 0 ]]; then
     error "Aucune cible trouvée dans .deploy-targets"


### PR DESCRIPTION
## Problème

`tr -d '[:space:]'` dans `deploy-all.sh` supprimait les retours à la ligne en plus des espaces, fusionnant tous les prénoms du fichier `.deploy-targets` en un seul token (`ronanyannick`).

## Solution

Remplacé par `sed 's/^[[:space:]]*//;s/[[:space:]]*$//'` qui ne retire que les espaces en début et fin de chaque ligne, en préservant les sauts de ligne.

## Test plan

- [ ] `bash bin/deploy-all.sh` déploie bien 2 instances séparées ✅ (validé en local)