### PR TITLE
🔒 security(SecurityHeadersListener): autoriser l'embedding same-origin sur /files/{id}/view

### DIFF
--- a/src/EventListener/SecurityHeadersListener.php
+++ b/src/EventListener/SecurityHeadersListener.php
@@ -29,6 +29,11 @@ use Symfony\Component\HttpKernel\KernelEvents;
  *   principal (app.js et tout ce qu'il importe). Risque limité : `data:`
  *   n'autorise que du contenu inline déjà rendu par le serveur, comme
  *   `'unsafe-inline'` déjà présent.
+ *
+ * Dérogation /files/{id}/view (#280) : le viewer PDF (#241) embarque cette
+ * route dans une <iframe> same-origin — DENY/'none' bloquerait cet embedding
+ * même en same-origin. Remplacé par SAMEORIGIN/'self' UNIQUEMENT sur cette
+ * route, pour ne pas affaiblir la protection anti-clickjacking ailleurs.
  */
 #[AsEventListener(event: KernelEvents::RESPONSE)]
 final class SecurityHeadersListener
@@ -43,17 +48,18 @@ final class SecurityHeadersListener
             return;
         }
 
+        $path = $event->getRequest()->getPathInfo();
+        $isFileViewRoute = (bool) preg_match('#^/files/[^/]+/view$#', $path);
+
         $headers = $event->getResponse()->headers;
         $headers->set('X-Content-Type-Options', 'nosniff');
-        $headers->set('X-Frame-Options', 'DENY');
+        $headers->set('X-Frame-Options', $isFileViewRoute ? 'SAMEORIGIN' : 'DENY');
         $headers->set('Referrer-Policy', 'no-referrer');
 
         // HSTS : uniquement en prod — HTTPS non disponible en dev/test.
         if ('prod' === $this->env) {
             $headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
         }
-
-        $path = $event->getRequest()->getPathInfo();
 
         // CSP strict sur l'API (JSON) — pas de script, style, image, etc.
         // La Swagger UI est exclue car elle charge des scripts et styles externes.
@@ -70,9 +76,10 @@ final class SecurityHeadersListener
         // CSP permissive sur le front HTML : bloque l'injection de sources
         // EXTERNES (le vecteur XSS le plus dangereux), mais autorise encore
         // les scripts/styles inline existants faute de nonces sur chacun.
+        $frameAncestors = $isFileViewRoute ? "frame-ancestors 'self'" : "frame-ancestors 'none'";
         $headers->set(
             'Content-Security-Policy',
-            "default-src 'self'; script-src 'self' 'unsafe-inline' data:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'",
+            "default-src 'self'; script-src 'self' 'unsafe-inline' data:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; object-src 'none'; base-uri 'self'; {$frameAncestors}",
         );
     }
 }

--- a/tests/Unit/EventListener/SecurityHeadersListenerTest.php
+++ b/tests/Unit/EventListener/SecurityHeadersListenerTest.php
@@ -131,4 +131,31 @@ final class SecurityHeadersListenerTest extends TestCase
 
         $this->assertSame("default-src 'none'", $event->getResponse()->headers->get('Content-Security-Policy'));
     }
+
+    /**
+     * #280 : le viewer PDF (#241) embarque /files/{id}/view dans une <iframe>
+     * same-origin. X-Frame-Options: DENY et frame-ancestors 'none' bloquent
+     * cet embedding inconditionnellement, y compris depuis la même origine —
+     * la dérogation est strictement scopée à cette route pour ne pas
+     * affaiblir la protection anti-clickjacking ailleurs.
+     */
+    public function testFileViewRouteAllowsSameOriginFraming(): void
+    {
+        $event = $this->buildEvent('/files/0198c1b2-6b8b-7f3e-8a1a-000000000001/view');
+        (new SecurityHeadersListener('test'))($event);
+
+        $headers = $event->getResponse()->headers;
+        $this->assertSame('SAMEORIGIN', $headers->get('X-Frame-Options'));
+        $this->assertStringContainsString("frame-ancestors 'self'", $headers->get('Content-Security-Policy'));
+    }
+
+    public function testOtherFrontRoutesStillDenyFraming(): void
+    {
+        $event = $this->buildEvent('/files/0198c1b2-6b8b-7f3e-8a1a-000000000001/download');
+        (new SecurityHeadersListener('test'))($event);
+
+        $headers = $event->getResponse()->headers;
+        $this->assertSame('DENY', $headers->get('X-Frame-Options'));
+        $this->assertStringContainsString("frame-ancestors 'none'", $headers->get('Content-Security-Policy'));
+    }
 }


### PR DESCRIPTION
## Résumé

Closes #280

- `X-Frame-Options: DENY` et `frame-ancestors 'none'` bloquaient inconditionnellement l'iframe same-origin du viewer PDF (#241)
- Dérogation strictement scopée à `/files/{id}/view` (`SAMEORIGIN` / `frame-ancestors 'self'`), les autres routes conservent la protection anti-clickjacking complète

## Test plan

- [x] RED : tests ajoutés sur la dérogation (échouent avant le fix)
- [x] GREEN : `SecurityHeadersListener` applique `SAMEORIGIN`/`'self'` uniquement sur `/files/{id}/view`
- [x] Suite complète : 804/805 (seul échec `TailwindBuildTest`, préexistant, assets non buildés en local)
- [x] Vérifié manuellement : ouverture d'un PDF dans la modale viewer

## Suivi

Audit de sécurité de ce changement → tickets #285 (dérogation basée sur `_route` plutôt que le path) et #286 (risque JS actif dans les PDF non scannés, aggravé par le same-origin)