### PR TITLE
✨ feat(BatchCompletionNotifier): notifier par email la fin d'un lot d'upload différé

### DIFF
--- a/.claude/deploiement.md
+++ b/.claude/deploiement.md
@@ -188,9 +188,20 @@ DATABASE_URL=mysql://ron2cuba_<prenom>:<password>@127.0.0.1:3306/ron2cuba_<preno
 JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
 JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
 JWT_PASSPHRASE=
+MAILER_DSN=smtp://<user>:<password>@lenouvel.me:465
 ```
 
 > Généré automatiquement par `bin/deploy-all.sh --init`. Pour `bin/deploy.sh`, le script le crée aussi.
+
+### `MAILER_DSN` — obligatoire pour les emails (dont la notif de fin de lot)
+
+Par défaut `MAILER_DSN=null://null` (`.env`) : **aucun email n'est envoyé**. Les
+flux transactionnels (reset password, invitation, notification de partage) et la
+**notification de fin de traitement d'un lot lourd** (#260 — email « vos fichiers
+sont prêts » quand le worker a terminé un lot deferred) nécessitent un DSN SMTP
+réel, à renseigner sur chaque instance (jamais dans git — SMTP o2switch injoignable
+depuis localhost, port 465 bloqué). Sans lui, le traitement se fait quand même,
+seul l'email de notification manque.
 
 ---
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -28,6 +28,7 @@ services:
     App\Interface\OwnershipCheckerInterface:      '@App\Security\OwnershipChecker'
     App\Interface\AuthenticationResolverInterface: '@App\Security\AuthenticationResolver'
     App\Interface\UploadBatchRepositoryInterface: '@App\Repository\UploadBatchRepository'
+    App\Interface\BatchCompletionNotifierInterface: '@App\Service\BatchCompletionNotifier'
 
     App\State\AlbumProcessor:
         arguments:

--- a/src/Handler/MediaProcessHandler.php
+++ b/src/Handler/MediaProcessHandler.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace App\Handler;
 
+use App\Entity\UploadBatch;
+use App\Interface\BatchCompletionNotifierInterface;
 use App\Interface\MediaProcessorInterface;
+use App\Interface\UploadBatchRepositoryInterface;
 use App\Message\MediaProcessMessage;
 use App\Repository\FileRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
@@ -14,9 +18,12 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  *
  * Rôle : point d'entrée asynchrone (transport doctrine) du traitement média —
  * ne bloque pas la réponse HTTP de l'upload. La logique métier (EXIF,
- * thumbnail, idempotence) est déléguée à MediaProcessor, réutilisé aussi en
- * synchrone par les flux qui ont besoin du Media immédiatement (ex: import
- * direct dans un album).
+ * thumbnail, idempotence) est déléguée à MediaProcessor.
+ *
+ * Depuis le routage par lot (#259), un message n'arrive ici que pour les lots
+ * lourds (deferred). Une fois le fichier traité, si c'est le dernier du lot,
+ * le handler marque le lot terminé et déclenche la notification (#260) — une
+ * seule fois, gardé par notifiedAt (le worker peut rejouer un message).
  */
 #[AsMessageHandler]
 final class MediaProcessHandler
@@ -24,6 +31,9 @@ final class MediaProcessHandler
     public function __construct(
         private readonly FileRepository $fileRepository,
         private readonly MediaProcessorInterface $mediaProcessor,
+        private readonly UploadBatchRepositoryInterface $uploadBatchRepository,
+        private readonly BatchCompletionNotifierInterface $batchCompletionNotifier,
+        private readonly EntityManagerInterface $em,
     ) {}
 
     public function __invoke(MediaProcessMessage $message): void
@@ -34,5 +44,32 @@ final class MediaProcessHandler
         }
 
         $this->mediaProcessor->process($file);
+
+        $this->notifyIfBatchCompleted($file->getBatch());
+    }
+
+    /**
+     * Marque le lot terminé et notifie le propriétaire dès que tous ses
+     * fichiers ont un Media. Ne concerne que les lots deferred (les lots
+     * immediate ne passent pas par le worker), et n'agit qu'une fois
+     * (notifiedAt). Le comptage s'appuie sur l'état réel en base
+     * (countProcessed) plutôt qu'un compteur, donc reste correct si un message
+     * est rejoué.
+     */
+    private function notifyIfBatchCompleted(?UploadBatch $batch): void
+    {
+        if ($batch === null || !$batch->isDeferred() || $batch->getNotifiedAt() !== null) {
+            return;
+        }
+
+        if ($this->uploadBatchRepository->countProcessed($batch) < $batch->getExpectedCount()) {
+            return;
+        }
+
+        $batch->setStatus(UploadBatch::STATUS_COMPLETED);
+        $batch->setCompletedAt(new \DateTimeImmutable());
+        $this->batchCompletionNotifier->notify($batch);
+
+        $this->em->flush();
     }
 }

--- a/src/Interface/BatchCompletionNotifierInterface.php
+++ b/src/Interface/BatchCompletionNotifierInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\UploadBatch;
+
+/**
+ * Contrat de notification de fin de traitement d'un lot d'upload (DIP :
+ * mockable en test, canal swappable — email aujourd'hui, autre demain).
+ */
+interface BatchCompletionNotifierInterface
+{
+    /**
+     * Notifie le propriétaire que le lot est prêt et pose notifiedAt.
+     */
+    public function notify(UploadBatch $batch): void;
+}

--- a/src/Service/BatchCompletionNotifier.php
+++ b/src/Service/BatchCompletionNotifier.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\UploadBatch;
+use App\Interface\BatchCompletionNotifierInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Prévient le propriétaire d'un lot lourd (deferred) que son traitement média
+ * est terminé, par email — seul canal garanti quand l'utilisateur a quitté
+ * l'écran (le worker traite hors session HTTP).
+ *
+ * Pose notifiedAt : conjugué au garde du handler, ce marqueur assure qu'un lot
+ * n'est notifié qu'une fois même si le worker rejoue un message.
+ *
+ * Calqué sur ShareNotificationMailer (from no-reply, branding centralisé).
+ */
+final readonly class BatchCompletionNotifier implements BatchCompletionNotifierInterface
+{
+    public function __construct(
+        private MailerInterface $mailer,
+        private UrlGeneratorInterface $urlGenerator,
+    ) {}
+
+    public function notify(UploadBatch $batch): void
+    {
+        $galleryUrl = $this->urlGenerator->generate(
+            'app_gallery',
+            [],
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+
+        $count = $batch->getExpectedCount();
+
+        $email = (new TemplatedEmail())
+            ->from(new Address('no-reply@homecloud.fr'))
+            ->to($batch->getOwner()->getEmail())
+            ->subject(sprintf(
+                '%d %s prêt%s dans votre galerie',
+                $count,
+                $count > 1 ? 'fichiers' : 'fichier',
+                $count > 1 ? 's' : '',
+            ))
+            ->htmlTemplate('emails/batch_ready.html.twig')
+            ->context([
+                'count'       => $count,
+                'galleryUrl'  => $galleryUrl,
+                'ownerName'   => $batch->getOwner()->getDisplayName(),
+                'accentColor' => EmailBranding::ACCENT_COLOR,
+            ]);
+
+        $this->mailer->send($email);
+
+        $batch->setNotifiedAt(new \DateTimeImmutable());
+    }
+}

--- a/templates/emails/batch_ready.html.twig
+++ b/templates/emails/batch_ready.html.twig
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Vos fichiers sont prêts — HomeCloud</title>
+</head>
+<body style="margin:0; padding:0; background-color:#FAFAFA; font-family:Arial, Helvetica, sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#FAFAFA;">
+<tr>
+<td align="center" style="padding:32px 16px;">
+
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:480px; background-color:#FFFFFF; border-radius:12px; border:1px solid #e5e5e5;">
+
+<tr>
+<td align="center" style="padding:28px 32px 0 32px;">
+<span style="font-size:20px; font-weight:bold; color:{{ accentColor }};">HomeCloud</span>
+</td>
+</tr>
+
+<tr>
+<td style="padding:24px 32px 8px 32px; color:#0b1220; font-size:15px; line-height:1.5;">
+Bonjour {{ ownerName }},
+</td>
+</tr>
+
+<tr>
+<td style="padding:0 32px 24px 32px; color:#0b1220; font-size:15px; line-height:1.5;">
+Le traitement de votre envoi est terminé&nbsp;:
+<br>
+<span style="font-size:17px; font-weight:bold;">
+{% if count > 1 %}{{ count }} fichiers sont prêts{% else %}{{ count }} fichier est prêt{% endif %}
+</span>
+dans votre galerie (vignettes et informations générées).
+</td>
+</tr>
+
+<tr>
+<td align="center" style="padding:0 32px 32px 32px;">
+<table role="presentation" cellpadding="0" cellspacing="0" border="0">
+<tr>
+<td align="center" bgcolor="{{ accentColor }}" style="border-radius:8px;">
+<a href="{{ galleryUrl }}" class="hc-email-cta-button" style="display:inline-block; padding:12px 28px; font-size:15px; font-weight:bold; color:#FFFFFF; text-decoration:none; border-radius:8px;">
+Voir ma galerie
+</a>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+
+<tr>
+<td style="padding:0 32px 28px 32px; border-top:1px solid #e5e5e5; padding-top:20px;">
+<span style="font-size:12px; color:#8a8f98;">
+Si le bouton ne fonctionne pas, copiez ce lien dans votre navigateur&nbsp;: {{ galleryUrl }}
+</span>
+</td>
+</tr>
+
+</table>
+
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:480px;">
+<tr>
+<td align="center" style="padding:16px 32px; color:#8a8f98; font-size:12px;">
+HomeCloud — votre cloud personnel
+<br>
+Solution entièrement développée par Ronan Lenouvel
+</td>
+</tr>
+</table>
+
+</td>
+</tr>
+</table>
+</body>
+</html>

--- a/tests/Handler/MediaProcessHandlerTest.php
+++ b/tests/Handler/MediaProcessHandlerTest.php
@@ -5,37 +5,177 @@ declare(strict_types=1);
 namespace App\Tests\Handler;
 
 use App\Entity\File;
+use App\Entity\UploadBatch;
+use App\Entity\User;
 use App\Handler\MediaProcessHandler;
-use App\Message\MediaProcessMessage;
 use App\Interface\MediaProcessorInterface;
+use App\Interface\UploadBatchRepositoryInterface;
+use App\Message\MediaProcessMessage;
 use App\Repository\FileRepository;
+use App\Interface\BatchCompletionNotifierInterface;
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 
 final class MediaProcessHandlerTest extends TestCase
 {
+    private function handler(
+        FileRepository $fileRepo,
+        MediaProcessorInterface $processor,
+        ?UploadBatchRepositoryInterface $batchRepo = null,
+        ?BatchCompletionNotifierInterface $notifier = null,
+        ?EntityManagerInterface $em = null,
+    ): MediaProcessHandler {
+        return new MediaProcessHandler(
+            $fileRepo,
+            $processor,
+            $batchRepo ?? $this->createStub(UploadBatchRepositoryInterface::class),
+            $notifier ?? $this->createStub(BatchCompletionNotifierInterface::class),
+            $em ?? $this->createStub(EntityManagerInterface::class),
+        );
+    }
+
     public function testHandlerDelegatesToMediaProcessorWhenFileExists(): void
     {
-        $file = $this->createMock(File::class);
+        $file = $this->createStub(File::class);
+        $file->method('getBatch')->willReturn(null);
 
-        $fileRepo = $this->createMock(FileRepository::class);
+        $fileRepo = $this->createStub(FileRepository::class);
         $fileRepo->method('find')->willReturn($file);
 
         $processor = $this->createMock(MediaProcessorInterface::class);
         $processor->expects($this->once())->method('process')->with($file);
 
-        $handler = new MediaProcessHandler($fileRepo, $processor);
-        $handler(new MediaProcessMessage('some-uuid'));
+        $this->handler($fileRepo, $processor)(new MediaProcessMessage('some-uuid'));
     }
 
     public function testHandlerDoesNothingWhenFileNotFound(): void
     {
-        $fileRepo = $this->createMock(FileRepository::class);
+        $fileRepo = $this->createStub(FileRepository::class);
         $fileRepo->method('find')->willReturn(null);
 
         $processor = $this->createMock(MediaProcessorInterface::class);
         $processor->expects($this->never())->method('process');
 
-        $handler = new MediaProcessHandler($fileRepo, $processor);
-        $handler(new MediaProcessMessage('some-uuid'));
+        $this->handler($fileRepo, $processor)(new MediaProcessMessage('some-uuid'));
+    }
+
+    /**
+     * Dernier fichier du lot traité → le lot est marqué terminé et le
+     * propriétaire est notifié, une seule fois.
+     */
+    public function testNotifiesWhenLastFileOfDeferredBatchIsProcessed(): void
+    {
+        $owner = new User('owner@example.com', 'Owner');
+        $batch = new UploadBatch($owner, 2, 300_000_000, UploadBatch::MODE_DEFERRED);
+
+        $file = $this->createStub(File::class);
+        $file->method('getBatch')->willReturn($batch);
+
+        $fileRepo = $this->createStub(FileRepository::class);
+        $fileRepo->method('find')->willReturn($file);
+
+        $processor = $this->createStub(MediaProcessorInterface::class);
+
+        $batchRepo = $this->createStub(UploadBatchRepositoryInterface::class);
+        $batchRepo->method('countProcessed')->willReturn(2); // tous traités
+
+        $notifier = $this->createMock(BatchCompletionNotifierInterface::class);
+        $notifier->expects($this->once())->method('notify')->with($batch);
+
+        $em = $this->createStub(EntityManagerInterface::class);
+
+        $this->handler($fileRepo, $processor, $batchRepo, $notifier, $em)(new MediaProcessMessage('id'));
+
+        $this->assertSame(UploadBatch::STATUS_COMPLETED, $batch->getStatus());
+        $this->assertNotNull($batch->getCompletedAt());
+    }
+
+    /**
+     * Fichier intermédiaire (le lot n'est pas complet) → aucune notification.
+     */
+    public function testDoesNotNotifyWhenBatchStillIncomplete(): void
+    {
+        $owner = new User('owner@example.com', 'Owner');
+        $batch = new UploadBatch($owner, 3, 300_000_000, UploadBatch::MODE_DEFERRED);
+
+        $file = $this->createStub(File::class);
+        $file->method('getBatch')->willReturn($batch);
+
+        $fileRepo = $this->createStub(FileRepository::class);
+        $fileRepo->method('find')->willReturn($file);
+
+        $batchRepo = $this->createStub(UploadBatchRepositoryInterface::class);
+        $batchRepo->method('countProcessed')->willReturn(1); // 1/3
+
+        $notifier = $this->createMock(BatchCompletionNotifierInterface::class);
+        $notifier->expects($this->never())->method('notify');
+
+        $this->handler(
+            $fileRepo,
+            $this->createStub(MediaProcessorInterface::class),
+            $batchRepo,
+            $notifier,
+        )(new MediaProcessMessage('id'));
+
+        $this->assertNotSame(UploadBatch::STATUS_COMPLETED, $batch->getStatus());
+    }
+
+    /**
+     * Idempotence : un lot déjà notifié (notifiedAt posé) ne renvoie jamais un
+     * second email, même si le worker rejoue un message.
+     */
+    public function testDoesNotNotifyTwiceForAlreadyNotifiedBatch(): void
+    {
+        $owner = new User('owner@example.com', 'Owner');
+        $batch = new UploadBatch($owner, 1, 300_000_000, UploadBatch::MODE_DEFERRED);
+        $batch->setNotifiedAt(new \DateTimeImmutable('-1 minute'));
+
+        $file = $this->createStub(File::class);
+        $file->method('getBatch')->willReturn($batch);
+
+        $fileRepo = $this->createStub(FileRepository::class);
+        $fileRepo->method('find')->willReturn($file);
+
+        $batchRepo = $this->createStub(UploadBatchRepositoryInterface::class);
+        $batchRepo->method('countProcessed')->willReturn(1);
+
+        $notifier = $this->createMock(BatchCompletionNotifierInterface::class);
+        $notifier->expects($this->never())->method('notify');
+
+        $this->handler(
+            $fileRepo,
+            $this->createStub(MediaProcessorInterface::class),
+            $batchRepo,
+            $notifier,
+        )(new MediaProcessMessage('id'));
+    }
+
+    /**
+     * Un lot immediate ne passe jamais par le worker pour la notification :
+     * même traité ici (secours), il ne déclenche pas d'email.
+     */
+    public function testImmediateBatchIsNeverNotified(): void
+    {
+        $owner = new User('owner@example.com', 'Owner');
+        $batch = new UploadBatch($owner, 1, 500_000, UploadBatch::MODE_IMMEDIATE);
+
+        $file = $this->createStub(File::class);
+        $file->method('getBatch')->willReturn($batch);
+
+        $fileRepo = $this->createStub(FileRepository::class);
+        $fileRepo->method('find')->willReturn($file);
+
+        $batchRepo = $this->createStub(UploadBatchRepositoryInterface::class);
+        $batchRepo->method('countProcessed')->willReturn(1);
+
+        $notifier = $this->createMock(BatchCompletionNotifierInterface::class);
+        $notifier->expects($this->never())->method('notify');
+
+        $this->handler(
+            $fileRepo,
+            $this->createStub(MediaProcessorInterface::class),
+            $batchRepo,
+            $notifier,
+        )(new MediaProcessMessage('id'));
     }
 }

--- a/tests/Service/BatchCompletionNotifierTest.php
+++ b/tests/Service/BatchCompletionNotifierTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Entity\UploadBatch;
+use App\Entity\User;
+use App\Service\BatchCompletionNotifier;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Notifie le propriétaire d'un lot lourd (deferred) quand son traitement média
+ * est terminé — canal email, garanti même si l'utilisateur a quitté l'écran.
+ */
+final class BatchCompletionNotifierTest extends TestCase
+{
+    public function testNotifySendsEmailToBatchOwnerAndStampsNotifiedAt(): void
+    {
+        $owner = new User('owner@example.com', 'Owner');
+        $batch = new UploadBatch($owner, 3, 300_000_000, UploadBatch::MODE_DEFERRED);
+
+        $sent = null;
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects($this->once())
+            ->method('send')
+            ->willReturnCallback(function (TemplatedEmail $email) use (&$sent): void {
+                $sent = $email;
+            });
+
+        $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturn('https://home.example/gallery');
+
+        $notifier = new BatchCompletionNotifier($mailer, $urlGenerator);
+        $notifier->notify($batch);
+
+        $this->assertNotNull($sent, 'Un email doit être envoyé');
+        $this->assertSame('emails/batch_ready.html.twig', $sent->getHtmlTemplate());
+        $addresses = array_map(static fn ($a) => $a->getAddress(), $sent->getTo());
+        $this->assertContains('owner@example.com', $addresses);
+        $this->assertNotNull($batch->getNotifiedAt(), 'notifiedAt doit être posé après envoi');
+    }
+}


### PR DESCRIPTION
Closes #260

_(Remplace #263, auto-fermée quand la branche de base #259 a été supprimée au merge de #262. Rebasée sur `main`.)_

## Contexte

Suite de #259 : quand un lot **deferred** (lourd) est entièrement traité par le worker Messenger, prévenir le propriétaire par **email** — canal garanti même s'il a quitté l'écran.

## Changements

- **`BatchCompletionNotifier`** (+ interface DIP) : `TemplatedEmail` au propriétaire du lot, pose `notifiedAt`. Calqué sur `ShareNotificationMailer` (from `no-reply`, `EmailBranding::ACCENT_COLOR`, lien `app_gallery`).
- **`templates/emails/batch_ready.html.twig`** : « vos N fichiers sont prêts ».
- **`MediaProcessHandler`** : au dernier fichier du lot (`countProcessed == expectedCount`) → `status=completed`, `completedAt`, notification une seule fois (garde `notifiedAt`, robuste au rejeu worker).
- **`.claude/deploiement.md`** : `MAILER_DSN` documenté (par défaut `null://null` → aucun email ; traitement OK, seul l'email manque).

## Tests (TDD)

- `BatchCompletionNotifierTest` : destinataire = owner, template, `notifiedAt`.
- `MediaProcessHandlerTest` : dernier → email 1 fois + completed ; intermédiaire → rien ; déjà notifié → pas de doublon ; immediate → jamais notifié.

## Vérifications

- ✅ PHPUnit complet : 778 tests, 0 échec.
