### PR TITLE
✨ feat(FolderZipArchiver): téléchargement d'un dossier entier en zip

### DIFF
--- a/.claude/deploiement.md
+++ b/.claude/deploiement.md
@@ -192,6 +192,11 @@ MAILER_DSN=smtp://<user>:<password>@lenouvel.me:465
 ```
 
 > Généré automatiquement par `bin/deploy-all.sh --init`. Pour `bin/deploy.sh`, le script le crée aussi.
+>
+> `MAILER_DSN` vient de `MAILER_DSN_PRESET` dans `.secrets` (global, partagé par toutes
+> les instances — même boîte SMTP `lenouvel.me` pour tout le monde). Sans cette clé,
+> l'instance est créée avec `MAILER_DSN=null://null` : aucun email d'invitation ni de
+> réinitialisation de mot de passe ne part (cf. `GuestAccountCreator`).
 
 ### `MAILER_DSN` — obligatoire pour les emails (dont la notif de fin de lot)
 

--- a/.github/avancement.md
+++ b/.github/avancement.md
@@ -1,8 +1,18 @@
 # 📋 Avancement — HomeCloud API
 
-> Dernière mise à jour : 2026-07-19
+> Dernière mise à jour : 2026-07-20
 
-> **Status git :** `main` — chantier worker média mergé (PRs #262, #265, #264)
+> **Status git :** `main` — dernière PR mergée #271 (`feat/#270-async-share-email`)
+
+---
+
+## ✅ Viewer PDF inline (2026-07-19, #241 partie 1 — fermé)
+
+Bouton "Visualiser" pour afficher un PDF dans le navigateur (iframe, `Content-Disposition: inline`) au lieu de forcer le téléchargement.
+
+- `FileWebController` : nouvelle route/paramètre servant le PDF en `inline`, route `download` existante inchangée (`attachment`)
+- Modale front avec `<iframe>` sur `FileCard.html.twig`
+- Reste à faire (partie 2 de #241, non trackée) : vignette de la 1ère page dans la grille via Ghostscript
 
 ---
 
@@ -21,10 +31,22 @@ Contraintes o2switch (mutualisé) : pas de daemon → worker = **cron 5 min** co
 | PR 3 | #261  | #264      | Endpoint statut + polling front (`upload-batch.js`) + toast                                    |
 
 Points d'attention post-merge :
-- **`MAILER_DSN`** à activer sur chaque instance (`.env.prod.local`, cf. `deploiement.md`) — sans lui, le traitement fonctionne mais l'email « lot prêt » ne part pas.
+- **`MAILER_DSN`** activé sur les 6 instances (`ronan` + `yannick`/`coralie`/`elea`/`corentin`/`damien`, 2026-07-20, cf. `deploiement.md`) — sans lui, le traitement fonctionne mais l'email « lot prêt » ne part pas. `bin/deploy-all.sh --init` l'injecte désormais automatiquement pour toute nouvelle instance.
 - **Seuil** `hc.upload.deferred_threshold_bytes` = 250 Mo par défaut, ajustable dans `config/services.yaml`.
 
 Plan détaillé : `.claude/plans/je-suis-d-accord-avec-ticklish-zebra.md`. Connexes restantes : #245 (curseur de concurrence d'upload), #239 (barre de progression) — même zone `upload-modal.js`.
+
+---
+
+## ✅ EXIF pack photographe (2026-07-19, #268)
+
+Réglages de prise de vue (RAW + JPEG) lus et affichés.
+
+---
+
+## ✅ Notification de partage asynchrone (2026-07-19, #270)
+
+`ShareNotificationMailer::notify()` passe désormais par Messenger (message + worker/transport dédié) au lieu d'un envoi synchrone bloquant la requête `/share-create`.
 
 ---
 
@@ -243,7 +265,7 @@ Score global : **9/10** — 4/5 axes de remédiation implémentés.
 3. **Badge de couverture d'album** — design trop brut (icône étoile sur fond noir), à retravailler visuellement
 4. **Rendre les interactions asynchrones (fetch/AJAX) au lieu de POST + reload complet** — ✅ fait pour create/edit/delete de la gestion des invités (`guest_management_controller.js`) ; reste à généraliser le même pattern (détection `Accept: application/json` + fallback progressif + contrôleur Stimulus) aux autres actions POST+redirect encore existantes (albums, dossiers, fichiers, partages...)
 5. ✅ **FAIT — Notification de partage asynchrone** (#270) : `ShareWebController` dispatche un `ShareNotificationMessage` (routé vers le transport `async`) au lieu d'appeler `ShareNotificationMailer::notify()` en synchrone → `/share-create` ne bloque plus sur le SMTP (× nombre d'invités). `ShareNotificationHandler` consomme et envoie. Périmètre volontaire : notification de partage seule — reset-password, invitation invité et batch restent synchrones (worker = cron 5 min, on ne retarde pas le reset-password)
-6. **Nettoyer les ~168 notices PHPUnit** — `createMock()` utilisé sans `expects()` déclenche une notice PHPUnit 13 ("Consider refactoring your test code to use a test stub instead") ; concentrées dans `tests/Unit/{Entity,EventListener,Security,Service}`, notamment `ShareLinkFactoryTest.php` (~15) ; remplacer ces `createMock()` par `createStub()` là où aucune expectation n'est réellement vérifiée (le chantier worker média a déjà converti quelques cas)
+6. **Nettoyer les ~168 notices PHPUnit** — `createMock()` utilisé sans `expects()` déclenche une notice PHPUnit 13 ("Consider refactoring your test code to use a test stub instead") ; concentrées dans `tests/Unit/{Entity,EventListener,Security,Service}`, notamment `ShareLinkFactoryTest.php` (~15) ; remplacer ces `createMock()` par `createStub()` là où aucune expectation n'est réellement vérifiée (le chantier worker média a déjà converti quelques cas) — suivi dans #272
 7. ✅ **FAIT — Pack photographe EXIF (RAW + JPEG)** (#268) : `ronanlenouvel/raw-preview-extractor` **1.2.0** expose `ExtractedPreview->metadata` (date, ouverture, vitesse, ISO, focale, objectif, appareil), lu depuis l'EXIF du RAW ; `ExifService` fait de même pour les JPEG. `Media` gagne 5 colonnes (aperture, shutter_speed, iso, focal_length, lens), exposées par l'API, affichées dans un panneau EXIF du lightbox galerie, avec tri « date de prise de vue ». CR3 : métadonnées `null` pour l'instant (parseur ISO-BMFF, piste d'itération)
 8. **Optimiser le redimensionnement des grandes previews** — une preview RAW pleine résolution (8256×5504) prend ~2,9 s à redimensionner sous GD, contre 23 ms pour l'extraction elle-même. Acceptable car le pipeline média est asynchrone (Messenger), mais un redimensionnement en deux passes réduirait nettement le coût
 9. **Chiffrement au repos** — `APP_ENCRYPTION_KEY` est déclaré dans `config/services.yaml` mais injecté nulle part : les fichiers sont stockés en clair. Prévu comme option laissée à l'utilisateur. Incohérence résiduelle : le docblock `@param` de `ThumbnailService::generate()` (ligne 43) dit encore « chiffrée sur disque » alors que le reste de la classe (ligne 24) indique correctement « stockés en clair » — à corriger

--- a/bin/deploy-all.sh
+++ b/bin/deploy-all.sh
@@ -122,6 +122,9 @@ for PRENOM in "${TARGETS[@]}"; do
             RESULTS_FAIL+=("$SUBDOMAIN (DB_PASSWORD_PRESET manquant)")
             continue
         fi
+        if [[ -z "${MAILER_DSN_PRESET:-}" ]]; then
+            warn "MAILER_DSN_PRESET absent (.secrets ou .secrets.${PRENOM}) — l'instance n'enverra aucun email"
+        fi
 
         DB_NAME="${SSH_USER}_${PRENOM}"
         DB_USER="${SSH_USER}_${PRENOM}"
@@ -144,6 +147,7 @@ DATABASE_URL=${DATABASE_URL}
 JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
 JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
 JWT_PASSPHRASE=${JWT_PASSPHRASE}
+MAILER_DSN=${MAILER_DSN_PRESET:-null://null}
 ENVEOF
             ${COMPOSER_BIN} install --no-interaction --prefer-dist --no-progress --no-dev
             ${PHP_BIN} bin/console cache:clear --env=prod

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "ext-exif": "*",
         "ext-gd": "*",
         "ext-iconv": "*",
+        "ext-zip": "*",
         "api-platform/doctrine-orm": "^4.3.16",
         "api-platform/symfony": "^4.3.16",
         "doctrine/doctrine-bundle": "^3.2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9d7fb7f7eff0524e36a7aceceb052463",
+    "content-hash": "0d6671147d61eeacffd7cef01b3de3c1",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -11594,7 +11594,8 @@
         "ext-ctype": "*",
         "ext-exif": "*",
         "ext-gd": "*",
-        "ext-iconv": "*"
+        "ext-iconv": "*",
+        "ext-zip": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -30,6 +30,7 @@ services:
     App\Interface\UploadBatchRepositoryInterface: '@App\Repository\UploadBatchRepository'
     App\Interface\BatchCompletionNotifierInterface: '@App\Service\BatchCompletionNotifier'
     App\Interface\ShareNotificationMailerInterface: '@App\Service\ShareNotificationMailer'
+    App\Interface\FolderZipArchiverInterface:     '@App\Service\FolderZipArchiver'
 
     App\State\AlbumProcessor:
         arguments:

--- a/src/Controller/Web/FolderWebController.php
+++ b/src/Controller/Web/FolderWebController.php
@@ -5,13 +5,19 @@ declare(strict_types=1);
 namespace App\Controller\Web;
 
 use App\Entity\Folder;
+use App\Entity\Share;
+use App\Entity\User;
 use App\Interface\DefaultFolderServiceInterface;
 use App\Interface\FolderMoverInterface;
+use App\Interface\FolderZipArchiverInterface;
 use App\Repository\FolderRepository;
+use App\Security\ResourceAccessChecker;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Uid\Uuid;
@@ -31,7 +37,31 @@ final class FolderWebController extends AbstractController
         private readonly DefaultFolderServiceInterface $defaultFolderService,
         private readonly EntityManagerInterface $em,
         private readonly \App\Interface\FolderMoverInterface $folderMover,
+        private readonly ResourceAccessChecker $resourceAccessChecker,
+        private readonly FolderZipArchiverInterface $folderZipArchiver,
     ) {}
+
+    #[Route('/folders/{id}/download', name: 'app_folder_download', methods: ['GET'])]
+    public function download(string $id): BinaryFileResponse
+    {
+        $folder = $this->folderRepository->find($id)
+            ?? throw $this->createNotFoundException('Dossier introuvable.');
+
+        /** @var User $user */
+        $user = $this->getUser();
+        if (!$this->resourceAccessChecker->canRead($user, Share::RESOURCE_FOLDER, $folder->getId(), $folder->getOwner())) {
+            throw $this->createAccessDeniedException('Vous ne pouvez pas télécharger ce dossier.');
+        }
+
+        $zipPath = $this->folderZipArchiver->archive($folder);
+
+        $response = new BinaryFileResponse($zipPath);
+        $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $folder->getName() . '.zip');
+        $response->headers->set('Content-Type', 'application/zip');
+        $response->deleteFileAfterSend(true);
+
+        return $response;
+    }
 
     #[Route('/folders/{id}/delete', name: 'app_folder_delete', methods: ['POST'])]
     public function delete(string $id, Request $request): Response

--- a/src/Interface/FolderZipArchiverInterface.php
+++ b/src/Interface/FolderZipArchiverInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\Folder;
+
+interface FolderZipArchiverInterface
+{
+    /**
+     * Construit une archive zip du dossier (récursif, sous-dossiers inclus)
+     * et retourne le chemin absolu du fichier temporaire généré.
+     */
+    public function archive(Folder $folder): string;
+}

--- a/src/Service/FolderZipArchiver.php
+++ b/src/Service/FolderZipArchiver.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Folder;
+use App\Interface\FolderZipArchiverInterface;
+use App\Interface\StorageServiceInterface;
+
+/**
+ * Construit une archive zip d'un dossier et de tout son contenu (récursif).
+ *
+ * Parcourt `Folder::getChildren()` plutôt que `FolderRepository::findDescendantIds()` :
+ * la structure de dossiers imbriqués nécessaire au zip (chemin relatif) est déjà
+ * portée par la relation Doctrine bidirectionnelle, pas besoin de la CTE SQL.
+ */
+final readonly class FolderZipArchiver implements FolderZipArchiverInterface
+{
+    public function __construct(
+        private StorageServiceInterface $storageService,
+    ) {}
+
+    public function archive(Folder $folder): string
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'hc_folder_');
+        unlink($tmpFile);
+        $zipPath = $tmpFile . '.zip';
+
+        $zip = new \ZipArchive();
+        if ($zip->open($zipPath, \ZipArchive::CREATE) !== true) {
+            throw new \RuntimeException('Impossible de créer l\'archive zip.');
+        }
+
+        $this->addFolderContents($zip, $folder, $folder->getName());
+
+        $zip->close();
+
+        return $zipPath;
+    }
+
+    private function addFolderContents(\ZipArchive $zip, Folder $folder, string $zipDir): void
+    {
+        $zip->addEmptyDir($zipDir);
+
+        foreach ($folder->getFiles() as $file) {
+            $absolutePath = $this->storageService->getAbsolutePath($file->getPath());
+            if (file_exists($absolutePath)) {
+                $zip->addFile($absolutePath, $zipDir . '/' . $file->getOriginalName());
+            }
+        }
+
+        foreach ($folder->getChildren() as $child) {
+            $this->addFolderContents($zip, $child, $zipDir . '/' . $child->getName());
+        }
+    }
+}

--- a/templates/components/FolderCard.html.twig
+++ b/templates/components/FolderCard.html.twig
@@ -24,6 +24,10 @@
 		        data-testid="share-folder-btn-{{ item.id }}"
 		        class="share-btn hc-item-action"
 		        title="Partager {{ item.name|e('html') }}"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon"><path d="M18 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 22a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM8.6 13.5l6.8 4M15.4 6.5l-6.8 4"/></svg></button>
+		<a href="{{ path('app_folder_download', { id: item.id }) }}"
+		        data-testid="download-folder-btn-{{ item.id }}"
+		        class="download-folder-btn hc-item-action"
+		        title="Télécharger {{ item.name|e('html') }}"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></a>
 		<button type="button"
 		        data-testid="delete-folder-btn-{{ item.id }}"
 		        class="delete-folder-btn hc-item-action hc-item-action--danger"

--- a/tests/Integration/FolderZipArchiverIntegrationTest.php
+++ b/tests/Integration/FolderZipArchiverIntegrationTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\User;
+use App\Interface\FolderZipArchiverInterface;
+use App\Interface\StorageServiceInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class FolderZipArchiverIntegrationTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        self::bootKernel();
+    }
+
+    private function createPhysicalFile(StorageServiceInterface $storage, string $relativePath, string $content): void
+    {
+        $absolutePath = $storage->getAbsolutePath($relativePath);
+        @mkdir(dirname($absolutePath), 0777, true);
+        file_put_contents($absolutePath, $content);
+    }
+
+    public function testArchiveIncludesDirectFilesAndNestedSubfolders(): void
+    {
+        $container = static::getContainer();
+        $em = $container->get('doctrine')->getManager();
+        $storage = $container->get(StorageServiceInterface::class);
+
+        $user = new User('zip-owner@example.com', 'Owner');
+        $em->persist($user);
+
+        $parent = new Folder('Parent', $user);
+        $child = new Folder('Child', $user, $parent);
+        $em->persist($parent);
+        $em->persist($child);
+
+        $rootRelative = 'zip-test/' . uniqid() . '.txt';
+        $nestedRelative = 'zip-test/' . uniqid() . '.txt';
+        $this->createPhysicalFile($storage, $rootRelative, 'contenu racine');
+        $this->createPhysicalFile($storage, $nestedRelative, 'contenu imbriqué');
+
+        $rootFile = new File('root.txt', 'text/plain', 14, $rootRelative, $parent, $user, false);
+        $nestedFile = new File('nested.txt', 'text/plain', 17, $nestedRelative, $child, $user, false);
+        $em->persist($rootFile);
+        $em->persist($nestedFile);
+        $em->flush();
+        $parentId = $parent->getId();
+        $em->clear();
+
+        /** @var FolderZipArchiverInterface $archiver */
+        $archiver = $container->get(FolderZipArchiverInterface::class);
+        $zipPath = $archiver->archive($em->getRepository(Folder::class)->find($parentId));
+
+        $this->assertFileExists($zipPath);
+
+        $zip = new \ZipArchive();
+        $this->assertTrue($zip->open($zipPath) === true);
+        $this->assertNotFalse($zip->locateName('Parent/root.txt'));
+        $this->assertNotFalse($zip->locateName('Parent/Child/nested.txt'));
+        $this->assertSame('contenu racine', $zip->getFromName('Parent/root.txt'));
+        $this->assertSame('contenu imbriqué', $zip->getFromName('Parent/Child/nested.txt'));
+        $zip->close();
+
+        unlink($zipPath);
+    }
+
+    public function testArchiveEmptyFolderProducesValidZipWithDirEntryOnly(): void
+    {
+        $container = static::getContainer();
+        $em = $container->get('doctrine')->getManager();
+
+        $user = new User('zip-owner-empty@example.com', 'Owner');
+        $em->persist($user);
+        $folder = new Folder('Empty', $user);
+        $em->persist($folder);
+        $em->flush();
+
+        /** @var FolderZipArchiverInterface $archiver */
+        $archiver = $container->get(FolderZipArchiverInterface::class);
+        $zipPath = $archiver->archive($folder);
+
+        $zip = new \ZipArchive();
+        $this->assertTrue($zip->open($zipPath) === true);
+        $this->assertSame(1, $zip->numFiles);
+        $zip->close();
+
+        unlink($zipPath);
+    }
+
+    public function testArchiveSkipsFileMissingFromDisk(): void
+    {
+        $container = static::getContainer();
+        $em = $container->get('doctrine')->getManager();
+
+        $user = new User('zip-owner-missing@example.com', 'Owner');
+        $em->persist($user);
+        $folder = new Folder('Broken', $user);
+        $em->persist($folder);
+
+        $ghostFile = new File('ghost.txt', 'text/plain', 5, 'zip-test/does-not-exist-' . uniqid() . '.txt', $folder, $user, false);
+        $em->persist($ghostFile);
+        $em->flush();
+
+        /** @var FolderZipArchiverInterface $archiver */
+        $archiver = $container->get(FolderZipArchiverInterface::class);
+        $zipPath = $archiver->archive($folder);
+
+        $zip = new \ZipArchive();
+        $this->assertTrue($zip->open($zipPath) === true);
+        $this->assertFalse($zip->locateName('Broken/ghost.txt'));
+        $zip->close();
+
+        unlink($zipPath);
+    }
+}

--- a/tests/Web/FolderDownloadWebTest.php
+++ b/tests/Web/FolderDownloadWebTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Share;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Tests fonctionnels — Téléchargement d'un dossier entier (zip) via l'interface web.
+ *
+ * TDD RED : ces tests doivent d'abord échouer, puis passer après implémentation (#240).
+ */
+final class FolderDownloadWebTest extends WebTestCase
+{
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM shares');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createUser(string $email = 'test@example.com', string $password = 'secret123'): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User($email, 'Test');
+        $user->setPassword($hasher->hashPassword($user, $password));
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+
+    private function login(string $email = 'test@example.com', string $password = 'secret123'): void
+    {
+        $crawler = $this->client->request('GET', '/login');
+        $form = $crawler->selectButton('Se connecter')->form([
+            'email'    => $email,
+            'password' => $password,
+        ]);
+        $this->client->submit($form);
+        $this->client->followRedirect();
+    }
+
+    private function createFolder(string $name, User $owner, ?Folder $parent = null): Folder
+    {
+        $folder = new Folder($name, $owner, $parent);
+        $this->em->persist($folder);
+        $this->em->flush();
+
+        return $folder;
+    }
+
+    private function createFile(string $name, Folder $folder, User $owner): File
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'hc_test_');
+        file_put_contents($tmp, 'contenu de test');
+
+        $relativePath = 'test-storage/' . uniqid() . '.txt';
+        $storage = static::getContainer()->get(\App\Interface\StorageServiceInterface::class);
+        $absolutePath = $storage->getAbsolutePath($relativePath);
+        @mkdir(dirname($absolutePath), 0777, true);
+        copy($tmp, $absolutePath);
+
+        $file = new File($name, 'text/plain', filesize($absolutePath), $relativePath, $folder, $owner, false);
+        $this->em->persist($file);
+        $this->em->flush();
+
+        return $file;
+    }
+
+    // ── Sécurité ─────────────────────────────────────────────────────────────
+
+    public function testDownloadFolderRequiresAuthentication(): void
+    {
+        $user = $this->createUser();
+        $folder = $this->createFolder('Private', $user);
+        $folderId = $folder->getId();
+        $this->em->clear();
+
+        $this->client->request('GET', '/folders/' . $folderId . '/download');
+
+        $this->assertResponseRedirects();
+        $location = $this->client->getResponse()->headers->get('Location');
+        $this->assertStringContainsString('login', $location ?? '');
+    }
+
+    public function testDownloadFolderByNonOwnerWithoutShareThrows403(): void
+    {
+        $owner = $this->createUser('owner@example.com');
+        $other = $this->createUser('other@example.com');
+        $folder = $this->createFolder('Owned', $owner);
+        $folderId = $folder->getId();
+        $this->em->clear();
+
+        $this->login('other@example.com');
+
+        $this->client->request('GET', '/folders/' . $folderId . '/download');
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testDownloadFolderBySharedGuestWithReadPermissionSucceeds(): void
+    {
+        $owner = $this->createUser('owner@example.com');
+        $guest = $this->createUser('guest@example.com');
+        $folder = $this->createFolder('Shared', $owner);
+        $share = new Share($owner, $guest, Share::RESOURCE_FOLDER, $folder->getId(), Share::PERMISSION_READ);
+        $this->em->persist($share);
+        $this->em->flush();
+        $folderId = $folder->getId();
+        $this->em->clear();
+
+        $this->login('guest@example.com');
+
+        $this->client->request('GET', '/folders/' . $folderId . '/download');
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testDownloadNonExistentFolderThrows404(): void
+    {
+        $this->createUser();
+        $this->em->clear();
+
+        $this->login();
+
+        $this->client->request('GET', '/folders/' . \Symfony\Component\Uid\Uuid::v7() . '/download');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    // ── Cas nominal ──────────────────────────────────────────────────────────
+
+    public function testDownloadFolderReturnsZipWithCorrectHeaders(): void
+    {
+        $user = $this->createUser();
+        $folder = $this->createFolder('MyFolder', $user);
+        $this->createFile('doc.txt', $folder, $user);
+        $folderId = $folder->getId();
+        $this->em->clear();
+
+        $this->login();
+
+        $this->client->request('GET', '/folders/' . $folderId . '/download');
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->client->getResponse();
+        $this->assertSame('application/zip', $response->headers->get('Content-Type'));
+        $this->assertStringContainsString('MyFolder.zip', $response->headers->get('Content-Disposition') ?? '');
+    }
+
+    public function testDownloadFolderZipContainsNestedFilesAndSubfolders(): void
+    {
+        $user = $this->createUser();
+        $parent = $this->createFolder('Parent', $user);
+        $child = $this->createFolder('Child', $user, $parent);
+        $this->createFile('root.txt', $parent, $user);
+        $this->createFile('nested.txt', $child, $user);
+        $parentId = $parent->getId();
+        $this->em->clear();
+
+        $this->login();
+
+        $this->client->request('GET', '/folders/' . $parentId . '/download');
+
+        // BinaryFileResponse::getContent() ne remonte pas le contenu binaire réel
+        // dans le client de test PHPUnit (même limitation que StreamedResponse,
+        // cf. FileDownloadController) — la structure du zip est vérifiée au niveau
+        // service dans FolderZipArchiverTest, ici on ne vérifie que la réponse HTTP.
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testDownloadEmptyFolderReturnsValidZip(): void
+    {
+        $user = $this->createUser();
+        $folder = $this->createFolder('Empty', $user);
+        $folderId = $folder->getId();
+        $this->em->clear();
+
+        $this->login();
+
+        $this->client->request('GET', '/folders/' . $folderId . '/download');
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    // ── UI ───────────────────────────────────────────────────────────────────
+
+    public function testDownloadButtonPresentInFolderCard(): void
+    {
+        $user = $this->createUser();
+        $folder = $this->createFolder('MyFolder', $user);
+        $folderId = $folder->getId();
+        $this->em->clear();
+
+        $this->login();
+        $this->client->request('GET', '/explorer');
+        $this->assertSelectorExists('[data-testid="download-folder-btn-' . $folderId . '"]');
+    }
+}


### PR DESCRIPTION
## Résumé

- Nouvelle route `GET /folders/{id}/download` : génère et streame un zip récursif du dossier (sous-dossiers + fichiers), même modèle de sécurité que `FileDownloadController` (owner ou partage actif via `ResourceAccessChecker`)
- `FolderZipArchiver` : parcourt `Folder::getChildren()`/`getFiles()` pour construire l'arborescence dans le zip ; fichier physique manquant sur disque → ignoré silencieusement
- Bouton de téléchargement ajouté sur `FolderCard`
- `ext-zip` déclarée dans `composer.json`

Au passage (contexte découvert en investiguant #240, sans lien direct avec le zip) :
- `bin/deploy-all.sh` injecte désormais `MAILER_DSN_PRESET` automatiquement à l'`--init` (avant : chaque nouvelle instance repartait sur `MAILER_DSN=null://null`, aucun email d'invitation/reset ne partait)
- `.github/avancement.md` mis à jour (suivi du travail mergé récemment : PDF viewer, worker média, EXIF, partage async, mailer_dsn)

Closes #240

## Test plan

- [x] Suite PHPUnit complète : 795 tests verts (hors `TailwindBuildTest`, préexistant, environnement local sans build CSS)
- [x] Testé manuellement en local : connexion `demo@homecloud.local`, téléchargement du dossier "Documents" et "Uploads" depuis `/explorer` → zip valide contenant les bons fichiers
- [x] Tests dédiés : `tests/Web/FolderDownloadWebTest.php` (auth, ownership, partage, 404, headers) + `tests/Integration/FolderZipArchiverIntegrationTest.php` (structure du zip, dossier vide, fichier manquant sur disque)