### PR TITLE
feat(media): commande app:media:process-missing pour rattraper les vignettes manquantes

### DIFF
--- a/src/Command/MediaProcessMissingCommand.php
+++ b/src/Command/MediaProcessMissingCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Interface\FileRepositoryInterface;
+use App\Interface\MediaProcessorInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Rattrape les fichiers restés sans Media (donc sans vignette en Galerie).
+ *
+ * Cas d'usage : des fichiers uploadés via un chemin qui ne dispatchait pas
+ * MediaProcessMessage (ex : route web legacy avant correction) restent
+ * indéfiniment sans vignette, le worker ne les voyant jamais passer.
+ * MediaProcessor::process() étant idempotent, relancer cette commande sans
+ * rien à traiter est sans risque.
+ */
+#[AsCommand(name: 'app:media:process-missing', description: 'Traite les fichiers restés sans Media (vignette manquante)')]
+final class MediaProcessMissingCommand extends Command
+{
+    public function __construct(
+        private readonly FileRepositoryInterface $fileRepository,
+        private readonly MediaProcessorInterface $mediaProcessor,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $files = $this->fileRepository->findWithoutMedia();
+
+        $processed = 0;
+        $skipped = 0;
+
+        foreach ($files as $file) {
+            if ($this->mediaProcessor->process($file) !== null) {
+                ++$processed;
+            } else {
+                ++$skipped;
+            }
+        }
+
+        $io->writeln(sprintf('%d traité(s), %d ignoré(s) (type non média).', $processed, $skipped));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Interface/FileRepositoryInterface.php
+++ b/src/Interface/FileRepositoryInterface.php
@@ -24,4 +24,15 @@ interface FileRepositoryInterface
     public function findById(Uuid $id): ?File;
 
     public function findOneByNameInFolder(string $name, Folder $folder): ?File;
+
+    /**
+     * Fichiers sans Media associé — candidats à un (re)traitement EXIF/vignette.
+     *
+     * Ne filtre pas par mimeType ici : MediaProcessor::process() sait déjà
+     * décider en un accès mémoire (resolveMediaType()) si un fichier est
+     * pertinent, sans toucher au disque pour ceux qu'il écarte (PDF, etc.).
+     *
+     * @return list<File>
+     */
+    public function findWithoutMedia(): array;
 }

--- a/src/Repository/FileRepository.php
+++ b/src/Repository/FileRepository.php
@@ -134,4 +134,13 @@ class FileRepository extends ServiceEntityRepository implements FileRepositoryIn
             ->getQuery()
             ->getResult();
     }
+
+    public function findWithoutMedia(): array
+    {
+        return $this->createQueryBuilder('f')
+            ->leftJoin(\App\Entity\Media::class, 'm', 'WITH', 'm.file = f')
+            ->andWhere('m.id IS NULL')
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/tests/Command/MediaProcessMissingCommandTest.php
+++ b/tests/Command/MediaProcessMissingCommandTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\MediaProcessMissingCommand;
+use App\Entity\File;
+use App\Entity\Media;
+use App\Interface\FileRepositoryInterface;
+use App\Interface\MediaProcessorInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Rattrapage des fichiers restés sans Media : constaté sur une instance de
+ * prod, des photos uploadées via une route qui ne dispatchait pas
+ * MediaProcessMessage (avant le fix async post-upload, cf. #251) n'ont
+ * jamais reçu de vignette. MediaProcessor::process() étant idempotent, cette
+ * commande peut aussi servir de filet de sécurité récurrent.
+ */
+final class MediaProcessMissingCommandTest extends TestCase
+{
+    public function testProcessesEachFileWithoutMedia(): void
+    {
+        $photo = $this->createMock(File::class);
+        $pdf = $this->createMock(File::class);
+
+        $fileRepository = $this->createMock(FileRepositoryInterface::class);
+        $fileRepository->method('findWithoutMedia')->willReturn([$photo, $pdf]);
+
+        $mediaProcessor = $this->createMock(MediaProcessorInterface::class);
+        $mediaProcessor->expects($this->exactly(2))
+            ->method('process')
+            ->willReturnCallback(fn (File $file) => $file === $photo ? $this->createMock(Media::class) : null);
+
+        $tester = $this->commandTester($fileRepository, $mediaProcessor);
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('1 traité', $tester->getDisplay());
+        $this->assertStringContainsString('1 ignoré', $tester->getDisplay());
+    }
+
+    public function testReportsNothingToDoWhenNoFileIsMissingMedia(): void
+    {
+        $fileRepository = $this->createMock(FileRepositoryInterface::class);
+        $fileRepository->method('findWithoutMedia')->willReturn([]);
+
+        $mediaProcessor = $this->createMock(MediaProcessorInterface::class);
+        $mediaProcessor->expects($this->never())->method('process');
+
+        $tester = $this->commandTester($fileRepository, $mediaProcessor);
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('0 traité', $tester->getDisplay());
+    }
+
+    private function commandTester(
+        FileRepositoryInterface $fileRepository,
+        MediaProcessorInterface $mediaProcessor,
+    ): CommandTester {
+        $command = new MediaProcessMissingCommand($fileRepository, $mediaProcessor);
+        $application = new Application();
+        $application->addCommand($command);
+
+        return new CommandTester($application->find('app:media:process-missing'));
+    }
+}


### PR DESCRIPTION
## Summary
- Nouvelle commande `app:media:process-missing` : traite tous les `File` sans `Media` associé via `MediaProcessor::process()` (idempotent, safe à relancer).
- Cas d'usage concret : 4 photos sur yannick.lenouvel.me n'ont jamais été mises en file (probablement uploadées via la route web legacy `FileWebController::upload`, qui ne dispatche pas `MediaProcessMessage`, contrairement à `FileUploadController` côté API).
- Ajout de `FileRepository::findWithoutMedia()`.

## Test plan
- [x] Tests RED→GREEN sur `MediaProcessMissingCommandTest` (traite les fichiers pertinents, ignore les non-médias, rapporte "0 traité" si rien à faire)
- [x] Suite PHPUnit complète : 743/743 tests verts (1 échec préexistant sans rapport, `TailwindBuildTest`)