### PR TITLE
fix(deploy): créer var/log manquant sur les instances o2switch

### DIFF
--- a/.claude/deploiement.md
+++ b/.claude/deploiement.md
@@ -204,3 +204,4 @@ JWT_PASSPHRASE=
 | DB access denied                     | `.env.local` incorrect           | Vérifier `DATABASE_URL` et mot de passe cPanel               |
 | SSH refusé                           | IP non whitelistée               | cPanel → Accès SSH → Autorisation SSH                        |
 | Pas de vignette/EXIF dans la Galerie | Worker Messenger absent          | Vérifier la tâche cron (voir « Worker Messenger » ci-dessus) |
+| Messages Messenger jamais consommés (`messenger:stats` ne baisse jamais) | `var/log/` absent sur le serveur | Le cron redirige vers `var/log/messenger.log` (`>>`) : si le dossier n'existe pas, la redirection échoue et **la commande PHP ne s'exécute jamais**, sans erreur visible. `mkdir -p var/log` (corrigé dans `bin/deploy-all.sh` depuis le 2026-07-18, mais les instances déployées avant cette date doivent l'avoir manuellement). |

--- a/bin/deploy-all.sh
+++ b/bin/deploy-all.sh
@@ -136,6 +136,7 @@ for PRENOM in "${TARGETS[@]}"; do
             mkdir -p ${DEPLOY_PATH}
             cd ${DEPLOY_PATH}
             git clone ${GIT_REPO} .
+            mkdir -p var/log
             cat > .env.local <<'ENVEOF'
 APP_ENV=prod
 APP_SECRET=${APP_SECRET}
@@ -167,6 +168,7 @@ ENVEOF
         if ssh ${SSH_KEY_OPTS} -p "${SSH_PORT}" "${SSH_USER}@${SSH_HOST}" "
             set -e
             cd ${DEPLOY_PATH}
+            mkdir -p var/log
             git pull origin ${GIT_BRANCH}
             ${COMPOSER_BIN} install --no-interaction --prefer-dist --no-progress --no-dev
             ${PHP_BIN} bin/console cache:clear --env=prod


### PR DESCRIPTION
## Summary
- 5 des 6 instances o2switch (coralie, elea, corentin, damien, yannick) n'avaient pas `var/log/` → le cron du worker Messenger échouait silencieusement à chaque exécution (`>> var/log/messenger.log` sur un dossier inexistant), aucune file n'était jamais consommée.
- Corrigé manuellement en SSH sur les 5 instances concernées.
- `mkdir -p var/log` ajouté dans `bin/deploy-all.sh` (init + update) pour que ça ne se reproduise pas.
- Documenté dans `.claude/deploiement.md`.

## Test plan
- [x] Vérifié l'absence de `var/log` sur 5/6 instances, créé manuellement
- [x] Pas de changement de code applicatif — script de déploiement et doc uniquement