### PR TITLE
🔒 security(StorageService): neutraliser les PDF actifs + fix Content-Type PDF décalé

### DIFF
--- a/src/Controller/Web/FileWebController.php
+++ b/src/Controller/Web/FileWebController.php
@@ -12,6 +12,7 @@ use App\Repository\FileRepository;
 use App\Interface\DefaultFolderServiceInterface;
 use App\Interface\SharedResourceCleanerInterface;
 use App\Security\GuestRestrictionChecker;
+use App\Service\PdfSignatureDetector;
 use App\Service\PendingMediaProcessingCollector;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -49,6 +50,7 @@ final class FileWebController extends AbstractController
         private readonly GuestRestrictionChecker $guestRestrictionChecker,
         private readonly PendingMediaProcessingCollector $pendingMediaProcessingCollector,
         private readonly MediaProcessorInterface $mediaProcessor,
+        private readonly PdfSignatureDetector $pdfSignatureDetector,
     ) {}
 
     #[Route('/files/{id}/download', name: 'app_file_download', methods: ['GET'])]
@@ -94,6 +96,17 @@ final class FileWebController extends AbstractController
         // exécute le JS embarqué, contournant la neutralisation (#278).
         if ($file->isNeutralized()) {
             $response->headers->set('Content-Type', 'application/octet-stream');
+        } elseif (
+            str_ends_with(strtolower($file->getOriginalName()), '.pdf')
+            && $response->headers->get('Content-Type') !== 'application/pdf'
+            && $this->pdfSignatureDetector->detect($absolutePath)
+        ) {
+            // finfo (via BinaryFileResponse) peut détecter à tort
+            // application/octet-stream sur un PDF valide mais dont l'en-tête
+            // est décalé (ex: texte de debug fuité en préfixe par un site
+            // tiers) — pourtant lisible par tout vrai lecteur PDF, cf.
+            // PdfSignatureDetector.
+            $response->headers->set('Content-Type', 'application/pdf');
         }
 
         return $response;

--- a/src/Service/PdfSignatureDetector.php
+++ b/src/Service/PdfSignatureDetector.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+/**
+ * Détecte l'en-tête `%PDF-` en tolérant qu'il soit décalé dans le fichier,
+ * comme le font les vrais lecteurs PDF (ISO 32000-1 §7.5.2 : l'en-tête peut
+ * apparaître n'importe où dans les 1024 premiers octets). `finfo`/libmagic,
+ * plus strict selon la version installée, peut détecter à tort
+ * `application/octet-stream` sur un PDF pourtant valide et lisible.
+ */
+final class PdfSignatureDetector
+{
+    private const SIGNATURE = '%PDF-';
+    private const TOLERANCE_BYTES = 1024;
+
+    public function detect(string $absolutePath): bool
+    {
+        $head = @file_get_contents($absolutePath, false, null, 0, self::TOLERANCE_BYTES);
+
+        return $head !== false && str_contains($head, self::SIGNATURE);
+    }
+}

--- a/src/Service/StorageService.php
+++ b/src/Service/StorageService.php
@@ -50,6 +50,20 @@ final class StorageService implements StorageServiceInterface
         'text/javascript', 'application/javascript', 'text/css',
     ];
 
+    /**
+     * Marqueurs de contenu actif PDF (#286) : le format PDF peut embarquer du
+     * JavaScript exécutable via ces objets (/OpenAction, /AA = actions
+     * automatiques à l'ouverture/l'événement, /JS/JavaScript = le script
+     * lui-même, /Launch = exécution d'un programme externe). Un PDF contenant
+     * l'un de ces tokens est neutralisé comme les autres types dangereux —
+     * détection par recherche de motif sur le contenu brut, pas un vrai parseur
+     * PDF (les objets compressés en flux /ObjStm échappent à cette détection,
+     * risque résiduel documenté dans #286).
+     */
+    private const PDF_ACTIVE_CONTENT_MARKERS = [
+        '/JavaScript', '/JS', '/OpenAction', '/AA', '/Launch',
+    ];
+
     public function __construct(
         private readonly string $storageDir,
     ) {}
@@ -83,6 +97,12 @@ final class StorageService implements StorageServiceInterface
         $neutralized = in_array($originalExt, self::NEUTRALIZED_EXTENSIONS, true)
             || in_array($detectedExt, self::NEUTRALIZED_EXTENSIONS, true)
             || in_array($detectedMime, self::NEUTRALIZED_MIME_TYPES, true);
+
+        $isPdf = $originalExt === 'pdf' || $detectedExt === 'pdf' || $detectedMime === 'application/pdf';
+        if (!$neutralized && $isPdf && $this->pdfHasActiveContent($file->getPathname())) {
+            $neutralized = true;
+        }
+
         $ext = $neutralized ? 'bin' : $originalExt;
 
         $subDir = sprintf('%s/%s', $year, $month);
@@ -94,6 +114,31 @@ final class StorageService implements StorageServiceInterface
             'path'       => sprintf('%s/%s', $subDir, $filename),
             'neutralized' => $neutralized,
         ];
+    }
+
+    /**
+     * Détecte du contenu actif (JS embarqué, action au lancement) dans un PDF
+     * via une recherche de motif sur le contenu brut (#286).
+     */
+    private function pdfHasActiveContent(string $pathname): bool
+    {
+        $content = file_get_contents($pathname);
+        if ($content === false) {
+            return false;
+        }
+
+        // Délimité par une lettre/chiffre en négatif : un vrai nom d'objet PDF
+        // (/JS, /AA…) n'est jamais suivi directement d'un caractère alphanumérique
+        // qui en ferait un nom différent — sinon /JS matcherait /JSON en sous-chaîne
+        // (ex: un chemin "config/JSON" cité dans le texte d'un PDF légitime, #286).
+        foreach (self::PDF_ACTIVE_CONTENT_MARKERS as $marker) {
+            $pattern = '/' . preg_quote($marker, '/') . '(?![A-Za-z0-9])/';
+            if (preg_match($pattern, $content) === 1) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Unit/Service/PdfSignatureDetectorTest.php
+++ b/tests/Unit/Service/PdfSignatureDetectorTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\PdfSignatureDetector;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * La norme PDF (ISO 32000-1 §7.5.2) tolère que l'en-tête `%PDF-` soit décalé
+ * dans les 1024 premiers octets du fichier — les vrais lecteurs PDF (Acrobat,
+ * visionneuses natives) scannent cette zone. `finfo`/libmagic, utilisé par
+ * BinaryFileResponse pour définir le Content-Type, est plus strict selon
+ * l'environnement et peut détecter `application/octet-stream` à tort sur un
+ * PDF pourtant valide (ex: fichier téléchargé depuis un site tiers ayant
+ * laissé fuiter du texte de debug avant le flux réel). Ce détecteur reproduit
+ * la tolérance des vrais lecteurs, indépendamment de la version de libmagic
+ * installée sur le serveur.
+ */
+final class PdfSignatureDetectorTest extends TestCase
+{
+    private string $tmpPath;
+
+    protected function setUp(): void
+    {
+        $this->tmpPath = tempnam(sys_get_temp_dir(), 'pdf_sig_test');
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->tmpPath);
+    }
+
+    public function testDetectsHeaderAtByteZero(): void
+    {
+        file_put_contents($this->tmpPath, '%PDF-1.4 content');
+
+        $this->assertTrue((new PdfSignatureDetector())->detect($this->tmpPath));
+    }
+
+    public function testDetectsHeaderShiftedWithinTolerance(): void
+    {
+        // En-tête décalé à ~1020 octets, toujours dans la fenêtre de tolérance de 1024.
+        $prefix = str_repeat('X', 1015);
+        file_put_contents($this->tmpPath, $prefix . '%PDF-1.5 content');
+
+        $this->assertTrue((new PdfSignatureDetector())->detect($this->tmpPath));
+    }
+
+    public function testRejectsHeaderBeyondToleranceWindow(): void
+    {
+        $prefix = str_repeat('X', 2000);
+        file_put_contents($this->tmpPath, $prefix . '%PDF-1.5 content');
+
+        $this->assertFalse((new PdfSignatureDetector())->detect($this->tmpPath));
+    }
+
+    public function testRejectsFileWithoutPdfSignature(): void
+    {
+        file_put_contents($this->tmpPath, '<html><body>not a pdf</body></html>');
+
+        $this->assertFalse((new PdfSignatureDetector())->detect($this->tmpPath));
+    }
+}

--- a/tests/Web/FileUploadPdfActiveContentTest.php
+++ b/tests/Web/FileUploadPdfActiveContentTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\File;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * #286 : le format PDF peut embarquer du JavaScript exécutable
+ * (/OpenAction, /AA, /JS) exécuté par le lecteur PDF natif du navigateur.
+ * Un PDF malveillant est neutralisé comme les autres types dangereux
+ * (HTML/SVG/JS) plutôt que stocké tel quel — même mécanisme, même garanties
+ * que StorageService::NEUTRALIZED_MIME_TYPES.
+ */
+final class FileUploadPdfActiveContentTest extends WebTestCase
+{
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createUser(string $email = 'test@example.com', string $password = 'pwd12345'): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User($email, 'Test');
+        $user->setPassword($hasher->hashPassword($user, $password));
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+
+    private function login(string $email = 'test@example.com', string $password = 'pwd12345'): void
+    {
+        $crawler = $this->client->request('GET', '/login');
+        $form = $crawler->selectButton('Se connecter')->form([
+            'email'    => $email,
+            'password' => $password,
+        ]);
+        $this->client->submit($form);
+        $this->client->followRedirect();
+    }
+
+    private function uploadPdf(string $content): void
+    {
+        $this->createUser();
+        $this->em->clear();
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/explorer');
+        $token = $crawler->filter('#main-upload-form input[name="_token"]')->attr('value');
+
+        $tmp = tempnam(sys_get_temp_dir(), 'pdf_upload');
+        file_put_contents($tmp, $content);
+        $upload = new UploadedFile($tmp, 'document.pdf', 'application/pdf', null, true);
+
+        $this->client->request('POST', '/files/upload', ['_token' => $token], ['file' => $upload]);
+        @unlink($tmp);
+    }
+
+    /**
+     * PDF minimal avec une action d'ouverture exécutant du JavaScript
+     * (/OpenAction /S /JavaScript /JS) — pattern typique d'un PDF malveillant.
+     */
+    public function testPdfWithOpenActionJavaScriptIsNeutralized(): void
+    {
+        $maliciousPdf = "%PDF-1.4\n"
+            . "1 0 obj\n<< /Type /Catalog /OpenAction 2 0 R >>\nendobj\n"
+            . "2 0 obj\n<< /Type /Action /S /JavaScript /JS (app.alert\\('pwned'\\);) >>\nendobj\n"
+            . "%%EOF";
+
+        $this->uploadPdf($maliciousPdf);
+
+        $stored = $this->em->getRepository(File::class)->findOneBy([]);
+
+        $this->assertNotNull($stored);
+        $this->assertTrue(
+            $stored->isNeutralized(),
+            'Un PDF avec /OpenAction /JavaScript doit être neutralisé, pas stocké tel quel.'
+        );
+    }
+
+    /**
+     * Un PDF ordinaire, sans contenu actif, ne doit subir aucune régression.
+     */
+    public function testOrdinaryPdfIsNotNeutralized(): void
+    {
+        $ordinaryPdf = "%PDF-1.4\n"
+            . "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+            . "2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n"
+            . "%%EOF";
+
+        $this->uploadPdf($ordinaryPdf);
+
+        $stored = $this->em->getRepository(File::class)->findOneBy([]);
+
+        $this->assertNotNull($stored);
+        $this->assertFalse(
+            $stored->isNeutralized(),
+            'Un PDF ordinaire sans contenu actif ne doit pas être neutralisé.'
+        );
+    }
+
+    /**
+     * Faux positif à éviter : un PDF légitime (ex. un cours sur le JavaScript
+     * ou le JSON) mentionne ces mots dans son contenu texte, sans qu'il
+     * s'agisse d'une véritable action PDF embarquée. Un marqueur `/JS` en
+     * simple sous-chaîne matcherait à tort `/JSON` (ex: un chemin de fichier
+     * "config/JSON" cité dans le texte) — le détecteur doit distinguer un
+     * vrai token PDF (`/JS` isolé) d'une sous-chaîne fortuite.
+     */
+    public function testPdfMentioningJsonInTextIsNotNeutralized(): void
+    {
+        $courseAboutJsonPdf = "%PDF-1.4\n"
+            . "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+            . "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
+            . "3 0 obj\n<< /Type /Page /Contents 4 0 R >>\nendobj\n"
+            . "4 0 obj\n<< /Length 60 >>\nstream\n"
+            . "BT (Voir le fichier de configuration config/JSON pour la suite) Tj ET\n"
+            . "endstream\nendobj\n"
+            . "%%EOF";
+
+        $this->uploadPdf($courseAboutJsonPdf);
+
+        $stored = $this->em->getRepository(File::class)->findOneBy([]);
+
+        $this->assertNotNull($stored);
+        $this->assertFalse(
+            $stored->isNeutralized(),
+            'Une mention textuelle de "/JSON" ne doit pas être confondue avec le token PDF "/JS".'
+        );
+    }
+}

--- a/tests/Web/FileViewInlineTest.php
+++ b/tests/Web/FileViewInlineTest.php
@@ -161,6 +161,52 @@ final class FileViewInlineTest extends WebTestCase
         $this->assertSame('application/octet-stream', $contentType);
     }
 
+    /**
+     * PDF valide mais dont l'en-tête `%PDF-` n'est pas à l'octet 0 (ex: un
+     * fichier téléchargé depuis un site tiers ayant laissé fuiter du texte de
+     * debug avant le flux réel). La norme PDF (ISO 32000-1 §7.5.2) tolère cet
+     * en-tête décalé dans les 1024 premiers octets — les vrais lecteurs PDF
+     * l'ouvrent sans problème — mais `finfo` (utilisé par BinaryFileResponse)
+     * est plus strict et détecte `application/octet-stream`. Combiné à
+     * X-Content-Type-Options: nosniff, le navigateur ne peut pas se
+     * rattraper : il propose le téléchargement au lieu du rendu inline.
+     */
+    private function createPdfWithShiftedHeader(User $owner): File
+    {
+        $folder = new Folder('Docs', $owner);
+        $this->em->persist($folder);
+
+        $rel = 'view-test/shifted-' . uniqid() . '.pdf';
+        @mkdir($this->storageDir . '/view-test', 0777, true);
+        $content = "SELECT * FROM `manuals` WHERE `id` = '375015'%PDF-1.5\r\n%âãÏÓ\r\nfake content";
+        file_put_contents($this->storageDir . '/' . $rel, $content);
+
+        $file = new File('manual.pdf', 'application/pdf', strlen($content), $rel, $folder, $owner);
+        $this->em->persist($file);
+        $this->em->flush();
+
+        return $file;
+    }
+
+    public function testViewRouteForcesPdfContentTypeWhenHeaderIsShiftedButWithinSpecTolerance(): void
+    {
+        $user = $this->createUser();
+        $file = $this->createPdfWithShiftedHeader($user);
+        $fileId = $file->getId();
+        $this->em->clear();
+
+        $this->login();
+        $this->client->request('GET', '/files/' . $fileId . '/view');
+
+        $this->assertResponseIsSuccessful();
+        $contentType = (string) $this->client->getResponse()->headers->get('Content-Type');
+        $this->assertSame(
+            'application/pdf',
+            $contentType,
+            'Un PDF valide dont l\'en-tête est décalé dans les 1024 premiers octets (toléré par la norme) doit rester servi comme application/pdf.'
+        );
+    }
+
     public function testViewRouteDeniesAccessToNonOwner(): void
     {
         $owner = $this->createUser('owner@example.com', 'pwd12345');


### PR DESCRIPTION
## Résumé

Closes #286

- `StorageService` neutralise à l'upload tout PDF contenant du contenu actif (`/OpenAction`, `/AA`, `/JS`, `/Launch`), même mécanisme que HTML/SVG existant
- Détection par motif délimité (évite le faux positif `/JSON` confondu avec `/JS`)
- Bug découvert en marge : un PDF valide mais à en-tête `%PDF-` décalé (toléré par la norme, ISO 32000-1 §7.5.2) était mal servi en `application/octet-stream` par `finfo`, forçant un téléchargement au lieu du rendu inline — corrigé via `PdfSignatureDetector`

## Limites documentées

Heuristique par motif, pas un vrai parseur PDF : les objets compressés en flux `/ObjStm` ou les noms PDF obfusqués (échappement `#XX`) échappent à cette détection (risque résiduel déjà noté dans #286).

## Test plan

- [x] TDD RED→GREEN sur chaque commit
- [x] Suite complète : 812/813 (seul échec `TailwindBuildTest`, préexistant, sans rapport)
- [ ] Après merge + déploiement : réparer `roland-fc-200.pdf` sur `ronan.lenouvel.me` (fichier prod avec préfixe SQL parasite avant l'en-tête, cause du bug découvert)