### PR TITLE
✨ feat(UploadBatch): router le traitement média vers le worker pour les lots lourds

### DIFF
--- a/.github/avancement.md
+++ b/.github/avancement.md
@@ -1,8 +1,26 @@
 # 📋 Avancement — HomeCloud API
 
-> Dernière mise à jour : 2026-07-15
+> Dernière mise à jour : 2026-07-19
 
-> **Status git :** branche `feat/album-explicit-cover` — 677 tests ✅
+> **Status git :** branche `feat/#259-worker-media-batch-routing` — chantier worker média en cours
+
+---
+
+## 🚧 En cours — Worker média : routage lots lourds / petits lots (2026-07-19)
+
+Le worker Messenger ne servait plus à rien : chaque upload faisait **les deux** — `bus->dispatch(MediaProcessMessage)` **et** `collector->add()` (traitement immédiat sur `kernel.terminate`) — le worker refaisant un **no-op** grâce à l'idempotence de `MediaProcessor::process()`.
+
+Refonte : le worker ne tourne **que pour les lots lourds**. Petit lot → traitement immédiat (latence perçue nulle). Lot lourd (**taille cumulée > seuil OU présence d'un RAW**) → déporté au worker, avec **notif email + toast** en fin de traitement. Le serveur décide du routage (le JS ne fait que l'UX) ; corrélation des fichiers d'un même envoi par `batchId`.
+
+Contraintes o2switch (mutualisé) : pas de daemon → worker = **cron 5 min** conservé ; **Mercure exclu** → notif écran par **polling court**.
+
+| Lot  | Ticket | Contenu                                                                                   | Statut                    |
+|------|--------|-------------------------------------------------------------------------------------------|---------------------------|
+| PR 1 | #259   | `UploadBatch` + seuil (`UploadRoutingDecider`) + routage exclusif immediate/deferred (fin du double dispatch) | 🚧 en cours               |
+| PR 2 | #260   | Email de fin de lot différé (`BatchCompletionNotifier`)                                    | ⏳ planifié (dépend #259) |
+| PR 3 | #261   | Polling statut de lot + toast front                                                       | ⏳ planifié (dépend #259) |
+
+Plan détaillé : `.claude/plans/je-suis-d-accord-avec-ticklish-zebra.md`. Connexes : #245 (curseur de concurrence d'upload), #239 (barre de progression).
 
 ---
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -9,6 +9,10 @@
 parameters:
     app.storage_dir: '%kernel.project_dir%/var/storage'
     app.encryption_key: '%env(base64:APP_ENCRYPTION_KEY)%'
+    # Seuil de taille cumulée (octets) au-delà duquel un lot d'upload est déporté
+    # au worker Messenger plutôt que traité immédiatement. 250 Mo par défaut,
+    # ajustable sans redéploiement de code.
+    hc.upload.deferred_threshold_bytes: 262144000
 
 services:
     # Bindings interfaces → implémentations (Dependency Inversion Principle)
@@ -23,6 +27,7 @@ services:
     App\Interface\FilenameValidatorInterface:     '@App\Service\FilenameValidator'
     App\Interface\OwnershipCheckerInterface:      '@App\Security\OwnershipChecker'
     App\Interface\AuthenticationResolverInterface: '@App\Security\AuthenticationResolver'
+    App\Interface\UploadBatchRepositoryInterface: '@App\Repository\UploadBatchRepository'
 
     App\State\AlbumProcessor:
         arguments:
@@ -52,7 +57,7 @@ services:
             $logger: '@logger'
 
     App\Security\AuthorizationChecker: ~
-    
+
     App\Service\FileActionService:
         arguments:
             $fileRepository: '@App\Repository\FileRepository'
@@ -84,6 +89,10 @@ services:
             $folderRepository: '@App\Repository\FolderRepository'
             $userRepository: '@App\Repository\UserRepository'
             $em: '@doctrine.orm.entity_manager'
+
+    App\Service\UploadRoutingDecider:
+        arguments:
+            $deferredThresholdBytes: '%hc.upload.deferred_threshold_bytes%'
 
     # Déclaration explicite du FolderProcessor pour garantir l'injection
     App\State\FolderProcessor:

--- a/migrations/Version20260719170154.php
+++ b/migrations/Version20260719170154.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260719170154 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Table upload_batches (lots d\'upload) + files.batch_id nullable pour le routage immediate/deferred du traitement média (#259)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE upload_batches (id BINARY(16) NOT NULL, expected_count INT NOT NULL, total_size BIGINT NOT NULL, mode VARCHAR(16) NOT NULL, status VARCHAR(16) DEFAULT \'pending\' NOT NULL, created_at DATETIME NOT NULL, completed_at DATETIME DEFAULT NULL, notified_at DATETIME DEFAULT NULL, owner_id BINARY(16) NOT NULL, INDEX IDX_35597FBD7E3C61F9 (owner_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
+        $this->addSql('ALTER TABLE upload_batches ADD CONSTRAINT FK_35597FBD7E3C61F9 FOREIGN KEY (owner_id) REFERENCES users (id)');
+        $this->addSql('ALTER TABLE files ADD batch_id BINARY(16) DEFAULT NULL');
+        $this->addSql('ALTER TABLE files ADD CONSTRAINT FK_6354059F39EBE7A FOREIGN KEY (batch_id) REFERENCES upload_batches (id)');
+        $this->addSql('CREATE INDEX IDX_6354059F39EBE7A ON files (batch_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Retirer d'abord la FK + colonne côté files (qui référence upload_batches)
+        // AVANT de supprimer la table cible, sinon la contrainte bloque le DROP.
+        $this->addSql('ALTER TABLE files DROP FOREIGN KEY FK_6354059F39EBE7A');
+        $this->addSql('DROP INDEX IDX_6354059F39EBE7A ON files');
+        $this->addSql('ALTER TABLE files DROP batch_id');
+        $this->addSql('ALTER TABLE upload_batches DROP FOREIGN KEY FK_35597FBD7E3C61F9');
+        $this->addSql('DROP TABLE upload_batches');
+    }
+}

--- a/src/Controller/Api/FileUploadController.php
+++ b/src/Controller/Api/FileUploadController.php
@@ -6,10 +6,14 @@ namespace App\Controller\Api;
 
 use App\ApiResource\FileOutput;
 use App\Interface\MediaProcessorInterface;
+use App\Interface\UploadBatchRepositoryInterface;
 use App\Message\MediaProcessMessage;
+use App\Entity\UploadBatch;
 use App\Service\CreateFileService;
 use App\Service\PendingMediaProcessingCollector;
 use App\State\FileProvider;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -44,6 +48,8 @@ final class FileUploadController extends AbstractController
         private readonly MessageBusInterface $bus,
         private readonly PendingMediaProcessingCollector $pendingMediaProcessingCollector,
         private readonly MediaProcessorInterface $mediaProcessor,
+        private readonly UploadBatchRepositoryInterface $uploadBatchRepository,
+        private readonly EntityManagerInterface $em,
     ) {}
 
     /**
@@ -77,15 +83,25 @@ final class FileUploadController extends AbstractController
             $request->request->get('newFolderName'),
         );
 
-        // Dispatch async (filet de sécurité) + traitement immédiat après la
-        // réponse HTTP (kernel.terminate, cf. ProcessPendingMediaListener) :
-        // le worker Messenger reste le secours si ce dernier échoue.
-        // supports() couvre aussi les RAW envoyés en application/octet-stream
-        // (mimeType inutile, reconnus par extension) — un simple test
-        // image/*|video/* les aurait ignorés silencieusement.
+        $batch = $this->resolveBatch($request, $ownerId);
+        if ($batch !== null) {
+            $file->setBatch($batch);
+            $this->em->flush();
+        }
+
+        // Routage EXCLUSIF du traitement média (supports() reconnaît aussi les RAW
+        // envoyés en application/octet-stream, via l'extension) :
+        // - lot "deferred" (lourd) → worker Messenger seul, l'utilisateur n'attend pas ;
+        // - sinon (immediate, ou pas de lot) → traitement juste après la réponse
+        //   HTTP (kernel.terminate), sans mobiliser la file.
+        // Un seul des deux chemins est emprunté : fini le no-op systématique du
+        // worker qui refaisait le travail déjà fait à kernel.terminate.
         if ($this->mediaProcessor->supports($file->getMimeType(), $file->getOriginalName())) {
-            $this->bus->dispatch(new MediaProcessMessage((string) $file->getId()));
-            $this->pendingMediaProcessingCollector->add((string) $file->getId());
+            if ($batch !== null && $batch->isDeferred()) {
+                $this->bus->dispatch(new MediaProcessMessage((string) $file->getId()));
+            } else {
+                $this->pendingMediaProcessingCollector->add((string) $file->getId());
+            }
         }
 
         $output = $this->provider->toOutput($file);
@@ -94,6 +110,34 @@ final class FileUploadController extends AbstractController
             json_decode($this->serializer->serialize($output, 'json'), true),
             Response::HTTP_CREATED,
         );
+    }
+
+    /**
+     * Résout le lot d'upload référencé par la requête, s'il existe.
+     *
+     * `batchId` est optionnel (uploads hors multi-fichiers, clients anciens) :
+     * son absence retourne null → traitement immédiat. On vérifie que le lot
+     * appartient bien à l'uploadeur pour qu'un batchId d'autrui ne puisse pas
+     * détourner le routage d'un fichier.
+     */
+    private function resolveBatch(Request $request, string $ownerId): ?UploadBatch
+    {
+        $batchId = $request->request->get('batchId');
+        if (empty($batchId)) {
+            return null;
+        }
+
+        try {
+            $batch = $this->uploadBatchRepository->findById(Uuid::fromString((string) $batchId));
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
+
+        if ($batch === null || (string) $batch->getOwner()->getId() !== $ownerId) {
+            return null;
+        }
+
+        return $batch;
     }
 }
 

--- a/src/Controller/Api/UploadBatchController.php
+++ b/src/Controller/Api/UploadBatchController.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Api;
+
+use App\Entity\UploadBatch;
+use App\Interface\AuthenticationResolverInterface;
+use App\Service\UploadRoutingDecider;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Déclaration d'un lot d'upload multi-fichiers.
+ *
+ * Le front, seul à connaître le lot entier (chaque fichier part ensuite dans sa
+ * propre requête POST /api/v1/files), déclare ici le lot avant d'uploader :
+ * nombre de fichiers, taille cumulée, noms. Le serveur décide alors — via
+ * UploadRoutingDecider, seul juge — si le traitement média sera immédiat ou
+ * déporté au worker, et retourne le batchId à joindre à chaque upload.
+ *
+ * Le JS ne fait qu'informer l'utilisateur (UX) : la décision de routage n'est
+ * jamais laissée au client (contournable, et ignorant du coût réel).
+ */
+#[AsController]
+final class UploadBatchController extends AbstractController
+{
+    public function __construct(
+        private readonly AuthenticationResolverInterface $authResolver,
+        private readonly UploadRoutingDecider $routingDecider,
+        private readonly EntityManagerInterface $em,
+    ) {}
+
+    #[Route('/api/v1/uploads/batch', name: 'api_upload_batch_create', methods: ['POST'])]
+    public function __invoke(Request $request): Response
+    {
+        $owner = $this->authResolver->requireUser();
+
+        $data = json_decode($request->getContent(), true);
+        if (!is_array($data)) {
+            $data = [];
+        }
+
+        $expectedCount = max(0, (int) ($data['count'] ?? 0));
+        $totalSize = max(0, (int) ($data['totalSize'] ?? 0));
+        $filenames = array_values(array_filter(
+            (array) ($data['filenames'] ?? []),
+            static fn ($name): bool => is_string($name),
+        ));
+
+        $mode = $this->routingDecider->decide($totalSize, $filenames);
+
+        $batch = new UploadBatch($owner, $expectedCount, $totalSize, $mode);
+        $this->em->persist($batch);
+        $this->em->flush();
+
+        return new JsonResponse(
+            [
+                'batchId' => (string) $batch->getId(),
+                'mode'    => $batch->getMode(),
+            ],
+            Response::HTTP_CREATED,
+        );
+    }
+}

--- a/src/Controller/Web/FileWebController.php
+++ b/src/Controller/Web/FileWebController.php
@@ -8,7 +8,6 @@ use App\Entity\File;
 use App\Entity\Share;
 use App\Interface\MediaProcessorInterface;
 use App\Interface\StorageServiceInterface;
-use App\Message\MediaProcessMessage;
 use App\Repository\FileRepository;
 use App\Interface\DefaultFolderServiceInterface;
 use App\Interface\SharedResourceCleanerInterface;
@@ -21,7 +20,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -49,7 +47,6 @@ final class FileWebController extends AbstractController
         private readonly EntityManagerInterface $em,
         private readonly SharedResourceCleanerInterface $sharedResourceCleaner,
         private readonly GuestRestrictionChecker $guestRestrictionChecker,
-        private readonly MessageBusInterface $bus,
         private readonly PendingMediaProcessingCollector $pendingMediaProcessingCollector,
         private readonly MediaProcessorInterface $mediaProcessor,
     ) {}
@@ -147,13 +144,13 @@ final class FileWebController extends AbstractController
         $this->em->persist($file);
         $this->em->flush();
 
-        // Dispatch async (filet de sécurité) + traitement immédiat après la
-        // réponse HTTP (kernel.terminate, cf. ProcessPendingMediaListener) —
-        // même mécanisme que FileUploadController (API). supports() couvre
-        // aussi les RAW envoyés en application/octet-stream (reconnus par
-        // extension) — un simple test image/*|video/* les aurait ignorés.
+        // Route web (un seul fichier par requête, pas de notion de lot) : le
+        // traitement média se fait toujours juste après la réponse HTTP
+        // (kernel.terminate, cf. ProcessPendingMediaListener), jamais via le
+        // worker — celui-ci est réservé aux lots lourds déclarés par l'API.
+        // supports() couvre aussi les RAW en application/octet-stream (reconnus
+        // par extension).
         if ($this->mediaProcessor->supports($mimeType, $originalName)) {
-            $this->bus->dispatch(new MediaProcessMessage((string) $file->getId()));
             $this->pendingMediaProcessingCollector->add((string) $file->getId());
         }
 

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -72,6 +72,16 @@ class File
     #[ORM\JoinColumn(nullable: false)]
     private User $owner;
 
+    /**
+     * Lot d'upload d'origine, si le fichier vient d'un envoi corrélé côté client
+     * (batchId). Nullable : les flux sans lot (route web, import album, fixtures)
+     * restent inchangés. Sert au routage immediate/deferred et à la détection de
+     * fin de lot pour la notification.
+     */
+    #[ORM\ManyToOne(targetEntity: UploadBatch::class)]
+    #[ORM\JoinColumn(nullable: true)]
+    private ?UploadBatch $batch = null;
+
     #[ORM\Column]
     private \DateTimeImmutable $createdAt;
 
@@ -150,6 +160,16 @@ class File
     public function getOwner(): User
     {
         return $this->owner;
+    }
+
+    public function getBatch(): ?UploadBatch
+    {
+        return $this->batch;
+    }
+
+    public function setBatch(?UploadBatch $batch): void
+    {
+        $this->batch = $batch;
     }
     public function getCreatedAt(): \DateTimeImmutable
     {

--- a/src/Entity/UploadBatch.php
+++ b/src/Entity/UploadBatch.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\UploadBatchRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Regroupe les fichiers d'un même envoi (multi-upload) pour permettre au serveur
+ * de raisonner sur le lot entier, alors que chaque fichier part dans sa propre
+ * requête HTTP (le front génère un batchId partagé).
+ *
+ * Rôle :
+ * - porter la décision de routage (`mode`) prise à la création par
+ *   UploadRoutingDecider : `immediate` (traitement sur kernel.terminate) ou
+ *   `deferred` (déport au worker Messenger pour les lots lourds) ;
+ * - servir de point d'agrégation pour la fin de traitement (comptage des Media
+ *   créés) et la notification unique (email + toast), gérés dans les lots suivants.
+ *
+ * `notifiedAt` garantit qu'un lot n'est notifié qu'une fois même si le worker
+ * rejoue un message (idempotence).
+ */
+#[ORM\Entity(repositoryClass: UploadBatchRepository::class)]
+#[ORM\Table(name: 'upload_batches')]
+class UploadBatch
+{
+    public const MODE_IMMEDIATE = 'immediate';
+    public const MODE_DEFERRED = 'deferred';
+
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_PROCESSING = 'processing';
+    public const STATUS_COMPLETED = 'completed';
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    private Uuid $id;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private User $owner;
+
+    /** Nombre de fichiers annoncés dans le lot. */
+    #[ORM\Column]
+    private int $expectedCount;
+
+    /**
+     * Taille cumulée annoncée, en octets. `bigint` (donc string côté Doctrine)
+     * car un lot lourd — le cas d'usage du worker — dépasse volontiers la limite
+     * d'un INTEGER 32 bits (~2 Go).
+     */
+    #[ORM\Column(type: Types::BIGINT)]
+    private string $totalSize;
+
+    #[ORM\Column(length: 16)]
+    private string $mode;
+
+    #[ORM\Column(length: 16, options: ['default' => self::STATUS_PENDING])]
+    private string $status = self::STATUS_PENDING;
+
+    #[ORM\Column]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $completedAt = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $notifiedAt = null;
+
+    public function __construct(User $owner, int $expectedCount, int $totalSize, string $mode)
+    {
+        if (isset($_ENV['APP_ENV']) && $_ENV['APP_ENV'] === 'test') {
+            // UUID v4 aléatoire garanti unique (même contrainte qu'App\Entity\File).
+            $this->id = Uuid::fromString(
+                sprintf(
+                    '%08x-%04x-%04x-%04x-%012x',
+                    random_int(0, 0xffffffff),
+                    random_int(0, 0xffff),
+                    (random_int(0, 0x0fff) | 0x4000),
+                    (random_int(0, 0x3fff) | 0x8000),
+                    random_int(0, 0xffffffffffff)
+                )
+            );
+        } else {
+            $this->id = Uuid::v7();
+        }
+
+        $this->owner = $owner;
+        $this->expectedCount = $expectedCount;
+        $this->totalSize = (string) $totalSize;
+        $this->mode = $mode;
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getOwner(): User
+    {
+        return $this->owner;
+    }
+
+    public function getExpectedCount(): int
+    {
+        return $this->expectedCount;
+    }
+
+    public function getTotalSize(): int
+    {
+        return (int) $this->totalSize;
+    }
+
+    public function getMode(): string
+    {
+        return $this->mode;
+    }
+
+    public function isDeferred(): bool
+    {
+        return $this->mode === self::MODE_DEFERRED;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): void
+    {
+        $this->status = $status;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getCompletedAt(): ?\DateTimeImmutable
+    {
+        return $this->completedAt;
+    }
+
+    public function setCompletedAt(?\DateTimeImmutable $completedAt): void
+    {
+        $this->completedAt = $completedAt;
+    }
+
+    public function getNotifiedAt(): ?\DateTimeImmutable
+    {
+        return $this->notifiedAt;
+    }
+
+    public function setNotifiedAt(?\DateTimeImmutable $notifiedAt): void
+    {
+        $this->notifiedAt = $notifiedAt;
+    }
+}

--- a/src/Interface/MediaProcessorInterface.php
+++ b/src/Interface/MediaProcessorInterface.php
@@ -21,4 +21,10 @@ interface MediaProcessorInterface
      * sans dupliquer la logique de reconnaissance (mimeType + extensions RAW).
      */
     public function supports(string $mimeType, string $originalName): bool;
+
+    /**
+     * Le fichier est-il un RAW (reconnu par extension) ? Seule source de vérité
+     * pour cette décision, réutilisée par UploadRoutingDecider.
+     */
+    public function isRaw(string $originalName): bool;
 }

--- a/src/Interface/UploadBatchRepositoryInterface.php
+++ b/src/Interface/UploadBatchRepositoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\UploadBatch;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Contrat d'accès aux données UploadBatch (DIP : mockable en test, implémentation
+ * swappable sans toucher aux consommateurs — controller, handler).
+ */
+interface UploadBatchRepositoryInterface
+{
+    public function findById(Uuid $id): ?UploadBatch;
+
+    /**
+     * Nombre de fichiers du lot ayant déjà un Media (traitement terminé).
+     * Base de la détection de fin de lot, robuste aux ré-exécutions du worker
+     * (on compte l'état réel plutôt qu'un compteur incrémental).
+     */
+    public function countProcessed(UploadBatch $batch): int;
+}

--- a/src/Repository/UploadBatchRepository.php
+++ b/src/Repository/UploadBatchRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Media;
+use App\Entity\UploadBatch;
+use App\Interface\UploadBatchRepositoryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<UploadBatch>
+ */
+class UploadBatchRepository extends ServiceEntityRepository implements UploadBatchRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, UploadBatch::class);
+    }
+
+    public function findById(Uuid $id): ?UploadBatch
+    {
+        return $this->find($id);
+    }
+
+    public function countProcessed(UploadBatch $batch): int
+    {
+        // Compte les File du lot pour lesquels un Media existe. On joint Media
+        // sur f.batch = :batch (index sur batch_id) : l'état réel en base fait
+        // foi, ce qui reste correct même si le worker rejoue un message.
+        return (int) $this->getEntityManager()->createQueryBuilder()
+            ->select('COUNT(f.id)')
+            ->from(\App\Entity\File::class, 'f')
+            ->innerJoin(Media::class, 'm', 'WITH', 'm.file = f')
+            ->andWhere('IDENTITY(f.batch) = :batchId')
+            ->setParameter('batchId', $batch->getId()->toBinary())
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+}

--- a/src/Service/MediaProcessor.php
+++ b/src/Service/MediaProcessor.php
@@ -108,14 +108,21 @@ final class MediaProcessor implements MediaProcessorInterface
 
         // Le mimeType ne dit rien d'utile (typiquement "application/octet-stream",
         // ce que les navigateurs envoient pour un RAW) : l'extension tranche.
-        if ($this->isRawFile($originalName)) {
+        if ($this->isRaw($originalName)) {
             return 'photo';
         }
 
         return null;
     }
 
-    private function isRawFile(string $originalName): bool
+    /**
+     * Le fichier est-il un RAW (reconnu par extension) ?
+     *
+     * Exposé publiquement pour être la seule source de vérité de cette décision,
+     * réutilisée par UploadRoutingDecider (un RAW dans un lot force le déport au
+     * worker, son décodage preview étant coûteux).
+     */
+    public function isRaw(string $originalName): bool
     {
         $extension = strtolower(pathinfo($originalName, PATHINFO_EXTENSION));
 

--- a/src/Service/UploadRoutingDecider.php
+++ b/src/Service/UploadRoutingDecider.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\UploadBatch;
+use App\Interface\MediaProcessorInterface;
+
+/**
+ * Décide, côté serveur, si un lot d'upload est traité immédiatement (après la
+ * réponse HTTP, sur kernel.terminate) ou déporté au worker Messenger.
+ *
+ * Le worker ne doit servir qu'aux lots lourds : un petit lot de photos se traite
+ * en quelques secondes sans mobiliser la file. Deux critères déclenchent le
+ * déport :
+ * - taille cumulée strictement supérieure au seuil configuré ;
+ * - présence d'au moins un RAW (décodage preview de loin le plus coûteux, un seul
+ *   RAW pouvant peser plus que dix JPEG).
+ *
+ * La reconnaissance RAW délègue à MediaProcessor::isRaw — seule source de vérité,
+ * jamais dupliquée ici.
+ */
+final class UploadRoutingDecider
+{
+    public function __construct(
+        private readonly MediaProcessorInterface $mediaProcessor,
+        private readonly int $deferredThresholdBytes,
+    ) {}
+
+    /**
+     * @param list<string> $filenames noms des fichiers du lot (extension suffit)
+     *
+     * @return self::MODE_* ('immediate' | 'deferred')
+     */
+    public function decide(int $totalSize, array $filenames): string
+    {
+        if ($totalSize > $this->deferredThresholdBytes) {
+            return UploadBatch::MODE_DEFERRED;
+        }
+
+        foreach ($filenames as $filename) {
+            if ($this->mediaProcessor->isRaw($filename)) {
+                return UploadBatch::MODE_DEFERRED;
+            }
+        }
+
+        return UploadBatch::MODE_IMMEDIATE;
+    }
+}

--- a/tests/Api/FileUploadTriggersImmediateMediaProcessingTest.php
+++ b/tests/Api/FileUploadTriggersImmediateMediaProcessingTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Api;
 use App\Entity\File;
 use App\Entity\Folder;
 use App\Entity\Media;
+use App\Entity\UploadBatch;
 use App\Entity\User;
 use App\Tests\AuthenticatedApiTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -156,5 +157,107 @@ final class FileUploadTriggersImmediateMediaProcessingTest extends Authenticated
         $media = $this->em->getRepository(Media::class)->findOneBy(['file' => $file]);
 
         $this->assertNull($media, 'Un PDF ne doit jamais produire de Media');
+    }
+
+    /**
+     * Routage exclusif — lot "deferred" (lourd) : le fichier part au worker
+     * Messenger (1 message) et n'est PAS traité immédiatement (kernel.terminate).
+     * L'utilisateur n'attend pas ; la vignette sera générée au cycle du worker.
+     */
+    public function testDeferredBatchDispatchesToWorkerAndSkipsImmediateProcessing(): void
+    {
+        $batch = new UploadBatch($this->alice, 1, 300_000_000, UploadBatch::MODE_DEFERRED);
+        $this->em->persist($batch);
+        $this->em->flush();
+        $batchId = (string) $batch->getId();
+
+        $client = $this->createAuthenticatedKernelBrowser($this->alice);
+
+        $fileId = $this->uploadImage($client, 'deferred.jpg', $batchId);
+
+        $transport = static::getContainer()->get('messenger.transport.async');
+        $this->assertCount(1, $transport->get(), 'Un lot deferred doit dispatcher exactement un message worker');
+
+        $file = $this->em->getRepository(File::class)->find(Uuid::fromString($fileId));
+        $media = $this->em->getRepository(Media::class)->findOneBy(['file' => $file]);
+        $this->assertNull(
+            $media,
+            'Un lot deferred ne doit PAS être traité immédiatement (kernel.terminate) — le worker s\'en charge'
+        );
+    }
+
+    /**
+     * Routage exclusif — lot "immediate" (petit) : traitement juste après la
+     * réponse HTTP, AUCUN message worker (fin du no-op systématique du worker).
+     */
+    public function testImmediateBatchProcessesWithoutDispatchingToWorker(): void
+    {
+        $batch = new UploadBatch($this->alice, 1, 500_000, UploadBatch::MODE_IMMEDIATE);
+        $this->em->persist($batch);
+        $this->em->flush();
+        $batchId = (string) $batch->getId();
+
+        $client = $this->createAuthenticatedKernelBrowser($this->alice);
+
+        $fileId = $this->uploadImage($client, 'immediate.jpg', $batchId);
+
+        $transport = static::getContainer()->get('messenger.transport.async');
+        $this->assertCount(0, $transport->get(), 'Un lot immediate ne doit jamais dispatcher au worker');
+
+        $file = $this->em->getRepository(File::class)->find(Uuid::fromString($fileId));
+        $media = $this->em->getRepository(Media::class)->findOneBy(['file' => $file]);
+        $this->assertNotNull($media, 'Un lot immediate doit être traité dans la foulée de la réponse HTTP');
+    }
+
+    /**
+     * Régression : un upload sans batchId (client ancien, upload isolé) reste
+     * traité immédiatement et ne dispatche jamais au worker — fin du double
+     * dispatch qui refaisait le travail en no-op.
+     */
+    public function testUploadWithoutBatchDoesNotDispatchToWorker(): void
+    {
+        $client = $this->createAuthenticatedKernelBrowser($this->alice);
+
+        $fileId = $this->uploadImage($client, 'nobatch.jpg', null);
+
+        $transport = static::getContainer()->get('messenger.transport.async');
+        $this->assertCount(0, $transport->get(), 'Sans lot, aucun dispatch worker (traitement immédiat seul)');
+
+        $file = $this->em->getRepository(File::class)->find(Uuid::fromString($fileId));
+        $media = $this->em->getRepository(Media::class)->findOneBy(['file' => $file]);
+        $this->assertNotNull($media, 'Sans lot, le Media doit exister immédiatement');
+    }
+
+    /**
+     * Upload d'une vraie image JPEG via multipart, avec batchId optionnel.
+     * Retourne l'id du File créé.
+     */
+    private function uploadImage(object $client, string $name, ?string $batchId): string
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'test_upload_');
+        $image = imagecreatetruecolor(120, 90);
+        imagejpeg($image, $tempFile);
+        imagedestroy($image);
+
+        $params = [
+            'ownerId'  => (string) $this->alice->getId(),
+            'folderId' => (string) $this->folder->getId(),
+        ];
+        if ($batchId !== null) {
+            $params['batchId'] = $batchId;
+        }
+
+        $client->request(
+            'POST',
+            '/api/v1/files',
+            $params,
+            ['file' => new UploadedFile($tempFile, $name, 'image/jpeg', null, false)],
+            ['CONTENT_TYPE' => 'multipart/form-data'],
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+        @unlink($tempFile);
+
+        return (string) json_decode((string) $client->getResponse()->getContent(), true)['id'];
     }
 }

--- a/tests/Api/MediaTest.php
+++ b/tests/Api/MediaTest.php
@@ -155,9 +155,15 @@ final class MediaTest extends AuthenticatedApiTestCase
         $this->assertResponseStatusCodeSame(404);
     }
 
-    // --- POST upload image → message dispatché ---
+    // --- POST upload image (sans lot) → traité immédiatement, pas via le worker ---
 
-    public function testUploadImageDispatchesMediaProcessMessage(): void
+    /**
+     * Depuis le routage exclusif (#259), un upload image sans lot déclaré n'est
+     * plus dispatché au worker : il est traité juste après la réponse HTTP
+     * (kernel.terminate). Le worker est réservé aux lots lourds (mode deferred).
+     * Ce test garantit qu'un upload isolé ne mobilise jamais la file.
+     */
+    public function testUploadImageWithoutBatchDoesNotDispatchToWorker(): void
     {
         $user = new User('uploader@example.com', 'Uploader');
         $this->em->persist($user);
@@ -177,7 +183,7 @@ final class MediaTest extends AuthenticatedApiTestCase
         $this->assertResponseStatusCodeSame(201);
 
         $transport = static::getContainer()->get('messenger.transport.async');
-        $this->assertCount(1, $transport->get());
+        $this->assertCount(0, $transport->get());
     }
 
     public function testUploadNonImageDoesNotDispatchMediaMessage(): void

--- a/tests/Api/UploadBatchControllerTest.php
+++ b/tests/Api/UploadBatchControllerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api;
+
+use App\Entity\UploadBatch;
+use App\Tests\AuthenticatedApiTestCase;
+
+/**
+ * POST /api/v1/uploads/batch — déclaration d'un lot d'upload. Le serveur, seul
+ * juge du routage, renvoie le mode (immediate/deferred) que le front joindra
+ * ensuite à chaque upload. La décision ne dépend jamais du client.
+ */
+final class UploadBatchControllerTest extends AuthenticatedApiTestCase
+{
+    public function testSmallJpegBatchReturnsImmediateMode(): void
+    {
+        $alice = $this->createUser('alice-batch@example.com', 'password123', 'Alice');
+        $browser = $this->createAuthenticatedKernelBrowser($alice);
+
+        $browser->request(
+            'POST',
+            '/api/v1/uploads/batch',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['count' => 3, 'totalSize' => 6_000_000, 'filenames' => ['a.jpg', 'b.jpg', 'c.jpg']]),
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+        $data = json_decode((string) $browser->getResponse()->getContent(), true);
+        $this->assertSame(UploadBatch::MODE_IMMEDIATE, $data['mode']);
+        $this->assertNotEmpty($data['batchId']);
+    }
+
+    public function testBatchWithRawReturnsDeferredMode(): void
+    {
+        $alice = $this->createUser('alice-raw@example.com', 'password123', 'Alice');
+        $browser = $this->createAuthenticatedKernelBrowser($alice);
+
+        $browser->request(
+            'POST',
+            '/api/v1/uploads/batch',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['count' => 2, 'totalSize' => 2_000_000, 'filenames' => ['a.jpg', 'shot.nef']]),
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+        $data = json_decode((string) $browser->getResponse()->getContent(), true);
+        $this->assertSame(UploadBatch::MODE_DEFERRED, $data['mode']);
+    }
+
+    public function testBatchIsOwnedByCurrentUser(): void
+    {
+        $alice = $this->createUser('alice-owner@example.com', 'password123', 'Alice');
+        $browser = $this->createAuthenticatedKernelBrowser($alice);
+
+        $browser->request(
+            'POST',
+            '/api/v1/uploads/batch',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['count' => 1, 'totalSize' => 1000, 'filenames' => ['a.jpg']]),
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+        $data = json_decode((string) $browser->getResponse()->getContent(), true);
+
+        $batch = $this->em->getRepository(UploadBatch::class)
+            ->find(\Symfony\Component\Uid\Uuid::fromString($data['batchId']));
+        $this->assertNotNull($batch);
+        $this->assertSame((string) $alice->getId(), (string) $batch->getOwner()->getId());
+    }
+
+    public function testUnauthenticatedRequestIsRejected(): void
+    {
+        $browser = static::createClient()->getKernelBrowser();
+
+        $browser->request(
+            'POST',
+            '/api/v1/uploads/batch',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['count' => 1, 'totalSize' => 1000, 'filenames' => ['a.jpg']]),
+        );
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+}

--- a/tests/Service/MediaProcessorTest.php
+++ b/tests/Service/MediaProcessorTest.php
@@ -206,4 +206,39 @@ final class MediaProcessorTest extends TestCase
         $this->assertInstanceOf(Media::class, $media);
         $this->assertSame('video', $media->getMediaType());
     }
+
+    /**
+     * `isRaw()` expose publiquement la reconnaissance des RAW (jusqu'ici privée)
+     * pour que la décision de routage (UploadRoutingDecider) s'appuie sur cette
+     * seule source de vérité plutôt que de redupliquer la liste RAW_EXTENSIONS.
+     */
+    #[DataProvider('isRawProvider')]
+    public function testIsRawRecognisesRawExtensionsCaseInsensitively(string $filename, bool $expected): void
+    {
+        $processor = new MediaProcessor(
+            $this->createStub(MediaRepository::class),
+            $this->createStub(EntityManagerInterface::class),
+            $this->createStub(ExifService::class),
+            $this->createStub(ThumbnailService::class),
+            $this->createStub(StorageServiceInterface::class),
+        );
+
+        $this->assertSame($expected, $processor->isRaw($filename));
+    }
+
+    /**
+     * @return iterable<string, array{string, bool}>
+     */
+    public static function isRawProvider(): iterable
+    {
+        yield 'nef minuscule'   => ['photo.nef', true];
+        yield 'NEF majuscule'   => ['PHOTO.NEF', true];
+        yield 'cr2 casse mixte' => ['img.Cr2', true];
+        yield 'cr3'             => ['clip.cr3', true];
+        yield 'arw'             => ['DSC01234.arw', true];
+        yield 'dng'             => ['shot.dng', true];
+        yield 'jpg non raw'     => ['photo.jpg', false];
+        yield 'tiff hors liste' => ['scan.tiff', false];
+        yield 'sans extension'  => ['README', false];
+    }
 }

--- a/tests/Unit/Service/UploadRoutingDeciderTest.php
+++ b/tests/Unit/Service/UploadRoutingDeciderTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\UploadBatch;
+use App\Interface\StorageServiceInterface;
+use App\Repository\MediaRepository;
+use App\Service\ExifService;
+use App\Service\MediaProcessor;
+use App\Service\ThumbnailService;
+use App\Service\UploadRoutingDecider;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Le worker Messenger ne doit tourner que pour les lots lourds. UploadRoutingDecider
+ * tranche, côté serveur, entre traitement immédiat (kernel.terminate) et déport au
+ * worker : au-dessus d'un seuil de taille cumulée, OU dès qu'un RAW est présent
+ * (décodage preview coûteux). La reconnaissance RAW délègue à MediaProcessor::isRaw
+ * (seule source de vérité), d'où l'injection d'un vrai MediaProcessor ici.
+ */
+final class UploadRoutingDeciderTest extends TestCase
+{
+    private const THRESHOLD = 262144000; // 250 Mo
+
+    private function decider(): UploadRoutingDecider
+    {
+        $mediaProcessor = new MediaProcessor(
+            $this->createStub(MediaRepository::class),
+            $this->createStub(EntityManagerInterface::class),
+            $this->createStub(ExifService::class),
+            $this->createStub(ThumbnailService::class),
+            $this->createStub(StorageServiceInterface::class),
+        );
+
+        return new UploadRoutingDecider($mediaProcessor, self::THRESHOLD);
+    }
+
+    public function testSmallJpegBatchIsImmediate(): void
+    {
+        $this->assertSame(
+            UploadBatch::MODE_IMMEDIATE,
+            $this->decider()->decide(10_000_000, ['a.jpg', 'b.jpg']),
+        );
+    }
+
+    public function testBatchOverThresholdIsDeferred(): void
+    {
+        $this->assertSame(
+            UploadBatch::MODE_DEFERRED,
+            $this->decider()->decide(self::THRESHOLD + 1, ['a.jpg']),
+        );
+    }
+
+    public function testExactThresholdStaysImmediate(): void
+    {
+        // Seuil strict (> SEUIL) : pile au seuil reste immédiat.
+        $this->assertSame(
+            UploadBatch::MODE_IMMEDIATE,
+            $this->decider()->decide(self::THRESHOLD, ['a.jpg']),
+        );
+    }
+
+    public function testSingleRawForcesDeferredEvenWhenSmall(): void
+    {
+        $this->assertSame(
+            UploadBatch::MODE_DEFERRED,
+            $this->decider()->decide(1_000_000, ['a.jpg', 'shot.nef']),
+        );
+    }
+
+    public function testRawDetectionIsCaseInsensitive(): void
+    {
+        $this->assertSame(
+            UploadBatch::MODE_DEFERRED,
+            $this->decider()->decide(1_000, ['PHOTO.NEF']),
+        );
+    }
+
+    public function testNonRawExtensionsStayImmediate(): void
+    {
+        $this->assertSame(
+            UploadBatch::MODE_IMMEDIATE,
+            $this->decider()->decide(1_000, ['scan.tiff', 'note.txt']),
+        );
+    }
+
+    public function testEmptyBatchIsImmediate(): void
+    {
+        $this->assertSame(
+            UploadBatch::MODE_IMMEDIATE,
+            $this->decider()->decide(0, []),
+        );
+    }
+}


### PR DESCRIPTION
Closes #259

## Contexte

Le worker Messenger ne servait plus à rien : chaque upload faisait **les deux** — `bus->dispatch(MediaProcessMessage)` **et** `collector->add()` (traitement immédiat sur `kernel.terminate`) — le worker refaisant un **no-op** grâce à l'idempotence de `MediaProcessor::process()`.

Cette PR rend au worker un rôle exclusif : il ne tourne **que pour les lots lourds**. Petit lot → traitement immédiat (latence perçue nulle, comportement préservé). Lot lourd (**taille cumulée > seuil OU présence d'un RAW**) → déporté au worker. La décision de routage vit **côté serveur** (jamais le client) ; les fichiers d'un même envoi sont corrélés par un `batchId`.

Premier des 3 lots (cœur worker). #260 (email de fin de lot) et #261 (polling + toast) en dépendent.

## Changements

- **`UploadBatch`** (entité) : lot d'upload, UUID v7, `mode` (immediate/deferred), `status`, `completedAt`, `notifiedAt`. Relation `File.batch` **nullable** (n'impacte ni la route web, ni l'import album, ni les fixtures).
- **`UploadRoutingDecider`** : `tailleCumulée > 250 Mo` (paramètre `hc.upload.deferred_threshold_bytes`, ajustable) **ou** présence d'un RAW → `deferred`. RAW délégué à `MediaProcessor::isRaw()`, désormais public (seule source de vérité).
- **`UploadBatchController`** : `POST /api/v1/uploads/batch` → `{ batchId, mode }`, owner = utilisateur courant.
- **`UploadBatchRepository`** : `findById` + `countProcessed` (COUNT indexé sur `batch_id`, base de la future détection de fin de lot).
- **`FileUploadController`** : routage **exclusif** — `deferred` → worker seul ; `immediate` ou pas de lot → collector seul. Vérifie que le lot appartient à l'uploadeur.
- **`FileWebController`** : immediate-only (retrait de `MessageBusInterface`) — la route web n'a pas de notion de lot.
- **Migration** `Version20260719170154` : table `upload_batches` + `files.batch_id` nullable + index. `down()` corrigé (ordre des FK).

## Tests (TDD RED→GREEN)

- `UploadRoutingDeciderTest` : sous/au-dessus du seuil, un seul RAW force deferred, casse, extensions hors liste.
- `UploadBatchControllerTest` : mode immediate/deferred, ownership, 401 non authentifié.
- `FileUploadTriggersImmediateMediaProcessingTest` étendu : deferred → dispatch sans collector ; immediate → collector sans dispatch ; **sans batchId → collector seul** (régression : fin du double dispatch).
- `MediaTest` ajusté : upload image sans lot ne dispatche plus au worker.

## Vérifications

- ✅ PHPUnit complet : **773 tests, 0 échec** (170 notices = dette pré-existante, aucune ajoutée).
- ✅ Jest : **73/73** (aucun JS modifié dans cette PR).
- ✅ Migration réversible (down → up validés).

## Hors périmètre / suite

- Activation `MAILER_DSN` en prod, email de fin de lot → #260.
- Endpoint de statut + polling front + toast → #261.
