### PR TITLE
🔒 fix(FileWebController): forcer octet-stream pour les fichiers neutralisés

### DIFF
--- a/src/Controller/Web/FileWebController.php
+++ b/src/Controller/Web/FileWebController.php
@@ -87,6 +87,15 @@ final class FileWebController extends AbstractController
         $response = new BinaryFileResponse($absolutePath);
         $response->setContentDisposition($disposition, $file->getOriginalName());
 
+        // BinaryFileResponse devine Content-Type depuis le contenu réel du
+        // fichier (magic bytes), pas depuis son extension .bin sur disque :
+        // un fichier neutralisé (HTML/SVG dangereux) reçoit sinon son vrai
+        // Content-Type (ex. text/html) — en inline, le navigateur le rend et
+        // exécute le JS embarqué, contournant la neutralisation (#278).
+        if ($file->isNeutralized()) {
+            $response->headers->set('Content-Type', 'application/octet-stream');
+        }
+
         return $response;
     }
 

--- a/tests/Web/FileViewInlineTest.php
+++ b/tests/Web/FileViewInlineTest.php
@@ -79,6 +79,27 @@ final class FileViewInlineTest extends WebTestCase
         return $file;
     }
 
+    /**
+     * Fichier neutralisé (#278) : stocké en .bin sur disque, contenu HTML réel —
+     * simule ce que StorageService produit pour un upload HTML/SVG dangereux.
+     */
+    private function createNeutralizedHtmlFile(User $owner): File
+    {
+        $folder = new Folder('Docs', $owner);
+        $this->em->persist($folder);
+
+        $rel = 'view-test/evil-' . uniqid() . '.bin';
+        @mkdir($this->storageDir . '/view-test', 0777, true);
+        $content = '<html><body><script>alert(document.cookie)</script></body></html>';
+        file_put_contents($this->storageDir . '/' . $rel, $content);
+
+        $file = new File('evil.html', 'text/html', strlen($content), $rel, $folder, $owner, neutralized: true);
+        $this->em->persist($file);
+        $this->em->flush();
+
+        return $file;
+    }
+
     public function testViewRouteRespondsWithInlineDisposition(): void
     {
         $user = $this->createUser();
@@ -108,6 +129,36 @@ final class FileViewInlineTest extends WebTestCase
         $this->assertResponseIsSuccessful();
         $disposition = (string) $this->client->getResponse()->headers->get('Content-Disposition');
         $this->assertStringStartsWith('attachment', $disposition);
+    }
+
+    public function testViewRouteForcesOctetStreamForNeutralizedFile(): void
+    {
+        $user = $this->createUser();
+        $file = $this->createNeutralizedHtmlFile($user);
+        $fileId = $file->getId();
+        $this->em->clear();
+
+        $this->login();
+        $this->client->request('GET', '/files/' . $fileId . '/view');
+
+        $this->assertResponseIsSuccessful();
+        $contentType = (string) $this->client->getResponse()->headers->get('Content-Type');
+        $this->assertSame('application/octet-stream', $contentType, 'Un fichier neutralisé ne doit jamais être rendu comme HTML/SVG en inline');
+    }
+
+    public function testDownloadRouteForcesOctetStreamForNeutralizedFile(): void
+    {
+        $user = $this->createUser();
+        $file = $this->createNeutralizedHtmlFile($user);
+        $fileId = $file->getId();
+        $this->em->clear();
+
+        $this->login();
+        $this->client->request('GET', '/files/' . $fileId . '/download');
+
+        $this->assertResponseIsSuccessful();
+        $contentType = (string) $this->client->getResponse()->headers->get('Content-Type');
+        $this->assertSame('application/octet-stream', $contentType);
     }
 
     public function testViewRouteDeniesAccessToNonOwner(): void


### PR DESCRIPTION
## Résumé

`BinaryFileResponse` devine `Content-Type` depuis le contenu réel du fichier (magic bytes), pas depuis l'extension `.bin` sur disque. Un fichier neutralisé (HTML/SVG dangereux, stocké en `.bin` par `StorageService`) consulté via `/files/{id}/view` recevait donc son vrai `Content-Type` (ex. `text/html`) combiné à `Content-Disposition: inline` — le navigateur le rendait et exécutait le JS embarqué, contournant la neutralisation.

Fix : `Content-Type` forcé à `application/octet-stream` quand `File::isNeutralized()` est vrai, sur `/view` et `/download`.

`MediaFullResponseFactory`/`MediaGalleryController` vérifiés non concernés — ils fixent déjà `Content-Type` explicitement (vignettes générées par le pipeline média, jamais le contenu brut d'un upload arbitraire).

Closes #278

## Test plan

- [x] Test RED confirmant la faille avant fix : `Content-Type: text/html; charset=UTF-8` effectivement renvoyé pour un `.bin` neutralisé
- [x] Test GREEN après fix : `application/octet-stream` sur `/view` et `/download`
- [x] Testé manuellement en local : upload d'un `.html` avec script embarqué → neutralisé → plus aucune proposition d'ouverture/exécution, juste un téléchargement générique
- [x] Suite PHPUnit complète : 802 tests verts (hors `TailwindBuildTest`, préexistant, sans rapport)