### PR TITLE
feat(#241): visualiser un PDF dans le navigateur au lieu de le télécharger

### DIFF
--- a/.claude/medias.md
+++ b/.claude/medias.md
@@ -183,6 +183,22 @@ Le serveur tourne sous **LiteSpeed** (`server: o2switch-PowerBoost-v3`), mais LS
 
 ---
 
+## Fichiers PDF
+
+Pas de `Media` créé (`MediaProcessor::resolveMediaType()` retourne `null` pour `application/pdf`) — pas de vignette, pas d'EXIF. Un PDF reste un `File` seul.
+
+### Visualisation (#241)
+
+La plupart des navigateurs affichent nativement un PDF (pagination, zoom, recherche texte) si le serveur répond en `Content-Disposition: inline` plutôt qu'`attachment`. `FileWebController::view()` (route `app_file_view`) sert exactement le même fichier que `download()` (même autorisation, factorisée dans `buildFileResponse()`), seule la disposition change.
+
+**Aucune librairie JS de rendu PDF (pas de PDF.js)** : le bouton "Visualiser" de `FileCard.html.twig` ouvre une modale avec une simple `<iframe src="…/view">` — c'est le lecteur du navigateur qui fait tout le travail.
+
+### Vignette de première page — non fait
+
+Idée explorée mais pas implémentée : rasteriser la page 1 via Ghostscript (`gs`, présent sur o2switch, `Process`/`shell_exec` non bloqués) — même esprit que l'extraction de preview RAW (extraire quelque chose de déjà là plutôt que tout re-décoder). Nécessiterait une dégradation gracieuse identique au pipeline RAW si `gs` est absent/échoue. Voir #241.
+
+---
+
 ## Points ouverts
 
 - **EXIF des RAW** : `exif_read_data()` ne lit pas ces conteneurs. Date de prise de vue, modèle d'appareil et GPS restent vides pour ces photos (la vignette, elle, fonctionne). Deux pistes : lire les EXIF de la preview extraite (simple, métadonnées appauvries), ou exposer les tags TIFF depuis le package (plus riche).

--- a/assets/app.js
+++ b/assets/app.js
@@ -7,6 +7,7 @@ import './js/move-modal.js';
 import './js/folder-children.js';
 import './js/rename.js';
 import './js/delete-folder-modal.js';
+import './js/pdf-viewer-modal.js';
 import { initUploadModal } from './js/upload-modal.js';
 
 initUploadModal();

--- a/assets/js/pdf-viewer-modal.js
+++ b/assets/js/pdf-viewer-modal.js
@@ -1,0 +1,34 @@
+import { Modal } from './modal.js';
+
+/**
+ * Ouvre la modale de visualisation PDF.
+ *
+ * Aucune librairie JS de rendu PDF : l'iframe pointe vers app_file_view, qui
+ * sert le fichier en Content-Disposition: inline — le navigateur l'affiche
+ * avec son lecteur natif (pagination, zoom, recherche texte).
+ *
+ * @param {string} viewUrl URL de app_file_view pour ce fichier
+ * @param {string} fileName Nom affiché dans la modale
+ */
+window.openPdfViewerModal = function (viewUrl, fileName) {
+	const iframe = document.getElementById('pdf-viewer-iframe');
+	const nameEl = document.getElementById('pdf-viewer-name');
+
+	if (!iframe) return;
+
+	iframe.src = viewUrl;
+	if (nameEl) {
+		nameEl.textContent = fileName || 'ce document';
+	}
+
+	Modal.open('pdf-viewer-modal');
+};
+
+window.closePdfViewerModal = function () {
+	const iframe = document.getElementById('pdf-viewer-iframe');
+	if (iframe) {
+		// Libère le document affiché plutôt que de le garder chargé en arrière-plan.
+		iframe.src = 'about:blank';
+	}
+	Modal.close('pdf-viewer-modal');
+};

--- a/assets/tests/pdf-viewer-modal.test.js
+++ b/assets/tests/pdf-viewer-modal.test.js
@@ -1,0 +1,40 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+jest.unstable_mockModule('../js/modal.js', () => ({
+  Modal: {
+    open: jest.fn(),
+    close: jest.fn(),
+  },
+}));
+
+const { Modal } = await import('../js/modal.js');
+await import('../js/pdf-viewer-modal.js');
+
+describe('pdf-viewer-modal behavior', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    document.body.innerHTML = `
+      <iframe id="pdf-viewer-iframe" src="about:blank"></iframe>
+      <span id="pdf-viewer-name"></span>
+    `;
+  });
+
+  test('sets iframe src to the view URL and opens the modal', () => {
+    window.openPdfViewerModal('/files/abc-123/view', 'rapport.pdf');
+
+    const iframe = document.getElementById('pdf-viewer-iframe');
+    expect(iframe.src).toContain('/files/abc-123/view');
+    expect(document.getElementById('pdf-viewer-name').textContent).toBe('rapport.pdf');
+    expect(Modal.open).toHaveBeenCalledWith('pdf-viewer-modal');
+  });
+
+  test('closing resets the iframe src and closes the modal', () => {
+    window.openPdfViewerModal('/files/abc-123/view', 'rapport.pdf');
+    window.closePdfViewerModal();
+
+    const iframe = document.getElementById('pdf-viewer-iframe');
+    expect(iframe.src).toContain('about:blank');
+    expect(Modal.close).toHaveBeenCalledWith('pdf-viewer-modal');
+  });
+});

--- a/src/Controller/Web/FileWebController.php
+++ b/src/Controller/Web/FileWebController.php
@@ -57,6 +57,23 @@ final class FileWebController extends AbstractController
     #[Route('/files/{id}/download', name: 'app_file_download', methods: ['GET'])]
     public function download(string $id): Response
     {
+        return $this->buildFileResponse($id, ResponseHeaderBag::DISPOSITION_ATTACHMENT);
+    }
+
+    /**
+     * Affiche le fichier dans le navigateur au lieu de forcer son
+     * téléchargement — un PDF s'ouvre alors avec le lecteur natif du
+     * navigateur (pagination, zoom, recherche texte), sans aucune librairie
+     * JS côté client (#241).
+     */
+    #[Route('/files/{id}/view', name: 'app_file_view', methods: ['GET'])]
+    public function view(string $id): Response
+    {
+        return $this->buildFileResponse($id, ResponseHeaderBag::DISPOSITION_INLINE);
+    }
+
+    private function buildFileResponse(string $id, string $disposition): Response
+    {
         $file = $this->fileRepository->find(\Symfony\Component\Uid\Uuid::fromString($id));
 
         if ($file === null) {
@@ -71,10 +88,7 @@ final class FileWebController extends AbstractController
 
         $absolutePath = $this->storage->getAbsolutePath($file->getPath());
         $response = new BinaryFileResponse($absolutePath);
-        $response->setContentDisposition(
-            ResponseHeaderBag::DISPOSITION_ATTACHMENT,
-            $file->getOriginalName()
-        );
+        $response->setContentDisposition($disposition, $file->getOriginalName());
 
         return $response;
     }

--- a/templates/components/FileCard.html.twig
+++ b/templates/components/FileCard.html.twig
@@ -38,6 +38,13 @@
 			   class="rename-btn hc-item-action hc-item-action--edit"
 			   title="Renommer {{ item.originalName ?? item.name|e('html') }}"
 			   data-file-id="{{ item.id }}"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-pencil"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg></a>
+			{% if item.mimeType == 'application/pdf' %}
+			<button type="button"
+			        data-testid="view-pdf-btn-{{ item.id }}"
+			        class="hc-item-action hc-item-action--move"
+			        title="Visualiser {{ item.originalName ?? item.name|e('html') }}"
+			        onclick="openPdfViewerModal('{{ path('app_file_view', { id: item.id }) }}', '{{ (item.originalName ?? item.name)|e('js') }}')"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></button>
+			{% endif %}
 			<a href="{{ path('app_file_download', { id: item.id }) }}"
 			   class="hc-item-action hc-item-action--move"
 			   title="Télécharger {{ item.originalName ?? item.name|e('html') }}"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-download"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></a>

--- a/templates/components/PdfViewerModal.html.twig
+++ b/templates/components/PdfViewerModal.html.twig
@@ -1,0 +1,25 @@
+{# Modale de visualisation PDF — lecteur natif du navigateur, aucune librairie JS #}
+<div id="pdf-viewer-modal"
+     class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+     tabindex="-1"
+     aria-modal="true"
+     role="dialog">
+  <div class="bg-white/10 backdrop-blur-2xl border border-white/20 rounded-3xl
+              shadow-2xl p-4 w-full h-full max-w-5xl max-h-[90vh] mx-4 flex flex-col">
+
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="text-white text-lg font-semibold truncate" id="pdf-viewer-name">ce document</h2>
+      <button type="button"
+              onclick="closePdfViewerModal()"
+              class="px-3 py-1.5 rounded-xl text-white/70 hover:text-white hover:bg-white/10 transition-colors">
+        Fermer
+      </button>
+    </div>
+
+    <iframe id="pdf-viewer-iframe"
+            src="about:blank"
+            class="flex-1 w-full rounded-xl bg-white"
+            title="Aperçu du document PDF"></iframe>
+
+  </div>
+</div>

--- a/templates/web/layout.html.twig
+++ b/templates/web/layout.html.twig
@@ -3,6 +3,7 @@
 <twig:MoveModal />
 <twig:DeleteFolderModal />
 <twig:RenameModal />
+<twig:PdfViewerModal />
 
 {% endblock %}
 {% extends 'base.html.twig' %}

--- a/tests/Web/ExplorerPageTest.php
+++ b/tests/Web/ExplorerPageTest.php
@@ -378,4 +378,45 @@ final class ExplorerPageTest extends WebTestCase
         $this->assertSelectorExists('[data-testid="share-folder-btn-' . $folder->getId()->toRfc4122() . '"]');
         $this->assertSelectorExists('form[action*="/share-create"] input[value="' . $folder->getId()->toRfc4122() . '"]');
     }
+
+    /**
+     * #241 — le bouton "Visualiser" (ouvre app_file_view en inline) ne doit
+     * apparaître que pour les PDF, pas pour les autres types de fichiers.
+     */
+    public function testViewButtonAppearsOnlyForPdfFiles(): void
+    {
+        $user = $this->createUser();
+
+        $folder = new Folder('Docs', $user);
+        $this->em->persist($folder);
+        $this->em->flush();
+        $folderId = $folder->getId()->toRfc4122();
+
+        $this->login();
+        $token = $this->uploadCsrfToken();
+
+        $pdfTmp = tempnam(sys_get_temp_dir(), 'hc_pdf_');
+        file_put_contents($pdfTmp, '%PDF-1.4 fake content');
+        $pdfUpload = new UploadedFile($pdfTmp, 'rapport.pdf', 'application/pdf', null, true);
+        $this->client->request('POST', '/files/upload', ['folder_id' => $folderId, '_token' => $token], ['file' => $pdfUpload]);
+        $this->client->followRedirect();
+
+        $txtTmp = tempnam(sys_get_temp_dir(), 'hc_txt_') . '.txt';
+        file_put_contents($txtTmp, 'contenu texte');
+        $txtUpload = new UploadedFile($txtTmp, 'notes.txt', 'text/plain', null, true);
+        $this->client->request('POST', '/files/upload', ['folder_id' => $folderId, '_token' => $this->uploadCsrfToken()], ['file' => $txtUpload]);
+        $crawler = $this->client->followRedirect();
+
+        $this->assertResponseIsSuccessful();
+
+        $pdfFile = $this->em->getRepository(\App\Entity\File::class)->findOneBy(['originalName' => 'rapport.pdf']);
+        $txtFile = $this->em->getRepository(\App\Entity\File::class)->findOneBy(['originalName' => 'notes.txt']);
+
+        $this->assertSelectorExists('[data-testid="view-pdf-btn-' . $pdfFile->getId()->toRfc4122() . '"]');
+        $this->assertCount(
+            0,
+            $crawler->filter('[data-testid="view-pdf-btn-' . $txtFile->getId()->toRfc4122() . '"]'),
+            'Un fichier non-PDF ne doit pas avoir de bouton "Visualiser"'
+        );
+    }
 }

--- a/tests/Web/FileViewInlineTest.php
+++ b/tests/Web/FileViewInlineTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * #241 — la plupart des navigateurs affichent un PDF nativement si le
+ * serveur répond en Content-Disposition: inline. app_file_download force
+ * "attachment" en dur (téléchargement systématique) : impossible de
+ * visualiser un PDF sans le télécharger d'abord.
+ *
+ * Nouvelle route dédiée à la visualisation, sans dupliquer la logique
+ * d'autorisation de app_file_download.
+ */
+final class FileViewInlineTest extends WebTestCase
+{
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+    private string $storageDir;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $this->storageDir = static::getContainer()->getParameter('app.storage_dir');
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createUser(string $email = 'test@example.com', string $password = 'pwd12345'): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User($email, 'Test');
+        $user->setPassword($hasher->hashPassword($user, $password));
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+
+    private function login(string $email = 'test@example.com', string $password = 'pwd12345'): void
+    {
+        $crawler = $this->client->request('GET', '/login');
+        $form = $crawler->selectButton('Se connecter')->form([
+            'email'    => $email,
+            'password' => $password,
+        ]);
+        $this->client->submit($form);
+        $this->client->followRedirect();
+    }
+
+    private function createPdfFile(User $owner): File
+    {
+        $folder = new Folder('Docs', $owner);
+        $this->em->persist($folder);
+
+        $rel = 'view-test/doc-' . uniqid() . '.pdf';
+        @mkdir($this->storageDir . '/view-test', 0777, true);
+        $content = '%PDF-1.4 fake content';
+        file_put_contents($this->storageDir . '/' . $rel, $content);
+
+        $file = new File('doc.pdf', 'application/pdf', strlen($content), $rel, $folder, $owner);
+        $this->em->persist($file);
+        $this->em->flush();
+
+        return $file;
+    }
+
+    public function testViewRouteRespondsWithInlineDisposition(): void
+    {
+        $user = $this->createUser();
+        $file = $this->createPdfFile($user);
+        $fileId = $file->getId();
+        $this->em->clear();
+
+        $this->login();
+        $this->client->request('GET', '/files/' . $fileId . '/view');
+
+        $this->assertResponseIsSuccessful();
+        $disposition = (string) $this->client->getResponse()->headers->get('Content-Disposition');
+        $this->assertStringStartsWith('inline', $disposition, 'Le PDF doit s\'afficher dans le navigateur, pas forcer un téléchargement');
+    }
+
+    public function testDownloadRouteStillForcesAttachment(): void
+    {
+        // Non-régression : la route de téléchargement existante ne doit pas changer.
+        $user = $this->createUser();
+        $file = $this->createPdfFile($user);
+        $fileId = $file->getId();
+        $this->em->clear();
+
+        $this->login();
+        $this->client->request('GET', '/files/' . $fileId . '/download');
+
+        $this->assertResponseIsSuccessful();
+        $disposition = (string) $this->client->getResponse()->headers->get('Content-Disposition');
+        $this->assertStringStartsWith('attachment', $disposition);
+    }
+
+    public function testViewRouteDeniesAccessToNonOwner(): void
+    {
+        $owner = $this->createUser('owner@example.com', 'pwd12345');
+        $file = $this->createPdfFile($owner);
+        $fileId = $file->getId();
+        $this->createUser('intruder@example.com', 'pwd12345');
+        $this->em->clear();
+
+        $this->login('intruder@example.com', 'pwd12345');
+        $this->client->request('GET', '/files/' . $fileId . '/view');
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+}


### PR DESCRIPTION
## Summary
- Partie 1 de #241 : la plupart des navigateurs affichent nativement un PDF (pagination, zoom, recherche texte) si le serveur répond en `Content-Disposition: inline` plutôt qu'`attachment`. **Aucune librairie JS de rendu PDF nécessaire.**
- Nouvelle route `app_file_view` (`GET /files/{id}/view`), même autorisation que `app_file_download` (factorisée dans `buildFileResponse()`)
- Bouton "Visualiser" dans `FileCard.html.twig`, affiché uniquement pour les PDF, ouvrant une modale avec `<iframe>` (`pdf-viewer-modal.js`, même pattern que `delete-folder-modal.js`)
- `app_file_download` reste inchangée (`attachment`)
- Documentation ajoutée dans `.claude/medias.md` (approche retenue + piste Ghostscript non implémentée pour une future vignette de première page)

## Test plan
- [x] Test RED→GREEN : `FileViewInlineTest` (disposition inline/attachment, autorisation par ownership)
- [x] Test RED→GREEN : `pdf-viewer-modal.test.js` (Jest)
- [x] Test RED→GREEN : rendu conditionnel du bouton "Visualiser" dans `ExplorerPageTest` (présent pour un PDF, absent pour un `.txt`)
- [x] Suite PHPUnit complète : 750/750 tests verts (1 échec préexistant sans rapport, `TailwindBuildTest`)
- [x] Suite Jest complète : 73/73 tests verts