### PR TITLE
perf(upload): exif_thumbnail() + traitement immédiat post-upload (kernel.terminate)

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -116,10 +116,13 @@ services:
 
     App\Interface\RawPreviewCacheInterface: '@App\Service\RawPreviewCache'
 
+    App\Interface\ExifThumbnailExtractorInterface: '@App\Service\ExifThumbnailExtractor'
+
     App\Service\ThumbnailService:
         arguments:
             $storageDir: '%app.storage_dir%'
             $rawPreviewExtractor: '@RonanLenouvel\RawPreviewExtractor\RawPreviewExtractorInterface'
+            $exifThumbnailExtractor: '@App\Interface\ExifThumbnailExtractorInterface'
 
     App\EventListener\SecurityHeadersListener:
         arguments:

--- a/src/Controller/Api/FileUploadController.php
+++ b/src/Controller/Api/FileUploadController.php
@@ -7,6 +7,7 @@ namespace App\Controller\Api;
 use App\ApiResource\FileOutput;
 use App\Message\MediaProcessMessage;
 use App\Service\CreateFileService;
+use App\Service\PendingMediaProcessingCollector;
 use App\State\FileProvider;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -40,6 +41,7 @@ final class FileUploadController extends AbstractController
         private readonly FileProvider $provider,
         private readonly SerializerInterface $serializer,
         private readonly MessageBusInterface $bus,
+        private readonly PendingMediaProcessingCollector $pendingMediaProcessingCollector,
     ) {}
 
     /**
@@ -73,10 +75,13 @@ final class FileUploadController extends AbstractController
             $request->request->get('newFolderName'),
         );
 
-        // Dispatch async si c'est un média (image/* ou video/*)
+        // Dispatch async (filet de sécurité) + traitement immédiat après la
+        // réponse HTTP (kernel.terminate, cf. ProcessPendingMediaListener) :
+        // le worker Messenger reste le secours si ce dernier échoue.
         $mimeType = $file->getMimeType();
         if (str_starts_with($mimeType, 'image/') || str_starts_with($mimeType, 'video/')) {
             $this->bus->dispatch(new MediaProcessMessage((string) $file->getId()));
+            $this->pendingMediaProcessingCollector->add((string) $file->getId());
         }
 
         $output = $this->provider->toOutput($file);

--- a/src/EventListener/ProcessPendingMediaListener.php
+++ b/src/EventListener/ProcessPendingMediaListener.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener;
+
+use App\Interface\MediaProcessorInterface;
+use App\Repository\FileRepository;
+use App\Service\PendingMediaProcessingCollector;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Traite les médias tout juste uploadés une fois la réponse HTTP envoyée.
+ *
+ * kernel.terminate se déclenche après que le client a déjà reçu la réponse
+ * (rien n'ajoute de latence perçue) : c'est là qu'on génère la vignette et
+ * qu'on extrait l'EXIF, au lieu d'attendre le prochain cycle du worker
+ * Messenger, potentiellement plusieurs minutes plus tard selon la charge du
+ * cron (cf. #251).
+ *
+ * MediaProcessor::process() est idempotent : si le worker traite quand même
+ * ce même fichier plus tard (secours en cas d'échec de ce listener), il ne
+ * fait rien de plus qu'un no-op.
+ */
+#[AsEventListener(event: KernelEvents::TERMINATE)]
+final class ProcessPendingMediaListener
+{
+    public function __construct(
+        private readonly PendingMediaProcessingCollector $collector,
+        #[Autowire(lazy: true)]
+        private readonly FileRepository $fileRepository,
+        #[Autowire(lazy: true)]
+        private readonly MediaProcessorInterface $mediaProcessor,
+    ) {}
+
+    public function __invoke(TerminateEvent $event): void
+    {
+        $fileIds = $this->collector->drain();
+        if ($fileIds === []) {
+            // Aucun upload média dans cette requête : ne pas instancier
+            // FileRepository/MediaProcessor (et leurs dépendances, dont
+            // StorageService) pour rien sur chaque requête de l'application.
+            return;
+        }
+
+        foreach ($fileIds as $fileId) {
+            $file = $this->fileRepository->find(Uuid::fromString($fileId));
+            if ($file === null) {
+                continue;
+            }
+
+            $this->mediaProcessor->process($file);
+        }
+    }
+}

--- a/src/Interface/ExifThumbnailExtractorInterface.php
+++ b/src/Interface/ExifThumbnailExtractorInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Service\ExifThumbnail;
+
+/**
+ * Extrait la miniature embarquée dans les métadonnées EXIF d'un JPEG.
+ *
+ * La plupart des JPEG issus d'un appareil photo ou d'un scanner embarquent
+ * déjà une petite miniature (souvent 160x120) dans leur IFD1. La récupérer
+ * évite de décoder l'image pleine résolution avec GD juste pour en tirer une
+ * vignette de 320px — un décodage qui, sur un scan haute résolution, peut à
+ * lui seul saturer la mémoire allouée au worker.
+ */
+interface ExifThumbnailExtractorInterface
+{
+    /**
+     * @param string $absolutePath Chemin absolu du JPEG source
+     */
+    public function extract(string $absolutePath): ?ExifThumbnail;
+}

--- a/src/Service/ExifThumbnail.php
+++ b/src/Service/ExifThumbnail.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use RonanLenouvel\RawPreviewExtractor\Orientation;
+
+/**
+ * Miniature EXIF extraite, avec l'orientation enregistrée par l'appareil.
+ *
+ * La miniature est stockée telle quelle par l'appareil, non redressée — même
+ * logique que {@see \RonanLenouvel\RawPreviewExtractor\ExtractedPreview} pour
+ * les RAW : c'est à l'appelant d'appliquer la rotation.
+ */
+final readonly class ExifThumbnail
+{
+    public function __construct(
+        public string $jpegData,
+        public Orientation $orientation,
+    ) {}
+}

--- a/src/Service/ExifThumbnailExtractor.php
+++ b/src/Service/ExifThumbnailExtractor.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Interface\ExifThumbnailExtractorInterface;
+use RonanLenouvel\RawPreviewExtractor\Orientation;
+
+/**
+ * Implémentation réelle : lit la miniature IFD1 et l'orientation via
+ * l'extension native `ext-exif` (déjà une dépendance requise du projet).
+ */
+final class ExifThumbnailExtractor implements ExifThumbnailExtractorInterface
+{
+    public function extract(string $absolutePath): ?ExifThumbnail
+    {
+        if (!function_exists('exif_thumbnail')) {
+            return null;
+        }
+
+        $jpegData = @exif_thumbnail($absolutePath);
+        if ($jpegData === false) {
+            return null;
+        }
+
+        $exif = @exif_read_data($absolutePath);
+        $orientationTag = is_array($exif) && isset($exif['Orientation']) ? (int) $exif['Orientation'] : null;
+
+        return new ExifThumbnail($jpegData, Orientation::fromExif($orientationTag));
+    }
+}

--- a/src/Service/PendingMediaProcessingCollector.php
+++ b/src/Service/PendingMediaProcessingCollector.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+/**
+ * Fait le pont entre le contrôleur d'upload et le listener kernel.terminate.
+ *
+ * Un fichier tout juste uploadé doit être traité (EXIF + vignette) dès que
+ * possible plutôt que d'attendre le prochain cycle du worker Messenger, qui
+ * peut prendre plusieurs minutes selon la charge du cron (cf. #251). Le
+ * contrôleur enregistre l'id ici ; le listener le lit après l'envoi de la
+ * réponse HTTP, sans faire attendre l'utilisateur.
+ *
+ * Un service normal suffit : une requête = un conteneur = une instance, pas
+ * de fuite d'un utilisateur à l'autre.
+ */
+final class PendingMediaProcessingCollector
+{
+    /** @var list<string> */
+    private array $fileIds = [];
+
+    public function add(string $fileId): void
+    {
+        $this->fileIds[] = $fileId;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function drain(): array
+    {
+        $fileIds = $this->fileIds;
+        $this->fileIds = [];
+
+        return $fileIds;
+    }
+}

--- a/src/Service/ThumbnailService.php
+++ b/src/Service/ThumbnailService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Interface\ExifThumbnailExtractorInterface;
 use RonanLenouvel\RawPreviewExtractor\Exception\RawPreviewExtractorException;
 use RonanLenouvel\RawPreviewExtractor\Orientation;
 use RonanLenouvel\RawPreviewExtractor\RawPreviewExtractorInterface;
@@ -33,6 +34,7 @@ class ThumbnailService
     public function __construct(
         private readonly string $storageDir,
         private readonly RawPreviewExtractorInterface $rawPreviewExtractor,
+        private readonly ExifThumbnailExtractorInterface $exifThumbnailExtractor,
     ) {}
 
     /**
@@ -88,9 +90,22 @@ class ThumbnailService
 
     /**
      * Génère le thumbnail depuis un fichier image en clair.
+     *
+     * La plupart des JPEG embarquent déjà une miniature dans leur IFD1 EXIF :
+     * l'utiliser évite de décoder l'image pleine résolution avec GD, un
+     * décodage qui peut à lui seul saturer la mémoire du worker sur un scan
+     * haute résolution. Repli sur le décodage complet si elle est absente.
      */
     private function generateFromPlain(string $plainPath): ?string
     {
+        $exifThumbnail = $this->exifThumbnailExtractor->extract($plainPath);
+        if ($exifThumbnail !== null) {
+            $source = @imagecreatefromstring($exifThumbnail->jpegData);
+            if ($source !== false) {
+                return $this->resizeAndSave($source, $exifThumbnail->orientation);
+            }
+        }
+
         // Vérifier les dimensions AVANT de charger l'image en mémoire GD
         // Une image 100000x100000 peut allouer des dizaines de Go RAM (GD bomb)
         $size = @getimagesize($plainPath);

--- a/tests/Api/FileUploadTriggersImmediateMediaProcessingTest.php
+++ b/tests/Api/FileUploadTriggersImmediateMediaProcessingTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Media;
+use App\Entity\User;
+use App\Tests\AuthenticatedApiTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * L'upload dispatchait MediaProcessMessage sur le transport async : sans
+ * worker qui dépile (ou en attendant le prochain cycle de cron), la vignette
+ * n'apparaissait jamais avant plusieurs minutes — inutilisable pour un
+ * multi-upload réel (cf. #251).
+ *
+ * Le traitement est désormais aussi déclenché immédiatement après la réponse
+ * HTTP (kernel.terminate), sans attendre le worker : le Media doit exister
+ * dès la fin de la requête de test, sans consommer explicitement la file.
+ */
+final class FileUploadTriggersImmediateMediaProcessingTest extends AuthenticatedApiTestCase
+{
+    private User $alice;
+    private Folder $folder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->alice = $this->createUser('alice-immediate@example.com', 'password123', 'Alice');
+        $this->folder = $this->createFolder('TestFolder', $this->alice);
+    }
+
+    public function testMediaExistsImmediatelyAfterUploadWithoutConsumingTheQueue(): void
+    {
+        $client = $this->createAuthenticatedKernelBrowser($this->alice);
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'test_upload_');
+        $image = imagecreatetruecolor(200, 150);
+        imagejpeg($image, $tempFile);
+        imagedestroy($image);
+
+        $uploadedFile = new UploadedFile($tempFile, 'photo.jpg', 'image/jpeg', null, false);
+
+        $client->request(
+            'POST',
+            '/api/v1/files',
+            [
+                'ownerId'  => (string) $this->alice->getId(),
+                'folderId' => (string) $this->folder->getId(),
+            ],
+            ['file' => $uploadedFile],
+            ['CONTENT_TYPE' => 'multipart/form-data'],
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+        @unlink($tempFile);
+
+        $response = json_decode((string) $client->getResponse()->getContent(), true);
+        $fileId = (string) $response['id'];
+
+        $file = $this->em->getRepository(File::class)->find(Uuid::fromString($fileId));
+        $this->assertNotNull($file);
+
+        $media = $this->em->getRepository(Media::class)->findOneBy(['file' => $file]);
+
+        $this->assertNotNull(
+            $media,
+            'Le Media doit exister immédiatement après la requête, sans consommer la file Messenger'
+        );
+        $this->assertNotNull($media->getThumbnailPath(), 'La vignette doit être générée dans la foulée');
+    }
+}

--- a/tests/Service/ThumbnailServiceExifThumbnailTest.php
+++ b/tests/Service/ThumbnailServiceExifThumbnailTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Interface\ExifThumbnailExtractorInterface;
+use App\Service\ExifThumbnail;
+use App\Service\ThumbnailService;
+use PHPUnit\Framework\TestCase;
+use RonanLenouvel\RawPreviewExtractor\Orientation;
+use RonanLenouvel\RawPreviewExtractor\RawPreviewExtractorInterface;
+
+/**
+ * Décoder une image pleine résolution avec GD juste pour en tirer une
+ * vignette de 320px peut à lui seul saturer la mémoire du worker sur un scan
+ * haute résolution (observé en prod : un seul fichier par cycle de cron de
+ * 5 min). La plupart des JPEG embarquent déjà une miniature EXIF (IFD1) : on
+ * l'utilise en priorité, avec repli sur le décodage GD complet si absente.
+ */
+final class ThumbnailServiceExifThumbnailTest extends TestCase
+{
+    private string $storageDir;
+
+    protected function setUp(): void
+    {
+        $this->storageDir = sys_get_temp_dir() . '/hc-thumb-exif-' . uniqid();
+        mkdir($this->storageDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $thumbsDir = $this->storageDir . '/thumbs';
+        if (is_dir($thumbsDir)) {
+            foreach (glob($thumbsDir . '/*') ?: [] as $file) {
+                unlink($file);
+            }
+            rmdir($thumbsDir);
+        }
+        foreach (glob($this->storageDir . '/*') ?: [] as $file) {
+            unlink($file);
+        }
+        if (is_dir($this->storageDir)) {
+            rmdir($this->storageDir);
+        }
+    }
+
+    private function makeJpeg(int $width, int $height): string
+    {
+        $image = imagecreatetruecolor($width, $height);
+        ob_start();
+        imagejpeg($image);
+        $data = (string) ob_get_clean();
+        imagedestroy($image);
+
+        return $data;
+    }
+
+    private function makePlainFile(): string
+    {
+        $path = $this->storageDir . '/photo.jpg';
+        file_put_contents($path, $this->makeJpeg(2000, 1500));
+
+        return $path;
+    }
+
+    private function service(ExifThumbnailExtractorInterface $exifExtractor): ThumbnailService
+    {
+        $rawExtractor = $this->createMock(RawPreviewExtractorInterface::class);
+        $rawExtractor->method('supports')->willReturn(false);
+
+        return new ThumbnailService($this->storageDir, $rawExtractor, $exifExtractor);
+    }
+
+    public function testUsesEmbeddedExifThumbnailWhenPresent(): void
+    {
+        $path = $this->makePlainFile();
+
+        $exifExtractor = $this->createMock(ExifThumbnailExtractorInterface::class);
+        $exifExtractor->expects($this->once())->method('extract')->with($path)->willReturn(
+            new ExifThumbnail($this->makeJpeg(160, 120), Orientation::Normal),
+        );
+
+        $thumb = $this->service($exifExtractor)->generate($path);
+
+        $this->assertNotNull($thumb, 'Une miniature EXIF présente doit produire une vignette');
+        $this->assertFileExists($this->storageDir . '/' . $thumb);
+    }
+
+    public function testFallsBackToFullGdDecodeWhenNoExifThumbnail(): void
+    {
+        $path = $this->makePlainFile();
+
+        $exifExtractor = $this->createMock(ExifThumbnailExtractorInterface::class);
+        $exifExtractor->method('extract')->willReturn(null);
+
+        $thumb = $this->service($exifExtractor)->generate($path);
+
+        $this->assertNotNull($thumb, 'Le repli GD complet doit continuer à fonctionner');
+    }
+
+    public function testRotatesExifThumbnailAccordingToItsOrientation(): void
+    {
+        $path = $this->makePlainFile();
+
+        // Miniature stockée couchée (téléphone tenu à la verticale) : la
+        // vignette finale doit ressortir en portrait, comme pour les RAW.
+        $exifExtractor = $this->createMock(ExifThumbnailExtractorInterface::class);
+        $exifExtractor->method('extract')->willReturn(
+            new ExifThumbnail($this->makeJpeg(160, 120), Orientation::Rotate90),
+        );
+
+        $thumb = $this->service($exifExtractor)->generate($path);
+
+        $this->assertNotNull($thumb);
+        $size = getimagesize($this->storageDir . '/' . $thumb);
+        $this->assertNotFalse($size);
+
+        [$width, $height] = $size;
+        $this->assertGreaterThan($width, $height, 'Une miniature Rotate90 doit ressortir en portrait');
+    }
+}

--- a/tests/Service/ThumbnailServiceRawTest.php
+++ b/tests/Service/ThumbnailServiceRawTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Service;
 
+use App\Interface\ExifThumbnailExtractorInterface;
 use App\Service\ThumbnailService;
 use PHPUnit\Framework\TestCase;
 use RonanLenouvel\RawPreviewExtractor\Exception\PreviewNotFoundException;
@@ -63,6 +64,19 @@ final class ThumbnailServiceRawTest extends TestCase
     }
 
     /**
+     * Ces tests couvrent le pipeline RAW, pas la miniature EXIF : l'extracteur
+     * EXIF est doublé pour toujours renvoyer null (pas de raccourci), afin de
+     * garder le comportement RAW existant sous les projecteurs.
+     */
+    private function service(RawPreviewExtractorInterface $rawExtractor): ThumbnailService
+    {
+        $exifExtractor = $this->createMock(ExifThumbnailExtractorInterface::class);
+        $exifExtractor->method('extract')->willReturn(null);
+
+        return new ThumbnailService($this->storageDir, $rawExtractor, $exifExtractor);
+    }
+
+    /**
      * Un faux fichier RAW : le contenu importe peu, l'extracteur est doublé.
      */
     private function makeRawFile(): string
@@ -83,7 +97,7 @@ final class ThumbnailServiceRawTest extends TestCase
             new ExtractedPreview($this->makeJpeg(800, 600), 800, 600, Format::NEF),
         );
 
-        $service = new ThumbnailService($this->storageDir, $extractor);
+        $service = $this->service($extractor);
         $thumb = $service->generate($rawPath);
 
         $this->assertNotNull($thumb, 'Un RAW avec preview embarquée doit produire une vignette');
@@ -99,7 +113,7 @@ final class ThumbnailServiceRawTest extends TestCase
         $extractor->method('supports')->willReturn(true);
         $extractor->method('extract')->willThrowException(new PreviewNotFoundException('no preview'));
 
-        $service = new ThumbnailService($this->storageDir, $extractor);
+        $service = $this->service($extractor);
 
         // Dégradation gracieuse : pas de vignette, mais pas d'exception non plus.
         $this->assertNull($service->generate($rawPath));
@@ -120,7 +134,7 @@ final class ThumbnailServiceRawTest extends TestCase
             new ExtractedPreview($this->makeJpeg(900, 600), 900, 600, Format::NEF, Orientation::Rotate90),
         );
 
-        $service = new ThumbnailService($this->storageDir, $extractor);
+        $service = $this->service($extractor);
         $thumb = $service->generate($rawPath);
 
         $this->assertNotNull($thumb);
@@ -145,7 +159,7 @@ final class ThumbnailServiceRawTest extends TestCase
         $extractor->method('supports')->willReturn(false);
         $extractor->expects($this->never())->method('extract');
 
-        $service = new ThumbnailService($this->storageDir, $extractor);
+        $service = $this->service($extractor);
         $thumb = $service->generate($jpegPath);
 
         $this->assertNotNull($thumb, 'Le pipeline GD existant doit continuer à fonctionner');

--- a/tests/Service/ThumbnailServiceRealRawTest.php
+++ b/tests/Service/ThumbnailServiceRealRawTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Service;
 
+use App\Interface\ExifThumbnailExtractorInterface;
 use App\Service\ThumbnailService;
 use PHPUnit\Framework\TestCase;
 use RonanLenouvel\RawPreviewExtractor\Orientation;
@@ -69,9 +70,13 @@ final class ThumbnailServiceRealRawTest extends TestCase
 
     public function testGeneratesUprightThumbnailFromRealNef(): void
     {
+        $exifExtractor = $this->createMock(ExifThumbnailExtractorInterface::class);
+        $exifExtractor->method('extract')->willReturn(null);
+
         $service = new ThumbnailService(
             $this->storageDir,
             RawPreviewExtractor::createDefault(),
+            $exifExtractor,
         );
 
         $thumb = $service->generate(self::FIXTURE);


### PR DESCRIPTION
Closes #251

## Summary
- **exif_thumbnail() avant décodage GD complet** : la plupart des JPEG embarquent déjà une miniature dans leur IFD1 EXIF. `ThumbnailService` l'utilise en priorité (nouveau `ExifThumbnailExtractor`, via `ext-exif` déjà requis), avec repli inchangé sur le décodage GD complet si absente. Évite de décoder une image pleine résolution juste pour en tirer une vignette de 320px — un décodage qui, sur un scan haute résolution, pouvait à lui seul saturer la mémoire du worker (observé en prod : 1 seule photo traitée par cycle de cron de 5 min).
- **Traitement immédiat après la réponse HTTP** : `FileUploadController` enregistre le fichier dans un nouveau `PendingMediaProcessingCollector`, en plus du dispatch async existant (gardé comme filet de sécurité). `ProcessPendingMediaListener`, sur `kernel.terminate`, traite ces fichiers juste après l'envoi de la réponse au client — latence perçue nulle, vignette prête en quelques secondes au lieu de dépendre du prochain cycle de cron. `MediaProcessor::process()` étant idempotent, un traitement en double par le worker ne fait rien de plus qu'un no-op.
- `FileRepository`/`MediaProcessorInterface` injectés en lazy (`#[Autowire(lazy: true)]`) dans le listener pour ne jamais être instanciés sur les requêtes qui n'uploadent aucun média.

## Test plan
- [x] Tests RED→GREEN : `ThumbnailServiceExifThumbnailTest` (présence/absence/orientation de la miniature EXIF)
- [x] Test RED→GREEN : `FileUploadTriggersImmediateMediaProcessingTest` — le Media existe immédiatement après la requête d'upload, sans consommer la file Messenger
- [x] Suite PHPUnit complète : 741/741 tests verts (1 échec préexistant sans rapport, `TailwindBuildTest`, assets non compilés dans cet environnement)
- [x] Suite Jest complète : 71/71 tests verts