### PR TITLE
📝 docs: corriger le docblock ThumbnailService + retirer la mention PWA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Ne jamais utiliser `#[ORM\GeneratedValue]` ni `private ?Uuid $id = null;`.
 | `File`   | Fichier uploadé                 |
 | `Media`  | Métadonnées média (image/vidéo) |
 
-Stack : Symfony 7 / API Platform 3, PHP 8.4, MariaDB, Tailwind v4, Stimulus, PWA.
+Stack : Symfony 7 / API Platform 3, PHP 8.4, MariaDB, Tailwind v4, Stimulus.
 
 ---
 

--- a/src/Service/ThumbnailService.php
+++ b/src/Service/ThumbnailService.php
@@ -40,7 +40,7 @@ class ThumbnailService
     /**
      * Génère un thumbnail et retourne son chemin relatif, ou null si impossible.
      *
-     * @param string $absolutePath Chemin absolu de l'image source (chiffrée sur disque)
+     * @param string $absolutePath Chemin absolu de l'image source (stockée en clair sur disque)
      * @return string|null         Chemin relatif du thumbnail (ex: "thumbs/uuid.jpg") ou null
      */
     public function generate(string $absolutePath): ?string


### PR DESCRIPTION
Deux quick wins issus de l'audit du backlog (`avancement.md`) :

- **`ThumbnailService::generate()`** : le docblock `@param` disait « chiffrée sur disque » alors que la source est stockée en clair (incohérent avec le reste de la classe). Corrigé.
- **`CLAUDE.md`** : retrait de « PWA » de la ligne stack — aucun `manifest.json` ni service worker n'existe dans le projet.

Aucun changement de comportement (docblock + doc uniquement). Résout les incohérences #9 (partielle) et #11 du backlog.