### PR TITLE
✨ feat(explorer-drop): glisser-déposer un dossier local avec sa structure

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -9,5 +9,7 @@ import './js/rename.js';
 import './js/delete-folder-modal.js';
 import './js/pdf-viewer-modal.js';
 import { initUploadModal } from './js/upload-modal.js';
+import { initExplorerDrop } from './js/explorer-drop.js';
 
 initUploadModal();
+initExplorerDrop();

--- a/assets/controllers/new_menu_controller.js
+++ b/assets/controllers/new_menu_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from '@hotwired/stimulus';
+import { annotateWebkitRelativePaths } from '../js/directory-entry-reader.js';
 
 /* Bouton "Nouveau" (sidebar) : menu déroulant positionné dynamiquement sous
  * le bouton (fixed, hors du stacking context backdrop-filter de la sidebar).
@@ -55,8 +56,11 @@ export default class extends Controller {
     }
 
     folderSelected() {
+        const files = Array.from(this.folderInputTarget.files);
         this.folderInputTarget.value = '';
         this.closeMenu();
-        window.alert('Folder import — coming soon.');
+        if (files.length === 0) return;
+        annotateWebkitRelativePaths(files);
+        document.dispatchEvent(new CustomEvent('hc:files-selected', { detail: { files } }));
     }
 }

--- a/assets/js/directory-entry-reader.js
+++ b/assets/js/directory-entry-reader.js
@@ -1,0 +1,73 @@
+/**
+ * Lit récursivement les entrées d'un drop (DataTransferItemList), fichiers ET
+ * dossiers, en résolvant le chemin relatif à la racine du drop — pour
+ * recréer l'arborescence côté serveur (#238).
+ *
+ * S'appuie sur DataTransferItem.webkitGetAsEntry() : seule API permettant de
+ * distinguer un dossier d'un fichier lors d'un drag & drop natif (DataTransfer.files
+ * "aplatit" un dossier sans exposer sa structure).
+ *
+ * @param {DataTransferItemList|Array} items
+ * @returns {Promise<{file: File, relativePath: string}[]>}
+ */
+export async function readDroppedEntries(items) {
+    const entries = Array.from(items)
+        .map(item => (typeof item.webkitGetAsEntry === 'function' ? item.webkitGetAsEntry() : null))
+        .filter(Boolean);
+
+    const results = [];
+    for (const entry of entries) {
+        await readEntry(entry, '', results);
+    }
+    return results;
+}
+
+function readEntry(entry, basePath, results) {
+    if (entry.isFile) {
+        return new Promise((resolve, reject) => {
+            entry.file(file => {
+                results.push({ file, relativePath: basePath });
+                resolve();
+            }, reject);
+        });
+    }
+
+    if (entry.isDirectory) {
+        const childPath = basePath ? `${basePath}/${entry.name}` : entry.name;
+        return readDirectory(entry, childPath, results);
+    }
+
+    return Promise.resolve();
+}
+
+/**
+ * Annote chaque File de son dossier parent déduit de `webkitRelativePath`
+ * (peuplé nativement par le navigateur pour <input webkitdirectory>, ex.
+ * "2026-07-10-BMA/scans/scan1.pdf") — même contrat que readDroppedEntries,
+ * pour le menu "Importer un dossier" (#238).
+ *
+ * @param {File[]} files
+ * @returns {File[]} les mêmes fichiers, mutés en place
+ */
+export function annotateWebkitRelativePaths(files) {
+    files.forEach(file => {
+        const rel = file.webkitRelativePath;
+        if (!rel) return;
+        const idx = rel.lastIndexOf('/');
+        if (idx > 0) {
+            file._hcRelativePath = rel.slice(0, idx);
+        }
+    });
+    return files;
+}
+
+async function readDirectory(dirEntry, path, results) {
+    const reader = dirEntry.createReader();
+    let entries;
+    do {
+        entries = await new Promise((resolve, reject) => reader.readEntries(resolve, reject));
+        for (const child of entries) {
+            await readEntry(child, path, results);
+        }
+    } while (entries.length > 0);
+}

--- a/assets/js/explorer-drop.js
+++ b/assets/js/explorer-drop.js
@@ -1,0 +1,66 @@
+import { readDroppedEntries } from './directory-entry-reader.js';
+
+/**
+ * Active le drag & drop de fichiers/dossiers sur la zone d'import
+ * (`#main-import-card`), en réutilisant la structure du dossier local déposé
+ * (#238) : chaque fichier annoté de son relativePath, consommé par
+ * upload-modal.js pour recréer l'arborescence côté serveur.
+ *
+ * Auparavant dupliqué à l'identique dans explorer.html.twig et home.html.twig.
+ */
+export function initExplorerDrop() {
+    const importCard = document.getElementById('main-import-card');
+    if (!importCard) return { destroy() {} };
+
+    let dragCounter = 0;
+
+    const onDragEnter = (e) => {
+        e.preventDefault();
+        dragCounter++;
+        importCard.classList.add('drop-active');
+    };
+    const onDragOver = (e) => { e.preventDefault(); };
+    const onDragLeave = (e) => {
+        dragCounter--;
+        // relatedTarget null = le curseur a quitté la fenêtre du navigateur
+        if (dragCounter <= 0 || e.relatedTarget === null) {
+            dragCounter = 0;
+            importCard.classList.remove('drop-active');
+        }
+    };
+    const onDrop = async (e) => {
+        e.preventDefault();
+        dragCounter = 0;
+        importCard.classList.remove('drop-active');
+
+        const entries = await readDroppedEntries(e.dataTransfer.items);
+        const files = entries
+            .filter(({ file }) => file.size > 0)
+            .map(({ file, relativePath }) => {
+                if (relativePath) {
+                    file._hcRelativePath = relativePath;
+                }
+                return file;
+            });
+
+        if (files.length === 0) return;
+
+        const folderIdInput = importCard.querySelector('input[name="folder_id"]');
+        const folderId = folderIdInput ? folderIdInput.value : '';
+        document.dispatchEvent(new CustomEvent('hc:files-selected', { detail: { files, folderId } }));
+    };
+
+    document.addEventListener('dragenter', onDragEnter);
+    document.addEventListener('dragover', onDragOver);
+    document.addEventListener('dragleave', onDragLeave);
+    document.addEventListener('drop', onDrop);
+
+    return {
+        destroy() {
+            document.removeEventListener('dragenter', onDragEnter);
+            document.removeEventListener('dragover', onDragOver);
+            document.removeEventListener('dragleave', onDragLeave);
+            document.removeEventListener('drop', onDrop);
+        },
+    };
+}

--- a/assets/js/upload-modal.js
+++ b/assets/js/upload-modal.js
@@ -100,6 +100,8 @@ function createUploadFn(token, folderId, newFolderName, batchId) {
             if (folderId) formData.append('folderId', folderId);
             if (newFolderName) formData.append('newFolderName', newFolderName);
             if (batchId) formData.append('batchId', batchId);
+            // Dossier local glissé-déposé (#238) : recrée l'arborescence côté serveur
+            if (file._hcRelativePath) formData.append('relativePath', file._hcRelativePath);
 
             // Progress tracking
             if (xhr.upload) {

--- a/assets/tests/directory-entry-reader.test.js
+++ b/assets/tests/directory-entry-reader.test.js
@@ -1,0 +1,98 @@
+import { jest, describe, test, expect } from '@jest/globals';
+
+const { readDroppedEntries } = await import('../js/directory-entry-reader.js');
+
+/**
+ * Fakes pour DataTransferItem / FileSystemEntry (API navigateur non disponible
+ * sous jsdom) — reproduisent le contrat callback-based réel :
+ *   FileSystemFileEntry.file(successCb, errorCb)
+ *   FileSystemDirectoryEntry.createReader().readEntries(successCb, errorCb)
+ *   (readEntries doit être appelé en boucle jusqu'à un tableau vide, par spec)
+ */
+function fakeFileEntry(file) {
+    return {
+        isFile: true,
+        isDirectory: false,
+        name: file.name,
+        file(successCb) { successCb(file); },
+    };
+}
+
+function fakeDirEntry(name, children) {
+    let served = false;
+    return {
+        isFile: false,
+        isDirectory: true,
+        name,
+        createReader() {
+            return {
+                readEntries(successCb) {
+                    if (served) {
+                        successCb([]);
+                    } else {
+                        served = true;
+                        successCb(children);
+                    }
+                },
+            };
+        },
+    };
+}
+
+function fakeItem(entry) {
+    return { webkitGetAsEntry: () => entry };
+}
+
+describe('readDroppedEntries', () => {
+    test('un fichier déposé seul → relativePath vide', async () => {
+        const file = new File(['x'], 'photo.jpg');
+        const items = [fakeItem(fakeFileEntry(file))];
+
+        const results = await readDroppedEntries(items);
+
+        expect(results).toEqual([{ file, relativePath: '' }]);
+    });
+
+    test('un dossier contenant un fichier direct → relativePath = nom du dossier', async () => {
+        const file = new File(['x'], 'scan1.pdf');
+        const dir = fakeDirEntry('2026-07-10-BMA', [fakeFileEntry(file)]);
+        const items = [fakeItem(dir)];
+
+        const results = await readDroppedEntries(items);
+
+        expect(results).toEqual([{ file, relativePath: '2026-07-10-BMA' }]);
+    });
+
+    test('sous-dossiers imbriqués sur plusieurs niveaux', async () => {
+        const fileA = new File(['x'], 'a.pdf');
+        const fileB = new File(['y'], 'b.pdf');
+        const nested = fakeDirEntry('Nested', [fakeFileEntry(fileB)]);
+        const root = fakeDirEntry('Root', [fakeFileEntry(fileA), nested]);
+        const items = [fakeItem(root)];
+
+        const results = await readDroppedEntries(items);
+
+        expect(results).toContainEqual({ file: fileA, relativePath: 'Root' });
+        expect(results).toContainEqual({ file: fileB, relativePath: 'Root/Nested' });
+    });
+
+    test('plusieurs éléments déposés en même temps (dossier + fichier isolé)', async () => {
+        const inDir = new File(['x'], 'in.pdf');
+        const alone = new File(['y'], 'alone.pdf');
+        const dir = fakeDirEntry('Folder', [fakeFileEntry(inDir)]);
+        const items = [fakeItem(dir), fakeItem(fakeFileEntry(alone))];
+
+        const results = await readDroppedEntries(items);
+
+        expect(results).toContainEqual({ file: inDir, relativePath: 'Folder' });
+        expect(results).toContainEqual({ file: alone, relativePath: '' });
+    });
+
+    test('ignore les items sans webkitGetAsEntry ou entrée nulle', async () => {
+        const items = [{ webkitGetAsEntry: () => null }, {}];
+
+        const results = await readDroppedEntries(items);
+
+        expect(results).toEqual([]);
+    });
+});

--- a/assets/tests/explorer-drop.test.js
+++ b/assets/tests/explorer-drop.test.js
@@ -1,0 +1,104 @@
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+
+const { initExplorerDrop } = await import('../js/explorer-drop.js');
+
+function fakeFileEntry(file) {
+    return {
+        isFile: true,
+        isDirectory: false,
+        name: file.name,
+        file(successCb) { successCb(file); },
+    };
+}
+
+function fakeDirEntry(name, children) {
+    let served = false;
+    return {
+        isFile: false,
+        isDirectory: true,
+        name,
+        createReader() {
+            return {
+                readEntries(successCb) {
+                    if (served) { successCb([]); } else { served = true; successCb(children); }
+                },
+            };
+        },
+    };
+}
+
+function fakeItem(entry) {
+    return { webkitGetAsEntry: () => entry };
+}
+
+async function flushMicrotasks(times = 20) {
+    for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+describe('initExplorerDrop', () => {
+    let handle;
+
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="main-import-card">
+                <input type="hidden" name="folder_id" value="folder-42">
+            </div>
+        `;
+        handle = initExplorerDrop();
+    });
+
+    afterEach(() => {
+        handle.destroy();
+    });
+
+    test("dépose d'un dossier local → hc:files-selected avec relativePath annoté sur chaque File", async () => {
+        const inDirFile = new File(['x'], 'scan.pdf');
+        const dir = fakeDirEntry('2026-07-10-BMA', [fakeFileEntry(inDirFile)]);
+
+        const received = jest.fn();
+        document.addEventListener('hc:files-selected', received);
+
+        const dropEvent = new Event('drop', { bubbles: true, cancelable: true });
+        dropEvent.dataTransfer = { items: [fakeItem(dir)] };
+        document.dispatchEvent(dropEvent);
+
+        await flushMicrotasks();
+
+        expect(received).toHaveBeenCalledTimes(1);
+        const { files, folderId } = received.mock.calls[0][0].detail;
+        expect(folderId).toBe('folder-42');
+        expect(files).toHaveLength(1);
+        expect(files[0]._hcRelativePath).toBe('2026-07-10-BMA');
+    });
+
+    test('fichier isolé (pas de dossier) : pas de relativePath annoté', async () => {
+        const alone = new File(['y'], 'alone.pdf');
+
+        const received = jest.fn();
+        document.addEventListener('hc:files-selected', received);
+
+        const dropEvent = new Event('drop', { bubbles: true, cancelable: true });
+        dropEvent.dataTransfer = { items: [fakeItem(fakeFileEntry(alone))] };
+        document.dispatchEvent(dropEvent);
+
+        await flushMicrotasks();
+
+        const { files } = received.mock.calls[0][0].detail;
+        expect(files[0]._hcRelativePath).toBeUndefined();
+    });
+
+    test('fichiers vides (taille 0) sont filtrés', async () => {
+        const empty = new File([], 'empty.pdf');
+
+        const received = jest.fn();
+        document.addEventListener('hc:files-selected', received);
+
+        const dropEvent = new Event('drop', { bubbles: true, cancelable: true });
+        dropEvent.dataTransfer = { items: [fakeItem(fakeFileEntry(empty))] };
+        document.dispatchEvent(dropEvent);
+
+        await flushMicrotasks();
+
+        expect(received).not.toHaveBeenCalled();
+    });
+});

--- a/assets/tests/upload-modal-relative-path.test.js
+++ b/assets/tests/upload-modal-relative-path.test.js
@@ -1,0 +1,53 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+const { createUploadFn } = await import('../js/upload-modal.js');
+
+/**
+ * #238 — le fichier annoté d'un relativePath (dossier local glissé-déposé,
+ * via explorer-drop.js/directory-entry-reader.js) doit voir ce champ propagé
+ * dans le multipart envoyé au serveur, pour que FileUploadController recrée
+ * l'arborescence (DefaultFolderService::ensureSubfolderPath).
+ */
+let capturedFormData = null;
+
+class FakeXHR {
+    constructor() {
+        this.upload = { addEventListener() {} };
+        this._listeners = {};
+    }
+    addEventListener(evt, cb) { this._listeners[evt] = cb; }
+    open() {}
+    setRequestHeader() {}
+    send(formData) {
+        capturedFormData = formData;
+        this.status = 201;
+        this.responseText = JSON.stringify({ id: 'f1' });
+        this._listeners['load']?.();
+    }
+}
+
+describe('createUploadFn — propagation du relativePath', () => {
+    beforeEach(() => {
+        capturedFormData = null;
+        global.XMLHttpRequest = FakeXHR;
+    });
+
+    test('un fichier annoté _hcRelativePath envoie le champ relativePath', async () => {
+        const uploadFn = createUploadFn('token', 'folder-1', null, null);
+        const file = new File(['x'], 'scan.pdf');
+        file._hcRelativePath = '2026-07-10-BMA';
+
+        await uploadFn(file, {}, () => {});
+
+        expect(capturedFormData.get('relativePath')).toBe('2026-07-10-BMA');
+    });
+
+    test('un fichier sans relativePath n\'envoie pas le champ', async () => {
+        const uploadFn = createUploadFn('token', 'folder-1', null, null);
+        const file = new File(['x'], 'alone.pdf');
+
+        await uploadFn(file, {}, () => {});
+
+        expect(capturedFormData.get('relativePath')).toBeNull();
+    });
+});

--- a/assets/tests/webkit-relative-path.test.js
+++ b/assets/tests/webkit-relative-path.test.js
@@ -1,0 +1,40 @@
+import { describe, test, expect } from '@jest/globals';
+
+const { annotateWebkitRelativePaths } = await import('../js/directory-entry-reader.js');
+
+/**
+ * #238 — sélection via <input webkitdirectory> (menu "Importer un dossier").
+ * file.webkitRelativePath est peuplé nativement par le navigateur
+ * (ex. "2026-07-10-BMA/scans/scan1.pdf") ; on en extrait le dossier parent
+ * pour l'annoter en _hcRelativePath, même contrat que le drag & drop.
+ */
+function withWebkitRelativePath(file, relativePath) {
+    Object.defineProperty(file, 'webkitRelativePath', { value: relativePath });
+    return file;
+}
+
+describe('annotateWebkitRelativePaths', () => {
+    test('extrait le dossier parent de webkitRelativePath', () => {
+        const file = withWebkitRelativePath(new File(['x'], 'scan1.pdf'), '2026-07-10-BMA/scan1.pdf');
+
+        annotateWebkitRelativePaths([file]);
+
+        expect(file._hcRelativePath).toBe('2026-07-10-BMA');
+    });
+
+    test('sous-dossiers imbriqués', () => {
+        const file = withWebkitRelativePath(new File(['x'], 'scan2.pdf'), '2026-07-10-BMA/scans/scan2.pdf');
+
+        annotateWebkitRelativePaths([file]);
+
+        expect(file._hcRelativePath).toBe('2026-07-10-BMA/scans');
+    });
+
+    test('sans webkitRelativePath : pas d\'annotation', () => {
+        const file = new File(['x'], 'plain.pdf');
+
+        annotateWebkitRelativePaths([file]);
+
+        expect(file._hcRelativePath).toBeUndefined();
+    });
+});

--- a/src/Controller/Api/FileUploadController.php
+++ b/src/Controller/Api/FileUploadController.php
@@ -60,8 +60,11 @@ final class FileUploadController extends AbstractController
      *   ownerId        (UUID utilisateur, obligatoire)
      *   folderId       (UUID folder existant, optionnel)
      *   newFolderName  (nom du nouveau folder à créer, optionnel)
+     *   relativePath   (sous-arborescence à recréer sous le folder cible,
+     *                   ex. "2026-07-10-BMA/scans" — import d'un dossier
+     *                   local avec sa structure, #238)
      *
-     * Priorité : folderId > newFolderName > dossier "Uploads"
+     * Priorité : folderId > newFolderName > dossier "Uploads", puis relativePath
      */
     public function __invoke(Request $request): Response
     {
@@ -81,6 +84,7 @@ final class FileUploadController extends AbstractController
             $ownerId,
             $request->request->get('folderId'),
             $request->request->get('newFolderName'),
+            $request->request->get('relativePath'),
         );
 
         $batch = $this->resolveBatch($request, $ownerId);

--- a/src/Interface/CreateFileServiceInterface.php
+++ b/src/Interface/CreateFileServiceInterface.php
@@ -20,5 +20,6 @@ interface CreateFileServiceInterface
         string $ownerId,
         ?string $folderId = null,
         ?string $newFolderName = null,
+        ?string $relativePath = null,
     ): File;
 }

--- a/src/Interface/DefaultFolderServiceInterface.php
+++ b/src/Interface/DefaultFolderServiceInterface.php
@@ -21,7 +21,10 @@ interface DefaultFolderServiceInterface
      *   2. $newFolderName fourni → crée un nouveau dossier
      *   3. Aucun → retourne/crée le dossier système "Uploads"
      *
+     * $relativePath (optionnel) recrée une sous-arborescence sous le dossier
+     * ainsi résolu — import d'un dossier local avec sa structure (#238).
+     *
      * @throws \Symfony\Component\HttpKernel\Exception\BadRequestHttpException si le folderId n'existe pas ou n'appartient pas à $owner
      */
-    public function resolve(?string $folderId, ?string $newFolderName, User $owner): Folder;
+    public function resolve(?string $folderId, ?string $newFolderName, User $owner, ?string $relativePath = null): Folder;
 }

--- a/src/Service/CreateFileService.php
+++ b/src/Service/CreateFileService.php
@@ -58,6 +58,8 @@ final class CreateFileService implements CreateFileServiceInterface
      * @param string $ownerId              User UUID
      * @param string|null $folderId        Target folder (optional)
      * @param string|null $newFolderName   Create new folder (optional)
+     * @param string|null $relativePath    Sous-arborescence à recréer sous le dossier
+     *                                     résolu (import d'un dossier local, #238)
      * @return File                        Persisted entity
      *
      * @throws BadRequestHttpException     if validation fails
@@ -68,6 +70,7 @@ final class CreateFileService implements CreateFileServiceInterface
         string $ownerId,
         ?string $folderId = null,
         ?string $newFolderName = null,
+        ?string $relativePath = null,
     ): File {
         // 1. Security FIRST: validate file is not executable (before any DB lookup)
         $this->validateExecutable($uploadedFile);
@@ -78,8 +81,8 @@ final class CreateFileService implements CreateFileServiceInterface
 
         $this->guestRestrictionChecker->denyUnlessFullAccount($owner);
 
-        // 3. Folder resolution: folderId > newFolderName > Uploads
-        $folder = $this->defaultFolderService->resolve($folderId, $newFolderName, $owner);
+        // 3. Folder resolution: folderId > newFolderName > Uploads, puis relativePath
+        $folder = $this->defaultFolderService->resolve($folderId, $newFolderName, $owner, $relativePath);
 
         // 4. Extract metadata (name, mime, size)
         $metadata = $this->extractMetadata($uploadedFile);

--- a/src/Service/DefaultFolderService.php
+++ b/src/Service/DefaultFolderService.php
@@ -38,9 +38,24 @@ final class DefaultFolderService implements DefaultFolderServiceInterface
      *   newFolderName fourni → crée un nouveau Folder
      *   aucun → retourne (ou crée) le folder "Uploads"
      *
+     * Si $relativePath est fourni (import d'un dossier local avec sa structure,
+     * cf. #238), la ou les sous-arborescences sont créées/réutilisées sous le
+     * folder ainsi résolu, via ensureSubfolderPath().
+     *
      * @throws BadRequestHttpException si folderId est fourni mais introuvable
      */
-    public function resolve(?string $folderId, ?string $newFolderName, User $owner): Folder
+    public function resolve(?string $folderId, ?string $newFolderName, User $owner, ?string $relativePath = null): Folder
+    {
+        $base = $this->resolveBase($folderId, $newFolderName, $owner);
+
+        if ($relativePath === null || $relativePath === '') {
+            return $base;
+        }
+
+        return $this->ensureSubfolderPath($base, $relativePath, $owner);
+    }
+
+    private function resolveBase(?string $folderId, ?string $newFolderName, User $owner): Folder
     {
         if ($folderId !== null && $folderId !== '') {
             $folder = $this->folderRepository->find($folderId);

--- a/templates/web/explorer.html.twig
+++ b/templates/web/explorer.html.twig
@@ -41,44 +41,5 @@
 
 </div>
 
-<script>
-(function () {
-  const importCard = document.getElementById('main-import-card');
-  if (!importCard) return;
-
-  // Compteur pour ignorer les dragleave sur les éléments enfants
-  let dragCounter = 0;
-
-  // Activation sur tout le document — la zone réagit dès que le fichier entre dans la page
-  document.addEventListener('dragenter', (e) => {
-    e.preventDefault();
-    dragCounter++;
-    importCard.classList.add('drop-active');
-  });
-
-  document.addEventListener('dragover', (e) => { e.preventDefault(); });
-
-  document.addEventListener('dragleave', (e) => {
-    dragCounter--;
-    // relatedTarget null = le curseur a quitté la fenêtre du navigateur
-    if (dragCounter <= 0 || e.relatedTarget === null) {
-      dragCounter = 0;
-      importCard.classList.remove('drop-active');
-    }
-  });
-
-  document.addEventListener('drop', (e) => {
-    e.preventDefault();
-    dragCounter = 0;
-    importCard.classList.remove('drop-active');
-    const files = Array.from(e.dataTransfer.files).filter(f => f.size > 0);
-    if (files.length === 0) return;
-    const folderIdInput = importCard.querySelector('input[name="folder_id"]');
-    const folderId = folderIdInput ? folderIdInput.value : '';
-    document.dispatchEvent(new CustomEvent('hc:files-selected', { detail: { files, folderId } }));
-  });
-}());
-</script>
-
 {% endblock %}
 

--- a/templates/web/home.html.twig
+++ b/templates/web/home.html.twig
@@ -32,44 +32,5 @@
 
 </div>
 
-<script>
-(function () {
-  const importCard = document.getElementById('main-import-card');
-  if (!importCard) return;
-
-  // Compteur pour ignorer les dragleave sur les éléments enfants
-  let dragCounter = 0;
-
-  // Activation sur tout le document — la zone réagit dès que le fichier entre dans la page
-  document.addEventListener('dragenter', (e) => {
-    e.preventDefault();
-    dragCounter++;
-    importCard.classList.add('drop-active');
-  });
-
-  document.addEventListener('dragover', (e) => { e.preventDefault(); });
-
-  document.addEventListener('dragleave', (e) => {
-    dragCounter--;
-    // relatedTarget null = le curseur a quitté la fenêtre du navigateur
-    if (dragCounter <= 0 || e.relatedTarget === null) {
-      dragCounter = 0;
-      importCard.classList.remove('drop-active');
-    }
-  });
-
-  document.addEventListener('drop', (e) => {
-    e.preventDefault();
-    dragCounter = 0;
-    importCard.classList.remove('drop-active');
-    const files = Array.from(e.dataTransfer.files).filter(f => f.size > 0);
-    if (files.length === 0) return;
-    const folderIdInput = importCard.querySelector('input[name="folder_id"]');
-    const folderId = folderIdInput ? folderIdInput.value : '';
-    document.dispatchEvent(new CustomEvent('hc:files-selected', { detail: { files, folderId } }));
-  });
-}());
-</script>
-
 {% endblock %}
 

--- a/tests/Api/FileUploadTest.php
+++ b/tests/Api/FileUploadTest.php
@@ -56,4 +56,48 @@ final class FileUploadTest extends AuthenticatedApiTestCase
         $this->assertResponseStatusCodeSame(201);
         @unlink($tempFile);
     }
+
+    /**
+     * #238 — glisser-déposer un dossier local : le fichier est reçu avec
+     * relativePath, la sous-arborescence doit être recréée sous le folder cible.
+     */
+    public function testUploadFileWithRelativePathCreatesNestedFolder(): void
+    {
+        $client = $this->createAuthenticatedKernelBrowser($this->alice);
+        $tempFile = tempnam(sys_get_temp_dir(), 'test_upload_');
+        file_put_contents($tempFile, 'contenu du scan');
+
+        $uploadedFile = new UploadedFile($tempFile, 'scan1.pdf', 'application/pdf', null, false);
+
+        $client->request(
+            'POST',
+            '/api/v1/files',
+            [
+                'ownerId' => (string) $this->alice->getId(),
+                'folderId' => (string) $this->folder->getId(),
+                'relativePath' => '2026-07-10-BMA',
+            ],
+            [
+                'file' => $uploadedFile,
+            ],
+            [
+                'CONTENT_TYPE' => 'multipart/form-data',
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+        @unlink($tempFile);
+
+        $em = static::getContainer()->get('doctrine')->getManager();
+        $subFolder = $em->getRepository(Folder::class)->findOneBy([
+            'name' => '2026-07-10-BMA',
+            'owner' => $this->alice,
+        ]);
+        $this->assertNotNull($subFolder, 'Le sous-dossier doit avoir été créé');
+        $this->assertSame((string) $this->folder->getId(), (string) $subFolder->getParent()->getId());
+
+        $createdFile = $em->getRepository(\App\Entity\File::class)->findOneBy(['originalName' => 'scan1.pdf']);
+        $this->assertNotNull($createdFile);
+        $this->assertSame((string) $subFolder->getId(), (string) $createdFile->getFolder()->getId());
+    }
 }

--- a/tests/Service/CreateFileServiceTest.php
+++ b/tests/Service/CreateFileServiceTest.php
@@ -166,7 +166,7 @@ class CreateFileServiceTest extends TestCase
 
         $this->defaultFolderService->expects($this->once())
             ->method('resolve')
-            ->with($folderId, null, $owner)
+            ->with($folderId, null, $owner, null)
             ->willReturn($targetFolder);
 
         $this->storageService->expects($this->once())
@@ -207,7 +207,7 @@ class CreateFileServiceTest extends TestCase
 
         $this->defaultFolderService->expects($this->once())
             ->method('resolve')
-            ->with(null, 'New Folder', $owner)
+            ->with(null, 'New Folder', $owner, null)
             ->willReturn($newFolder);
 
         $this->storageService->expects($this->once())
@@ -226,6 +226,44 @@ class CreateFileServiceTest extends TestCase
 
         // Assert
         $this->assertEquals($newFolder, $file->getFolder());
+    }
+
+    public function testCreateFromUploadWithRelativePathPassesItToResolve(): void
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'test');
+        file_put_contents($tmpFile, 'content');
+        $uploadedFile = new UploadedFile($tmpFile, 'scan.pdf', 'application/pdf', null, true);
+
+        $owner = new User('owner@example.com', 'Owner');
+        $ownerId = (string) $owner->getId();
+        $targetFolder = new Folder('Archives', $owner);
+        $folderId = (string) $targetFolder->getId();
+        $subFolder = new Folder('2026-07-10-BMA', $owner, $targetFolder);
+
+        $this->userRepository->expects($this->once())
+            ->method('find')
+            ->willReturn($owner);
+
+        $this->defaultFolderService->expects($this->once())
+            ->method('resolve')
+            ->with($folderId, null, $owner, '2026-07-10-BMA')
+            ->willReturn($subFolder);
+
+        $this->storageService->expects($this->once())
+            ->method('store')
+            ->willReturn(['path' => '/path/scan.pdf', 'neutralized' => false]);
+
+        $this->em->expects($this->once())->method('persist');
+        $this->em->expects($this->once())->method('flush');
+
+        $file = $this->service->createFromUpload(
+            $uploadedFile,
+            $ownerId,
+            $folderId,
+            relativePath: '2026-07-10-BMA',
+        );
+
+        $this->assertSame($subFolder, $file->getFolder());
     }
 
     public function testCreateFromUploadPersistsFile(): void

--- a/tests/Unit/Service/DefaultFolderServiceTest.php
+++ b/tests/Unit/Service/DefaultFolderServiceTest.php
@@ -105,6 +105,65 @@ final class DefaultFolderServiceTest extends TestCase
         $this->service->resolve('some-id', null, $owner);
     }
 
+    public function testResolveWithRelativePathCreatesSubfolderUnderFolderId(): void
+    {
+        $owner = new User('owner-rel@example.com', 'Owner');
+        $target = new Folder('Archives', $owner);
+
+        $this->repo->expects($this->once())
+            ->method('find')
+            ->with('target-id')
+            ->willReturn($target);
+
+        // ensureSubfolderPath cherche un enfant existant nommé '2026-07-10-BMA' — absent
+        $this->repo->method('findOneBy')->willReturn(null);
+        $this->em->expects($this->once())->method('persist');
+        $this->em->expects($this->once())->method('flush');
+
+        $result = $this->service->resolve('target-id', null, $owner, '2026-07-10-BMA');
+
+        $this->assertSame('2026-07-10-BMA', $result->getName());
+        $this->assertSame($target, $result->getParent());
+    }
+
+    public function testResolveWithoutRelativePathReturnsFolderIdDirectly(): void
+    {
+        $owner = new User('owner-norel@example.com', 'Owner');
+        $target = new Folder('Archives', $owner);
+
+        $this->repo->expects($this->once())
+            ->method('find')
+            ->with('target-id')
+            ->willReturn($target);
+        $this->em->expects($this->never())->method('persist');
+
+        $result = $this->service->resolve('target-id', null, $owner, null);
+
+        $this->assertSame($target, $result);
+    }
+
+    public function testResolveWithRelativePathAndNoFolderIdCreatesUnderUploads(): void
+    {
+        $owner = new User('owner-rel2@example.com', 'Owner');
+        $uploads = new Folder(DefaultFolderService::DEFAULT_FOLDER_NAME, $owner);
+
+        $this->repo->method('findOneBy')
+            ->willReturnCallback(function (array $criteria) use ($uploads) {
+                if (($criteria['name'] ?? null) === DefaultFolderService::DEFAULT_FOLDER_NAME) {
+                    return $uploads;
+                }
+                return null; // pas de sous-dossier existant
+            });
+
+        $this->em->expects($this->once())->method('persist');
+        $this->em->expects($this->once())->method('flush');
+
+        $result = $this->service->resolve(null, null, $owner, 'Photos2026');
+
+        $this->assertSame('Photos2026', $result->getName());
+        $this->assertSame($uploads, $result->getParent());
+    }
+
     public function testEnsureSubfolderPathCreatesNestedFolders(): void
     {
         $owner = new User('owner@example.com', 'Owner');


### PR DESCRIPTION
## Résumé

- `assets/js/directory-entry-reader.js` : lecture récursive d'un dossier déposé (`DataTransferItem.webkitGetAsEntry()`) ou sélectionné (`<input webkitdirectory>`), logique pure et testée
- `assets/js/explorer-drop.js` : remplace le script inline dupliqué à l'identique dans `explorer.html.twig`/`home.html.twig`, câblé sur `readDroppedEntries()` au lieu de `dataTransfer.files` brut (qui aplatissait la structure d'un dossier déposé)
- `upload-modal.js` : propage `relativePath` au serveur pour chaque fichier annoté
- Backend : `DefaultFolderService::resolve()` accepte un `relativePath` optionnel, recréé via `ensureSubfolderPath()` (déjà en place et testée, mais orpheline côté HTTP jusqu'ici) — propagé `FileUploadController → CreateFileService → DefaultFolderService`
- Bonus : le menu "Nouveau > Importer un dossier" (stub `window.alert('coming soon')` existant) est maintenant fonctionnel, même mécanisme

Closes #238

## Test plan

- [x] Suite PHPUnit complète : 800 tests verts (hors `TailwindBuildTest`, préexistant, sans rapport)
- [x] Suite Jest complète : 194 tests verts
- [x] Testé manuellement en local par l'utilisateur : glisser un dossier local sur l'explorateur recrée le sous-dossier avec les fichiers dedans — confirmé fonctionnel