### PR TITLE
fix(#247): logging suppression + RAW en octet-stream + doc pipeline

### DIFF
--- a/.claude/medias.md
+++ b/.claude/medias.md
@@ -36,6 +36,17 @@ Seule la vignette est référencée en base (`Media::$thumbnailPath`). La previe
 upload → CreateFileService → File
                                │
                                ▼
+              mediaProcessor->supports(mimeType, nom) ?
+                               │
+                    ┌──────────┴──────────┐
+                  true                  false
+                    │                      │
+       dispatch async (secours)      rien à faire
+       + PendingMediaProcessingCollector
+                    │
+       kernel.terminate (juste après la réponse HTTP)
+                    │
+                    ▼
                     MediaProcessor::process()
                                │
                     resolveMediaType(mimeType, nom)
@@ -49,7 +60,14 @@ upload → CreateFileService → File
                  Media
 ```
 
-`MediaProcessor` est appelé en asynchrone (Messenger) pour l'upload normal, et en synchrone quand le Media est requis immédiatement (import direct dans un album).
+`supports()` est la **seule source de vérité** pour décider si un fichier mérite un traitement (image/video par mimeType, ou RAW reconnu par extension quand le mimeType ne dit rien) — les deux contrôleurs d'upload (API et web) l'utilisent, pour ne jamais dupliquer cette logique et risquer de l'oublier sur un chemin (déjà arrivé : les RAW en `application/octet-stream` étaient silencieusement ignorés avant).
+
+`MediaProcessor::process()` est appelé :
+- **immédiatement après la réponse HTTP** (`kernel.terminate`, via `PendingMediaProcessingCollector` + `ProcessPendingMediaListener`) — chemin normal depuis #251, latence perçue nulle
+- **en asynchrone** (Messenger, cron) en secours si le traitement immédiat échoue — idempotent, un double traitement ne fait rien de plus qu'un no-op
+- **en synchrone** quand le Media est requis immédiatement pour une autre raison (import direct dans un album, `AlbumImportService`)
+
+`ThumbnailService::generate()` tente d'abord `exif_thumbnail()` (miniature déjà embarquée dans l'IFD1 EXIF de la plupart des JPEG) avant de décoder l'image pleine résolution avec GD — décoder une image haute résolution juste pour en tirer une vignette de 320px peut à lui seul saturer la mémoire du worker.
 
 ---
 

--- a/src/Controller/Api/FileUploadController.php
+++ b/src/Controller/Api/FileUploadController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller\Api;
 
 use App\ApiResource\FileOutput;
+use App\Interface\MediaProcessorInterface;
 use App\Message\MediaProcessMessage;
 use App\Service\CreateFileService;
 use App\Service\PendingMediaProcessingCollector;
@@ -42,6 +43,7 @@ final class FileUploadController extends AbstractController
         private readonly SerializerInterface $serializer,
         private readonly MessageBusInterface $bus,
         private readonly PendingMediaProcessingCollector $pendingMediaProcessingCollector,
+        private readonly MediaProcessorInterface $mediaProcessor,
     ) {}
 
     /**
@@ -78,8 +80,10 @@ final class FileUploadController extends AbstractController
         // Dispatch async (filet de sécurité) + traitement immédiat après la
         // réponse HTTP (kernel.terminate, cf. ProcessPendingMediaListener) :
         // le worker Messenger reste le secours si ce dernier échoue.
-        $mimeType = $file->getMimeType();
-        if (str_starts_with($mimeType, 'image/') || str_starts_with($mimeType, 'video/')) {
+        // supports() couvre aussi les RAW envoyés en application/octet-stream
+        // (mimeType inutile, reconnus par extension) — un simple test
+        // image/*|video/* les aurait ignorés silencieusement.
+        if ($this->mediaProcessor->supports($file->getMimeType(), $file->getOriginalName())) {
             $this->bus->dispatch(new MediaProcessMessage((string) $file->getId()));
             $this->pendingMediaProcessingCollector->add((string) $file->getId());
         }

--- a/src/Controller/Web/FileWebController.php
+++ b/src/Controller/Web/FileWebController.php
@@ -6,6 +6,7 @@ namespace App\Controller\Web;
 
 use App\Entity\File;
 use App\Entity\Share;
+use App\Interface\MediaProcessorInterface;
 use App\Interface\StorageServiceInterface;
 use App\Message\MediaProcessMessage;
 use App\Repository\FileRepository;
@@ -50,6 +51,7 @@ final class FileWebController extends AbstractController
         private readonly GuestRestrictionChecker $guestRestrictionChecker,
         private readonly MessageBusInterface $bus,
         private readonly PendingMediaProcessingCollector $pendingMediaProcessingCollector,
+        private readonly MediaProcessorInterface $mediaProcessor,
     ) {}
 
     #[Route('/files/{id}/download', name: 'app_file_download', methods: ['GET'])]
@@ -133,8 +135,10 @@ final class FileWebController extends AbstractController
 
         // Dispatch async (filet de sécurité) + traitement immédiat après la
         // réponse HTTP (kernel.terminate, cf. ProcessPendingMediaListener) —
-        // même mécanisme que FileUploadController (API).
-        if (str_starts_with($mimeType, 'image/') || str_starts_with($mimeType, 'video/')) {
+        // même mécanisme que FileUploadController (API). supports() couvre
+        // aussi les RAW envoyés en application/octet-stream (reconnus par
+        // extension) — un simple test image/*|video/* les aurait ignorés.
+        if ($this->mediaProcessor->supports($mimeType, $originalName)) {
             $this->bus->dispatch(new MediaProcessMessage((string) $file->getId()));
             $this->pendingMediaProcessingCollector->add((string) $file->getId());
         }

--- a/src/Interface/MediaProcessorInterface.php
+++ b/src/Interface/MediaProcessorInterface.php
@@ -14,4 +14,11 @@ interface MediaProcessorInterface
      * Retourne null si le type MIME du fichier n'est pas un média supporté.
      */
     public function process(File $file): ?Media;
+
+    /**
+     * Un fichier mérite-t-il un Media, sans toucher au disque ? Permet aux
+     * appelants (contrôleurs d'upload) de décider s'il faut dispatcher/traiter
+     * sans dupliquer la logique de reconnaissance (mimeType + extensions RAW).
+     */
+    public function supports(string $mimeType, string $originalName): bool;
 }

--- a/src/Service/FileActionService.php
+++ b/src/Service/FileActionService.php
@@ -12,6 +12,7 @@ use App\Interface\FileRepositoryInterface;
 use App\Interface\StorageServiceInterface;
 use App\Service\FilenameValidator;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
@@ -34,6 +35,7 @@ final class FileActionService implements FileActionServiceInterface
         private readonly AuthorizationCheckerInterface $authChecker,
         private readonly EntityManagerInterface $em,
         private readonly FilenameValidator $filenameValidator,
+        private readonly LoggerInterface $logger,
     ) {}
 
     /**
@@ -93,8 +95,17 @@ final class FileActionService implements FileActionServiceInterface
         try {
             $this->storageService->delete($file->getPath());
         } catch (\Exception $e) {
-            // Log: disk file missing is not critical
-            // TODO: Add logger to log this
+            // Non bloquant : l'entité doit rester supprimable même si le
+            // fichier physique a déjà disparu. On logue quand même, pour
+            // distinguer ce cas attendu d'un vrai souci disque récurrent.
+            $this->logger->warning(
+                sprintf('Échec de suppression disque pour le fichier "%s"', $file->getOriginalName()),
+                [
+                    'path' => $file->getPath(),
+                    'fileId' => (string) $file->getId(),
+                    'exception' => $e->getMessage(),
+                ],
+            );
         }
 
         // 2. Remove entity (cascade rules will handle Media cleanup if configured)

--- a/src/Service/MediaProcessor.php
+++ b/src/Service/MediaProcessor.php
@@ -86,6 +86,18 @@ final class MediaProcessor implements MediaProcessorInterface
         return $media;
     }
 
+    /**
+     * Un fichier mérite-t-il un Media (photo/vidéo), sans toucher au disque ?
+     *
+     * Seule source de vérité pour cette décision — les contrôleurs d'upload
+     * l'utilisent pour savoir s'il faut dispatcher/traiter, plutôt que de
+     * dupliquer la logique image/video + extensions RAW à chaque appelant.
+     */
+    public function supports(string $mimeType, string $originalName): bool
+    {
+        return $this->resolveMediaType($mimeType, $originalName) !== null;
+    }
+
     private function resolveMediaType(string $mimeType, string $originalName): ?string
     {
         foreach (self::MEDIA_MIME_TYPES as $prefix => $type) {

--- a/tests/Api/FileUploadTriggersImmediateMediaProcessingTest.php
+++ b/tests/Api/FileUploadTriggersImmediateMediaProcessingTest.php
@@ -73,4 +73,88 @@ final class FileUploadTriggersImmediateMediaProcessingTest extends Authenticated
         );
         $this->assertNotNull($media->getThumbnailPath(), 'La vignette doit être générée dans la foulée');
     }
+
+    /**
+     * Les navigateurs n'ont pas de mimeType pour les RAW et envoient
+     * "application/octet-stream" (cf. commentaire de MediaProcessor sur
+     * RAW_EXTENSIONS). Si le dispatch se limite à `image/*`/`video/*`, un
+     * upload RAW via l'API ne crée jamais de Media — la reconnaissance par
+     * extension de MediaProcessor ne sert à rien si le message ne part
+     * jamais.
+     */
+    public function testRawUploadWithOctetStreamMimeTypeStillCreatesMedia(): void
+    {
+        $client = $this->createAuthenticatedKernelBrowser($this->alice);
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'test_raw_');
+        file_put_contents($tempFile, 'not-a-real-raw-file-content');
+
+        $uploadedFile = new UploadedFile($tempFile, 'photo.nef', 'application/octet-stream', null, false);
+
+        $client->request(
+            'POST',
+            '/api/v1/files',
+            [
+                'ownerId'  => (string) $this->alice->getId(),
+                'folderId' => (string) $this->folder->getId(),
+            ],
+            ['file' => $uploadedFile],
+            ['CONTENT_TYPE' => 'multipart/form-data'],
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+        @unlink($tempFile);
+
+        $response = json_decode((string) $client->getResponse()->getContent(), true);
+        $fileId = (string) $response['id'];
+
+        $file = $this->em->getRepository(File::class)->find(Uuid::fromString($fileId));
+        $this->assertNotNull($file);
+
+        $media = $this->em->getRepository(Media::class)->findOneBy(['file' => $file]);
+
+        $this->assertNotNull(
+            $media,
+            'Un RAW envoyé en application/octet-stream doit quand même produire un Media (reconnu par extension)'
+        );
+        $this->assertSame('photo', $media->getMediaType());
+    }
+
+    /**
+     * Symétrique du test PDF côté dispatch (MediaTest::testUploadNonImageDoesNotDispatchMediaMessage) :
+     * ferme la boucle côté traitement immédiat (kernel.terminate) introduit pour #251.
+     */
+    public function testPdfUploadNeverCreatesMedia(): void
+    {
+        $client = $this->createAuthenticatedKernelBrowser($this->alice);
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'test_pdf_');
+        file_put_contents($tempFile, '%PDF-1.4 fake content');
+
+        $uploadedFile = new UploadedFile($tempFile, 'doc.pdf', 'application/pdf', null, false);
+
+        $client->request(
+            'POST',
+            '/api/v1/files',
+            [
+                'ownerId'  => (string) $this->alice->getId(),
+                'folderId' => (string) $this->folder->getId(),
+            ],
+            ['file' => $uploadedFile],
+            ['CONTENT_TYPE' => 'multipart/form-data'],
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+        @unlink($tempFile);
+
+        $response = json_decode((string) $client->getResponse()->getContent(), true);
+        $fileId = (string) $response['id'];
+
+        $file = $this->em->getRepository(File::class)->find(Uuid::fromString($fileId));
+        $this->assertNotNull($file);
+
+        $media = $this->em->getRepository(Media::class)->findOneBy(['file' => $file]);
+
+        $this->assertNull($media, 'Un PDF ne doit jamais produire de Media');
+    }
 }

--- a/tests/Service/FileActionServiceTest.php
+++ b/tests/Service/FileActionServiceTest.php
@@ -13,6 +13,7 @@ use App\Service\FileActionService;
 use App\Service\FilenameValidator;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
@@ -22,6 +23,7 @@ class FileActionServiceTest extends TestCase
     private StorageServiceInterface $storageService;
     private AuthorizationCheckerInterface $authChecker;
     private EntityManagerInterface $em;
+    private LoggerInterface $logger;
 
     protected function setUp(): void
     {
@@ -29,6 +31,7 @@ class FileActionServiceTest extends TestCase
         $this->storageService = $this->createMock(StorageServiceInterface::class);
         $this->authChecker = $this->createMock(AuthorizationCheckerInterface::class);
         $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
 
         $this->service = new FileActionService(
             $this->createMock(FileRepositoryInterface::class),
@@ -36,6 +39,7 @@ class FileActionServiceTest extends TestCase
             $this->authChecker,
             $this->em,
             new FilenameValidator(),
+            $this->logger,
         );
     }
 
@@ -207,6 +211,9 @@ class FileActionServiceTest extends TestCase
         $this->em->expects($this->once())
             ->method('flush');
 
+        // Happy path : rien à signaler, pas de log
+        $this->logger->expects($this->never())->method('warning');
+
         // Act
         $this->service->delete($file);
 
@@ -231,6 +238,14 @@ class FileActionServiceTest extends TestCase
             ->with($file);
         $this->em->expects($this->once())
             ->method('flush');
+
+        // L'échec de suppression disque doit être loggé (pas juste avalé silencieusement)
+        $this->logger->expects($this->once())
+            ->method('warning')
+            ->with(
+                $this->stringContains('test.jpg'),
+                $this->callback(fn (array $context) => ($context['path'] ?? null) === '/path/test.jpg'),
+            );
 
         // Act & Assert (no exception thrown, graceful)
         $this->service->delete($file);


### PR DESCRIPTION
Closes #247

## Summary
- **Logging manquant** : `FileActionService::delete()` catchait l'échec de suppression disque avec un simple `// TODO` sans jamais logger. Loggé désormais (path, fileId, message d'exception), toujours de façon non bloquante.
- **Bug réel trouvé en auditant le flux RAW de bout en bout** : un fichier RAW uploadé (API ou route web) en `application/octet-stream` (ce que les navigateurs envoient, faute de mimeType pour ces formats) ne créait **jamais** de `Media` — les deux contrôleurs ne dispatchaient/collectaient que sur `image/*`/`video/*`, sans jamais consulter la reconnaissance par extension déjà présente dans `MediaProcessor`.
- `MediaProcessor` expose désormais `supports(mimeType, originalName): bool`, seule source de vérité, réutilisée par `FileUploadController` et `FileWebController`.
- Documentation (`.claude/medias.md`) mise à jour pour refléter le pipeline réel (traitement immédiat post-#251, `exif_thumbnail`, `supports()`).

## Test plan
- [x] Test RED→GREEN : échec de suppression disque loggé, jamais sur le happy path (`FileActionServiceTest`)
- [x] Test RED→GREEN : upload RAW en `application/octet-stream` crée bien un Media (`FileUploadTriggersImmediateMediaProcessingTest`)
- [x] Test ajouté : un PDF ne crée jamais de Media (ferme la boucle du fix #251)
- [x] Suite PHPUnit complète : 746/746 tests verts (1 échec préexistant sans rapport, `TailwindBuildTest`)
- [x] Suite Jest complète : 71/71 tests verts