### PR TITLE
✨ feat(upload-batch): suivre le traitement d'un lot différé par polling + toast

### DIFF
--- a/assets/js/upload-batch.js
+++ b/assets/js/upload-batch.js
@@ -1,0 +1,126 @@
+/**
+ * HomeCloud — Déclaration de lot d'upload et suivi de traitement (#261).
+ *
+ * Le multi-upload envoie une requête par fichier ; le serveur, pour raisonner
+ * sur le lot entier, a besoin qu'on le lui déclare d'abord (nombre + taille
+ * cumulée + noms). Il répond un batchId et un mode :
+ *   - "immediate" : petit lot, traité juste après la réponse HTTP ;
+ *   - "deferred"  : lot lourd, traité par le worker → on prévient l'utilisateur
+ *                   et on suit l'avancement par polling court.
+ *
+ * Module volontairement pur (aucune dépendance au DOM) pour être testable :
+ * les I/O (POST, GET, timers) sont injectées.
+ */
+
+export const BATCH_CREATE_ROUTE = '/api/v1/uploads/batch';
+
+// Polling court (jamais de long-polling : occuperait un process PHP-FPM sur
+// l'hébergement mutualisé). Intervalle croissant pour alléger encore le serveur.
+export const POLL_BACKOFF_MS = [5000, 10000, 15000];
+export const POLL_TIMEOUT_MS = 10 * 60 * 1000; // 10 min → l'email prend le relais
+
+/**
+ * Agrège les métadonnées d'un lot à partir des fichiers sélectionnés.
+ *
+ * @param {Iterable<File>} files
+ * @returns {{ count: number, totalSize: number, filenames: string[] }}
+ */
+export function computeBatch(files) {
+    const list = Array.from(files || []);
+    return {
+        count: list.length,
+        totalSize: list.reduce((sum, f) => sum + (Number(f?.size) || 0), 0),
+        filenames: list.map((f) => f?.name ?? ''),
+    };
+}
+
+/**
+ * Déclare le lot au serveur et retourne { batchId, mode }.
+ *
+ * @param {Iterable<File>} files
+ * @param {(url: string, payload: object) => Promise<object>} postJson
+ * @returns {Promise<{ batchId: string, mode: string }>}
+ */
+export async function declareBatch(files, postJson) {
+    const batch = computeBatch(files);
+    return postJson(BATCH_CREATE_ROUTE, batch);
+}
+
+/**
+ * Poller d'avancement d'un lot, avec backoff et arrêts garantis.
+ *
+ * S'arrête (définitivement) au premier des cas suivants : lot `completed`,
+ * `stop()` explicite (onglet caché, annulation), ou dépassement du timeout
+ * global. Les timers sont injectables pour des tests déterministes.
+ *
+ * @returns {{ start: () => object, stop: () => void, isStopped: () => boolean }}
+ */
+export function createBatchPoller({
+    batchId,
+    fetchStatus,
+    onComplete,
+    onError,
+    setTimeoutFn = setTimeout,
+    clearTimeoutFn = clearTimeout,
+    nowFn = () => Date.now(),
+    backoffMs = POLL_BACKOFF_MS,
+    timeoutMs = POLL_TIMEOUT_MS,
+}) {
+    let timer = null;
+    let attempt = 0;
+    let stopped = false;
+    const startedAt = nowFn();
+
+    function nextDelay() {
+        return backoffMs[Math.min(attempt, backoffMs.length - 1)];
+    }
+
+    function stop() {
+        stopped = true;
+        if (timer !== null) {
+            clearTimeoutFn(timer);
+            timer = null;
+        }
+    }
+
+    function schedule() {
+        if (stopped) return;
+        timer = setTimeoutFn(tick, nextDelay());
+    }
+
+    async function tick() {
+        timer = null;
+        if (stopped) return;
+
+        if (nowFn() - startedAt >= timeoutMs) {
+            stop();
+            return;
+        }
+
+        try {
+            const status = await fetchStatus(batchId);
+            if (stopped) return;
+            if (status && status.status === 'completed') {
+                stop();
+                onComplete?.(status);
+                return;
+            }
+        } catch (err) {
+            onError?.(err);
+        }
+
+        attempt += 1;
+        schedule();
+    }
+
+    const api = {
+        start() {
+            schedule();
+            return api;
+        },
+        stop,
+        isStopped: () => stopped,
+    };
+
+    return api;
+}

--- a/assets/js/upload-modal.js
+++ b/assets/js/upload-modal.js
@@ -12,6 +12,7 @@
 
 import '../components/hc-folder-list.js';
 import { apiFetch } from './api.js';
+import { declareBatch, createBatchPoller } from './upload-batch.js';
 
 const UPLOAD_API_ROUTE = '/api/v1/files';
 const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024; // 5 GB
@@ -31,24 +32,74 @@ async function getCreateUploadQueue() {
 }
 
 /**
+ * POST JSON vers l'API (déclaration de lot), avec auth centralisée (apiFetch).
+ */
+async function postBatchJson(url, payload) {
+    const res = await apiFetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+    });
+    if (!res.ok) throw new Error(`Batch request failed: ${res.status}`);
+    return res.json();
+}
+
+/**
+ * GET l'avancement d'un lot.
+ */
+async function fetchBatchStatus(batchId) {
+    const res = await apiFetch(`/api/v1/uploads/${batchId}/status`, { method: 'GET' });
+    if (!res.ok) throw new Error(`Batch status failed: ${res.status}`);
+    return res.json();
+}
+
+/**
+ * Suit un lot deferred : toast quand c'est prêt. S'arrête si l'onglet est caché
+ * (l'email prend le relais), à la complétion ou au timeout (gérés par le poller).
+ */
+function startBatchTracking(batchId) {
+    const poller = createBatchPoller({
+        batchId,
+        fetchStatus: fetchBatchStatus,
+        onComplete: () => {
+            document.removeEventListener('visibilitychange', onHidden);
+            window.showToast?.('Vos fichiers sont prêts dans la galerie', 'success');
+        },
+    });
+
+    function onHidden() {
+        if (document.hidden) {
+            poller.stop();
+            document.removeEventListener('visibilitychange', onHidden);
+        }
+    }
+    document.addEventListener('visibilitychange', onHidden);
+
+    poller.start();
+    return poller;
+}
+
+/**
  * Create uploadFn for upload queue.
  * Wraps XHR to support progress callbacks.
- * 
+ *
  * @param {string} token - Bearer token for auth
  * @param {string} folderId - Optional folder ID
  * @param {string} newFolderName - Optional new folder name
+ * @param {string} batchId - Optional upload batch ID (corrèle les fichiers d'un même envoi)
  * @returns {Function} (file, metadata, onProgress) => Promise
  */
-function createUploadFn(token, folderId, newFolderName) {
+function createUploadFn(token, folderId, newFolderName, batchId) {
     return (file, metadata, onProgress) => {
         return new Promise((resolve, reject) => {
             const xhr = new XMLHttpRequest();
             const formData = new FormData();
-            
+
             formData.append('file', file);
             formData.append('ownerId', window.HC?.userId || '');
             if (folderId) formData.append('folderId', folderId);
             if (newFolderName) formData.append('newFolderName', newFolderName);
+            if (batchId) formData.append('batchId', batchId);
 
             // Progress tracking
             if (xhr.upload) {
@@ -400,11 +451,25 @@ async function openUploadModal(files, options = {}) {
         }
 
         try {
-            // Create uploadFn with selected folder
+            // Déclarer le lot : le serveur décide immediate vs deferred et renvoie
+            // le batchId à joindre à chaque upload. Best-effort — si la déclaration
+            // échoue, on uploade quand même sans lot (traitement immédiat côté serveur).
+            let batchId = null;
+            let batchMode = 'immediate';
+            try {
+                const declared = await declareBatch(files, postBatchJson);
+                batchId = declared?.batchId ?? null;
+                batchMode = declared?.mode ?? 'immediate';
+            } catch (e) {
+                console.debug('Batch declaration failed, uploading without batch', e);
+            }
+
+            // Create uploadFn with selected folder + batch
             const uploadFn = createUploadFn(
                 currentToken,
                 destFolder.isNew ? null : destFolder.id,
-                destFolder.isNew ? destFolder.name : null
+                destFolder.isNew ? destFolder.name : null,
+                batchId
             );
 
             // Start queue processing with uploadFn
@@ -412,16 +477,21 @@ async function openUploadModal(files, options = {}) {
 
             // Check results
             const stats = currentUploadQueue.getStats();
-            if (stats.error === 0) {
-                window.showToast?.('Tous les fichiers ont été importés', 'success');
-                setTimeout(() => {
-                    location.reload();
-                }, 2000);
-            } else {
+            if (stats.error > 0) {
                 window.showToast?.(
                     `${stats.error} fichier(s) en erreur, ${stats.completed} réussi(s)`,
                     'warning'
                 );
+            } else if (batchMode === 'deferred' && batchId) {
+                // Lot lourd : le transfert est fini, le traitement média continue
+                // en tâche de fond (worker). On prévient et on suit par polling.
+                window.showToast?.('Envoi terminé — traitement en cours, vous recevrez un email quand tout sera prêt', 'success');
+                startBatchTracking(batchId);
+            } else {
+                window.showToast?.('Tous les fichiers ont été importés', 'success');
+                setTimeout(() => {
+                    location.reload();
+                }, 2000);
             }
 
             closeUploadModal();

--- a/assets/tests/upload-batch.test.js
+++ b/assets/tests/upload-batch.test.js
@@ -1,0 +1,143 @@
+import { jest, describe, test, expect } from '@jest/globals';
+
+const { computeBatch, declareBatch, createBatchPoller } = await import('../js/upload-batch.js');
+
+describe('computeBatch', () => {
+    test('agrège nombre, taille cumulée et noms', () => {
+        const files = [
+            { name: 'a.jpg', size: 1000 },
+            { name: 'b.nef', size: 2500 },
+        ];
+        expect(computeBatch(files)).toEqual({
+            count: 2,
+            totalSize: 3500,
+            filenames: ['a.jpg', 'b.nef'],
+        });
+    });
+
+    test('lot vide → zéro', () => {
+        expect(computeBatch([])).toEqual({ count: 0, totalSize: 0, filenames: [] });
+    });
+
+    test('tolère une taille manquante', () => {
+        expect(computeBatch([{ name: 'x' }]).totalSize).toBe(0);
+    });
+});
+
+describe('declareBatch', () => {
+    test('poste les métadonnées du lot et retourne la réponse serveur', async () => {
+        const postJson = jest.fn().mockResolvedValue({ batchId: 'b-1', mode: 'deferred' });
+        const files = [{ name: 'a.jpg', size: 10 }, { name: 'b.jpg', size: 20 }];
+
+        const res = await declareBatch(files, postJson);
+
+        expect(postJson).toHaveBeenCalledWith('/api/v1/uploads/batch', {
+            count: 2,
+            totalSize: 30,
+            filenames: ['a.jpg', 'b.jpg'],
+        });
+        expect(res).toEqual({ batchId: 'b-1', mode: 'deferred' });
+    });
+});
+
+describe('createBatchPoller', () => {
+    // Ordonnanceur de timers manuel : on garde la callback et on l'exécute à la
+    // demande, pour piloter le polling sans horloge réelle.
+    function manualScheduler() {
+        let pending = null;
+        return {
+            setTimeoutFn: (fn) => { pending = fn; return 1; },
+            clearTimeoutFn: () => { pending = null; },
+            run: async () => { const fn = pending; pending = null; if (fn) await fn(); },
+            hasPending: () => pending !== null,
+        };
+    }
+
+    test('appelle onComplete et s\'arrête quand le lot est completed', async () => {
+        const sched = manualScheduler();
+        const fetchStatus = jest.fn().mockResolvedValue({ status: 'completed', processed: 3, total: 3 });
+        const onComplete = jest.fn();
+
+        const poller = createBatchPoller({
+            batchId: 'b-1', fetchStatus, onComplete,
+            setTimeoutFn: sched.setTimeoutFn, clearTimeoutFn: sched.clearTimeoutFn,
+        });
+        poller.start();
+        await sched.run(); // premier tick
+
+        expect(onComplete).toHaveBeenCalledWith({ status: 'completed', processed: 3, total: 3 });
+        expect(poller.isStopped()).toBe(true);
+        expect(sched.hasPending()).toBe(false);
+    });
+
+    test('reprogramme tant que le lot n\'est pas terminé (backoff)', async () => {
+        const sched = manualScheduler();
+        const delays = [];
+        const setTimeoutFn = (fn, d) => { delays.push(d); return sched.setTimeoutFn(fn, d); };
+        const fetchStatus = jest.fn().mockResolvedValue({ status: 'processing', processed: 1, total: 3 });
+
+        const poller = createBatchPoller({
+            batchId: 'b-1', fetchStatus,
+            setTimeoutFn, clearTimeoutFn: sched.clearTimeoutFn,
+        });
+        poller.start();
+        await sched.run(); // tick 1 → reprogramme
+        await sched.run(); // tick 2 → reprogramme
+
+        expect(fetchStatus).toHaveBeenCalledTimes(2);
+        expect(poller.isStopped()).toBe(false);
+        // Intervalle croissant : 5s puis 10s puis 15s.
+        expect(delays.slice(0, 3)).toEqual([5000, 10000, 15000]);
+    });
+
+    test('s\'arrête au-delà du timeout global', async () => {
+        const sched = manualScheduler();
+        let clock = 0;
+        const nowFn = () => clock;
+        const fetchStatus = jest.fn().mockResolvedValue({ status: 'processing' });
+
+        const poller = createBatchPoller({
+            batchId: 'b-1', fetchStatus, nowFn, timeoutMs: 1000,
+            setTimeoutFn: sched.setTimeoutFn, clearTimeoutFn: sched.clearTimeoutFn,
+        });
+        poller.start();
+        clock = 2000; // au-delà du timeout
+        await sched.run();
+
+        expect(fetchStatus).not.toHaveBeenCalled();
+        expect(poller.isStopped()).toBe(true);
+    });
+
+    test('stop() empêche tout tick ultérieur', async () => {
+        const sched = manualScheduler();
+        const fetchStatus = jest.fn().mockResolvedValue({ status: 'processing' });
+
+        const poller = createBatchPoller({
+            batchId: 'b-1', fetchStatus,
+            setTimeoutFn: sched.setTimeoutFn, clearTimeoutFn: sched.clearTimeoutFn,
+        });
+        poller.start();
+        poller.stop();
+        await sched.run();
+
+        expect(fetchStatus).not.toHaveBeenCalled();
+        expect(poller.isStopped()).toBe(true);
+    });
+
+    test('poursuit le polling malgré une erreur réseau ponctuelle', async () => {
+        const sched = manualScheduler();
+        const fetchStatus = jest.fn().mockRejectedValue(new Error('network'));
+        const onError = jest.fn();
+
+        const poller = createBatchPoller({
+            batchId: 'b-1', fetchStatus, onError,
+            setTimeoutFn: sched.setTimeoutFn, clearTimeoutFn: sched.clearTimeoutFn,
+        });
+        poller.start();
+        await sched.run();
+
+        expect(onError).toHaveBeenCalled();
+        expect(poller.isStopped()).toBe(false);
+        expect(sched.hasPending()).toBe(true); // reprogrammé
+    });
+});

--- a/src/Controller/Api/UploadBatchController.php
+++ b/src/Controller/Api/UploadBatchController.php
@@ -6,6 +6,7 @@ namespace App\Controller\Api;
 
 use App\Entity\UploadBatch;
 use App\Interface\AuthenticationResolverInterface;
+use App\Interface\UploadBatchRepositoryInterface;
 use App\Service\UploadRoutingDecider;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -13,16 +14,22 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
 
 /**
- * Déclaration d'un lot d'upload multi-fichiers.
+ * Cycle de vie d'un lot d'upload multi-fichiers.
  *
  * Le front, seul à connaître le lot entier (chaque fichier part ensuite dans sa
  * propre requête POST /api/v1/files), déclare ici le lot avant d'uploader :
  * nombre de fichiers, taille cumulée, noms. Le serveur décide alors — via
  * UploadRoutingDecider, seul juge — si le traitement média sera immédiat ou
  * déporté au worker, et retourne le batchId à joindre à chaque upload.
+ *
+ * Pour un lot deferred, le front interroge ensuite l'avancement (`status`) par
+ * polling court afin d'afficher un toast quand tout est prêt.
  *
  * Le JS ne fait qu'informer l'utilisateur (UX) : la décision de routage n'est
  * jamais laissée au client (contournable, et ignorant du coût réel).
@@ -33,11 +40,12 @@ final class UploadBatchController extends AbstractController
     public function __construct(
         private readonly AuthenticationResolverInterface $authResolver,
         private readonly UploadRoutingDecider $routingDecider,
+        private readonly UploadBatchRepositoryInterface $uploadBatchRepository,
         private readonly EntityManagerInterface $em,
     ) {}
 
     #[Route('/api/v1/uploads/batch', name: 'api_upload_batch_create', methods: ['POST'])]
-    public function __invoke(Request $request): Response
+    public function create(Request $request): Response
     {
         $owner = $this->authResolver->requireUser();
 
@@ -66,5 +74,36 @@ final class UploadBatchController extends AbstractController
             ],
             Response::HTTP_CREATED,
         );
+    }
+
+    /**
+     * Avancement d'un lot, interrogé en polling court par le front (lot deferred).
+     * Réponse minimale (COUNT indexé) : coût négligeable devant le traitement.
+     */
+    #[Route('/api/v1/uploads/{batchId}/status', name: 'api_upload_batch_status', methods: ['GET'])]
+    public function status(string $batchId): Response
+    {
+        $owner = $this->authResolver->requireUser();
+
+        try {
+            $batch = $this->uploadBatchRepository->findById(Uuid::fromString($batchId));
+        } catch (\InvalidArgumentException) {
+            throw new NotFoundHttpException('Batch not found');
+        }
+
+        if ($batch === null) {
+            throw new NotFoundHttpException('Batch not found');
+        }
+
+        // Un utilisateur ne peut consulter que ses propres lots.
+        if ((string) $batch->getOwner()->getId() !== (string) $owner->getId()) {
+            throw new AccessDeniedHttpException('This batch belongs to another user');
+        }
+
+        return new JsonResponse([
+            'status'    => $batch->getStatus(),
+            'processed' => $this->uploadBatchRepository->countProcessed($batch),
+            'total'     => $batch->getExpectedCount(),
+        ]);
     }
 }

--- a/tests/Api/UploadBatchControllerTest.php
+++ b/tests/Api/UploadBatchControllerTest.php
@@ -91,4 +91,46 @@ final class UploadBatchControllerTest extends AuthenticatedApiTestCase
 
         $this->assertResponseStatusCodeSame(401);
     }
+
+    public function testStatusReturnsProgressForOwnBatch(): void
+    {
+        $alice = $this->createUser('alice-status@example.com', 'password123', 'Alice');
+        $batch = new UploadBatch($alice, 3, 300_000_000, UploadBatch::MODE_DEFERRED);
+        $this->em->persist($batch);
+        $this->em->flush();
+        $batchId = (string) $batch->getId();
+
+        $browser = $this->createAuthenticatedKernelBrowser($alice);
+        $browser->request('GET', '/api/v1/uploads/' . $batchId . '/status');
+
+        $this->assertResponseStatusCodeSame(200);
+        $data = json_decode((string) $browser->getResponse()->getContent(), true);
+        $this->assertSame(UploadBatch::STATUS_PENDING, $data['status']);
+        $this->assertSame(0, $data['processed']);
+        $this->assertSame(3, $data['total']);
+    }
+
+    public function testStatusOfAnotherUsersBatchIsForbidden(): void
+    {
+        $alice = $this->createUser('alice-owner2@example.com', 'password123', 'Alice');
+        $batch = new UploadBatch($alice, 1, 1000, UploadBatch::MODE_IMMEDIATE);
+        $this->em->persist($batch);
+        $this->em->flush();
+        $batchId = (string) $batch->getId();
+
+        $bob = $this->createUser('bob-intrus@example.com', 'password123', 'Bob');
+        $browser = $this->createAuthenticatedKernelBrowser($bob);
+        $browser->request('GET', '/api/v1/uploads/' . $batchId . '/status');
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testStatusOfUnknownBatchReturns404(): void
+    {
+        $alice = $this->createUser('alice-404@example.com', 'password123', 'Alice');
+        $browser = $this->createAuthenticatedKernelBrowser($alice);
+        $browser->request('GET', '/api/v1/uploads/00000000-0000-0000-0000-000000000000/status');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
 }


### PR DESCRIPTION
Closes #261

> ⚠️ **Stacked sur #263 (#260).** Base = `feat/#260-batch-completion-email`. À rebaser sur `main` une fois #259 puis #260 mergées.

## Contexte

Dernier des 3 lots. Pour un lot **deferred**, le front interroge l'avancement du traitement et affiche un toast quand tout est prêt — Mercure étant impossible sur o2switch (hub = daemon), on utilise du **polling court** (jamais de long-polling, qui occuperait un process PHP-FPM).

## Changements

### Backend
- **`UploadBatchController::status`** — `GET /api/v1/uploads/{batchId}/status` : `{ status, processed, total }` (`countProcessed` indexé). **Ownership obligatoire** (403 sinon), 404 si inconnu. Le contrôleur passe en actions nommées (`create` + `status`).

### Frontend
- **`assets/js/upload-batch.js`** (nouveau, pur/testable) :
  - `computeBatch(files)` → `{ count, totalSize, filenames }` ;
  - `declareBatch(files, postJson)` → `POST /uploads/batch` → `{ batchId, mode }` ;
  - `createBatchPoller(...)` → polling avec **backoff 5→10→15 s**, arrêts garantis (completed / `stop()` / timeout 10 min), timers injectables.
- **`assets/js/upload-modal.js`** : déclare le lot avant l'envoi (best-effort — échec ⇒ upload sans lot ⇒ traitement immédiat côté serveur), ajoute `batchId` au `FormData`, et si `deferred` : toast « traitement en cours, email à la fin » + polling → toast « prêts », **stop sur onglet caché** (`visibilitychange`).

## Tests (TDD RED→GREEN)

- `UploadBatchControllerTest` (statut) : happy path ; **403 pour un autre utilisateur** ; 404 inconnu.
- Jest `upload-batch.test.js` : `computeBatch` (count/totalSize/filenames, lot vide, taille manquante) ; `declareBatch` (payload + retour) ; poller (complétion, backoff, timeout, `stop()`, résilience réseau).

## Vérifications

- ✅ PHPUnit complet : **781 tests, 0 échec**.
- ✅ Jest : **82/82**.

## Notes

Connexes (même zone `upload-modal.js`) : #245 (curseur de concurrence), #239 (barre de progression).
