### PR TITLE
🔧 fix(upload-modal): barre de progression cassée en upload multiple

### DIFF
--- a/assets/js/upload-modal.js
+++ b/assets/js/upload-modal.js
@@ -406,29 +406,33 @@ async function openUploadModal(files, options = {}) {
     const fileListEl = overlay.querySelector('#hc-upload-file-list');
     const itemElements = new Map();
 
-    // Map file → queue item element
+    // Map file → queue item element. Indexé par la référence de l'objet File
+    // (et non son nom) : deux fichiers sélectionnés portant le même nom
+    // (ex. IMG_0001.jpg de deux dossiers différents) sont deux références
+    // distinctes, chacune avec sa propre barre — indexer par nom les ferait
+    // collisionner dans la Map (#239).
     files.forEach((file, idx) => {
         const itemEl = fileListEl.children[idx];
-        itemElements.set(file.name, itemEl);
+        itemElements.set(file, itemEl);
     });
 
     // Create upload queue with callbacks for UI updates
     currentUploadQueue = createUploadQueueFn({
         maxConcurrent: 3,
         onProgress: (file, progress) => {
-            const itemEl = itemElements.get(file.name);
+            const itemEl = itemElements.get(file);
             if (itemEl) {
                 updateUploadItem(itemEl, 'uploading', progress.progress || 0);
             }
         },
         onComplete: (file, response) => {
-            const itemEl = itemElements.get(file.name);
+            const itemEl = itemElements.get(file);
             if (itemEl) {
                 updateUploadItem(itemEl, 'completed', 100);
             }
         },
         onError: (file, error) => {
-            const itemEl = itemElements.get(file.name);
+            const itemEl = itemElements.get(file);
             if (itemEl) {
                 updateUploadItem(itemEl, 'error', 0, error.message || 'Unknown error');
             }

--- a/assets/tests/upload-modal-progress.test.js
+++ b/assets/tests/upload-modal-progress.test.js
@@ -1,0 +1,131 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+await import('../components/hc-folder-list.js');
+const { openUploadModal, closeUploadModal } = await import('../js/upload-modal.js');
+
+/**
+ * TDD RED — #239 : la barre de progression d'upload ne se met pas à jour.
+ *
+ * Simule un vrai upload XHR (comme le fait réellement le navigateur) plutôt
+ * que d'appeler directement les callbacks internes, pour reproduire le
+ * chemin exact emprunté en production.
+ */
+let createdXHRs = [];
+
+class FakeXHR {
+    constructor() {
+        createdXHRs.push(this);
+        this._listeners = {};
+        this.upload = {
+            _listeners: {},
+            addEventListener(evt, cb) { this._listeners[evt] = cb; },
+        };
+    }
+    addEventListener(evt, cb) { this._listeners[evt] = cb; }
+    open() {}
+    setRequestHeader() {}
+    send() {}
+    fireUploadProgress(loaded, total) {
+        this.upload._listeners['progress']?.({ lengthComputable: true, loaded, total });
+    }
+    fireLoad(status, body) {
+        this.status = status;
+        this.responseText = JSON.stringify(body);
+        this._listeners['load']?.();
+    }
+}
+
+async function flushMicrotasks(times = 20) {
+    for (let i = 0; i < times; i++) {
+        await Promise.resolve();
+    }
+}
+
+describe('openUploadModal — barre de progression (#239)', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        createdXHRs = [];
+        window.HC = { getToken: async () => 'test-token', userId: 'user-1' };
+        global.XMLHttpRequest = FakeXHR;
+        global.fetch = jest.fn().mockResolvedValue({ ok: false });
+    });
+
+    afterEach(() => {
+        closeUploadModal();
+    });
+
+    test("la largeur de la barre suit la progression de l'upload XHR", async () => {
+        const file = new File(['x'.repeat(1000)], 'photo.jpg', { type: 'image/jpeg' });
+
+        await openUploadModal([file], {
+            folderId: 'folder-1',
+            folders: [{ id: 'folder-1', name: 'Root' }],
+        });
+
+        const submitBtn = document.getElementById('hc-upload-submit-btn');
+        submitBtn.click();
+
+        await flushMicrotasks();
+        expect(createdXHRs.length).toBe(1);
+
+        createdXHRs[0].fireUploadProgress(500, 1000);
+        await flushMicrotasks();
+
+        const bar = document.querySelector('.upload-item__bar');
+        expect(bar.style.width).toBe('50%');
+
+        createdXHRs[0].fireUploadProgress(1000, 1000);
+        await flushMicrotasks();
+        expect(bar.style.width).toBe('100%');
+
+        createdXHRs[0].fireLoad(201, { id: 'f1' });
+        await flushMicrotasks();
+    });
+
+    test('chaque fichier a sa propre barre de progression, indépendamment des autres (upload multiple)', async () => {
+        const fileA = new File(['a'.repeat(1000)], 'a.jpg', { type: 'image/jpeg' });
+        const fileB = new File(['b'.repeat(1000)], 'b.jpg', { type: 'image/jpeg' });
+
+        await openUploadModal([fileA, fileB], {
+            folderId: 'folder-1',
+            folders: [{ id: 'folder-1', name: 'Root' }],
+        });
+
+        document.getElementById('hc-upload-submit-btn').click();
+        await flushMicrotasks();
+        expect(createdXHRs.length).toBe(2);
+
+        createdXHRs[0].fireUploadProgress(300, 1000);
+        await flushMicrotasks();
+
+        const bars = document.querySelectorAll('.upload-item__bar');
+        expect(bars[0].style.width).toBe('30%');
+        expect(bars[1].style.width).toBe('0%');
+
+        createdXHRs[1].fireUploadProgress(700, 1000);
+        await flushMicrotasks();
+        expect(bars[0].style.width).toBe('30%');
+        expect(bars[1].style.width).toBe('70%');
+    });
+
+    test('fichiers de même nom : chaque barre reste indépendante (pas de collision de clé)', async () => {
+        const fileA = new File(['a'.repeat(1000)], 'IMG_0001.jpg', { type: 'image/jpeg' });
+        const fileB = new File(['b'.repeat(1000)], 'IMG_0001.jpg', { type: 'image/jpeg' });
+
+        await openUploadModal([fileA, fileB], {
+            folderId: 'folder-1',
+            folders: [{ id: 'folder-1', name: 'Root' }],
+        });
+
+        document.getElementById('hc-upload-submit-btn').click();
+        await flushMicrotasks();
+        expect(createdXHRs.length).toBe(2);
+
+        createdXHRs[0].fireUploadProgress(200, 1000);
+        await flushMicrotasks();
+
+        const bars = document.querySelectorAll('.upload-item__bar');
+        expect(bars[0].style.width).toBe('20%');
+        expect(bars[1].style.width).toBe('0%');
+    });
+});


### PR DESCRIPTION
## Résumé

`itemElements` (Map file → élément DOM de la barre de progression) était indexée par `file.name`. Deux fichiers sélectionnés portant le même nom (cas courant : `IMG_0001.jpg` provenant de deux dossiers/appareils différents) collisionnaient dans la Map — toute la progression se retrouvait routée vers un seul élément DOM, l'autre restant figé à 0%.

Fix : indexer par la référence de l'objet `File` lui-même plutôt que son nom — deux fichiers distincts sont deux clés distinctes même à nom identique, sans avoir besoin de générer/faire circuler un id ou un hash. `upload-queue.js` fait déjà ça en interne ; `upload-modal.js` s'aligne dessus.

Closes #239

## Test plan

- [x] `assets/tests/upload-modal-progress.test.js` (nouveau) : simule un vrai upload XHR (progress events + load), reproduit le bug avec fichiers de même nom en RED, vérifie le fix en GREEN
  - la barre suit la progression d'un upload simple
  - deux fichiers distincts progressent indépendamment
  - deux fichiers de même nom progressent indépendamment (cas du bug)
- [x] Suite Jest complète : 181 tests verts