### PR TITLE
✨ feat(ChangelogController): page changelog auto-alimentée depuis GitHub

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -20,6 +20,7 @@ services:
     App\Interface\FolderRepositoryInterface:      '@App\Repository\FolderRepository'
     App\Interface\UserRepositoryInterface:        '@App\Repository\UserRepository'
     App\Interface\ShareRepositoryInterface:       '@App\Repository\ShareRepository'
+    App\Interface\ChangelogFetcherInterface:      '@App\Service\GitHubChangelogFetcher'
     App\Interface\ShareLinkRepositoryInterface:   '@App\Repository\ShareLinkRepository'
     App\Interface\ShareLinkAccessCheckerInterface: '@App\Security\ShareLinkAccessChecker'
     App\Interface\ResourceLocatorInterface:       '@App\Security\ResourceLocator'

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -19,3 +19,9 @@ when@test:
         App\Interface\StorageServiceInterface:
             alias: App\Service\StorageService
             public: true
+
+        App\Tests\Fake\FakeChangelogFetcher: ~
+
+        App\Interface\ChangelogFetcherInterface:
+            alias: App\Tests\Fake\FakeChangelogFetcher
+            public: true

--- a/src/Controller/Web/ChangelogController.php
+++ b/src/Controller/Web/ChangelogController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Web;
+
+use App\Interface\ChangelogFetcherInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * #290 : grands thèmes de l'historique du projet (date + titre + lien
+ * GitHub), alimenté automatiquement depuis les PR mergées.
+ */
+#[IsGranted('ROLE_USER')]
+final class ChangelogController extends AbstractController
+{
+    public function __construct(
+        private readonly ChangelogFetcherInterface $changelogFetcher,
+    ) {}
+
+    #[Route('/changelog', name: 'app_changelog', methods: ['GET'])]
+    public function index(): Response
+    {
+        return $this->render('web/changelog.html.twig', [
+            'entries' => $this->changelogFetcher->fetchEntries(),
+        ]);
+    }
+}

--- a/src/Interface/ChangelogFetcherInterface.php
+++ b/src/Interface/ChangelogFetcherInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+interface ChangelogFetcherInterface
+{
+    /**
+     * @return list<array{number: int, title: string, date: string, url: string}>
+     */
+    public function fetchEntries(): array;
+}

--- a/src/Service/GitHubChangelogFetcher.php
+++ b/src/Service/GitHubChangelogFetcher.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Interface\ChangelogFetcherInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * #290 : alimente le changelog automatiquement depuis les PR GitHub mergées,
+ * sans maintenance manuelle. Seules les PR labellisées comme changements
+ * visibles pour l'utilisateur (feature/bug/sécurité/perf) apparaissent — le
+ * reste (chore, refactor, ci, docs, tests) est du bruit pour un utilisateur
+ * final.
+ */
+final class GitHubChangelogFetcher implements ChangelogFetcherInterface
+{
+    private const REPO = 'ronan-develop/home-cloud';
+    private const RELEVANT_LABELS = ['feature', 'bug', 'securité', 'performance'];
+    private const CACHE_TTL_SECONDS = 3600;
+    private const CACHE_KEY = 'changelog_github_entries';
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly CacheInterface $cache,
+    ) {}
+
+    public function fetchEntries(): array
+    {
+        return $this->cache->get(self::CACHE_KEY, function (ItemInterface $item): array {
+            $item->expiresAfter(self::CACHE_TTL_SECONDS);
+
+            return $this->fetchFromGitHub();
+        });
+    }
+
+    /**
+     * @return list<array{number: int, title: string, date: string, url: string}>
+     */
+    private function fetchFromGitHub(): array
+    {
+        try {
+            $response = $this->httpClient->request('GET', sprintf(
+                'https://api.github.com/repos/%s/pulls?state=closed&per_page=100&sort=updated&direction=desc',
+                self::REPO,
+            ), [
+                'headers' => ['Accept' => 'application/vnd.github+json'],
+            ]);
+
+            $pulls = $response->toArray(false);
+        } catch (\Throwable) {
+            return [];
+        }
+
+        if (!is_array($pulls)) {
+            return [];
+        }
+
+        $entries = [];
+        foreach ($pulls as $pull) {
+            if (!is_array($pull) || empty($pull['merged_at'])) {
+                continue;
+            }
+
+            $labels = array_map(
+                static fn (array $label): string => strtolower((string) ($label['name'] ?? '')),
+                $pull['labels'] ?? [],
+            );
+
+            if (count(array_intersect($labels, self::RELEVANT_LABELS)) === 0) {
+                continue;
+            }
+
+            $entries[] = [
+                'number' => (int) $pull['number'],
+                'title' => $this->cleanTitle((string) $pull['title']),
+                'date' => substr((string) $pull['merged_at'], 0, 10),
+                'url' => (string) $pull['html_url'],
+                'mergedAt' => (string) $pull['merged_at'],
+            ];
+        }
+
+        usort($entries, static fn (array $a, array $b): int => $b['mergedAt'] <=> $a['mergedAt']);
+
+        return array_map(static function (array $entry): array {
+            unset($entry['mergedAt']);
+
+            return $entry;
+        }, $entries);
+    }
+
+    /**
+     * Retire l'emoji et le préfixe conventionnel ("type(scope): ") d'un titre
+     * de PR pour un affichage lisible côté utilisateur final (ex: "✨
+     * feat(FolderZipArchiver): télécharger un dossier en zip" → "Télécharger
+     * un dossier en zip").
+     */
+    private function cleanTitle(string $title): string
+    {
+        $cleaned = preg_replace(
+            '/^(\p{So}\s*)?[a-zA-Zàâäéèêëïîôöùûüç]+(\([^)]*\))?\s*:\s*/u',
+            '',
+            trim($title),
+        ) ?? $title;
+
+        $cleaned = trim($cleaned);
+
+        if ($cleaned === '') {
+            return trim($title);
+        }
+
+        return mb_strtoupper(mb_substr($cleaned, 0, 1)) . mb_substr($cleaned, 1);
+    }
+}

--- a/templates/web/changelog.html.twig
+++ b/templates/web/changelog.html.twig
@@ -1,0 +1,45 @@
+{% extends 'web/layout.html.twig' %}
+
+{% block title %}Changelog — HomeCloud{% endblock %}
+
+{% block content %}
+
+<div class="max-w-3xl mx-auto flex flex-col gap-6">
+
+    <h1 class="text-2xl font-bold" style="color: var(--hc-text)">Changelog</h1>
+    <p style="color: var(--hc-text-secondary, var(--hc-text))">
+        Les grandes évolutions de HomeCloud, mises à jour automatiquement.
+    </p>
+
+    <div class="settings-card">
+        {% if entries is empty %}
+            <p style="color: var(--hc-text-secondary, var(--hc-text))">Aucune entrée disponible pour le moment.</p>
+        {% else %}
+            <table class="w-full text-left" style="border-collapse: collapse">
+                <thead>
+                    <tr style="border-bottom: 1px solid var(--hc-border)">
+                        <th class="py-2 pr-4" style="color: var(--hc-text-secondary, var(--hc-text))">Date</th>
+                        <th class="py-2 pr-4" style="color: var(--hc-text-secondary, var(--hc-text))">Évolution</th>
+                        <th class="py-2" style="color: var(--hc-text-secondary, var(--hc-text))">GitHub</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for entry in entries %}
+                        <tr style="border-bottom: 1px solid var(--hc-border)">
+                            <td class="py-2 pr-4 whitespace-nowrap" style="color: var(--hc-text-secondary, var(--hc-text))">{{ entry.date }}</td>
+                            <td class="py-2 pr-4" style="color: var(--hc-text)">{{ entry.title }}</td>
+                            <td class="py-2">
+                                <a href="{{ entry.url }}" target="_blank" rel="noopener noreferrer" class="hc-nav-item" style="display: inline-flex; padding: 0.25rem 0.5rem">
+                                    #{{ entry.number }}
+                                </a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% endif %}
+    </div>
+
+</div>
+
+{% endblock %}

--- a/templates/web/layout.html.twig
+++ b/templates/web/layout.html.twig
@@ -91,6 +91,14 @@
                 </svg>
                 Invités
             </a>
+
+            <a href="{{ path('app_changelog') }}"
+               class="hc-nav-item {{ current_route == 'app_changelog' ? 'active' : '' }}">
+                <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                    <path d="M8 2v4M16 2v4M3 10h18M5 4h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"/>
+                </svg>
+                Changelog
+            </a>
         </nav>
     </aside>
 

--- a/tests/Fake/FakeChangelogFetcher.php
+++ b/tests/Fake/FakeChangelogFetcher.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Fake;
+
+use App\Interface\ChangelogFetcherInterface;
+
+/**
+ * Double de test pour ChangelogFetcherInterface — évite tout appel réseau
+ * réel vers l'API GitHub dans les tests fonctionnels (#290).
+ */
+final class FakeChangelogFetcher implements ChangelogFetcherInterface
+{
+    public function fetchEntries(): array
+    {
+        return [
+            [
+                'number' => 291,
+                'title' => 'Neutraliser les PDF actifs',
+                'date' => '2026-07-20',
+                'url' => 'https://github.com/ronan-develop/home-cloud/pull/291',
+            ],
+            [
+                'number' => 280,
+                'title' => 'Corriger le viewer PDF',
+                'date' => '2026-07-19',
+                'url' => 'https://github.com/ronan-develop/home-cloud/pull/280',
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Service/GitHubChangelogFetcherTest.php
+++ b/tests/Unit/Service/GitHubChangelogFetcherTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\GitHubChangelogFetcher;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * #290 : le changelog doit refléter automatiquement les features/bugs
+ * déployés, sans maintenance manuelle — alimenté par les PR GitHub mergées,
+ * filtrées par label (feature/bug/securité/performance = changements
+ * utilisateur, le reste — chore/refactor/ci/docs/tests — reste interne).
+ */
+final class GitHubChangelogFetcherTest extends TestCase
+{
+    private function pr(int $number, string $title, ?string $mergedAt, array $labels): array
+    {
+        return [
+            'number' => $number,
+            'title' => $title,
+            'merged_at' => $mergedAt,
+            'html_url' => "https://github.com/ronan-develop/home-cloud/pull/{$number}",
+            'labels' => array_map(static fn (string $name) => ['name' => $name], $labels),
+        ];
+    }
+
+    public function testKeepsOnlyMergedPullRequestsWithRelevantLabels(): void
+    {
+        $prs = [
+            $this->pr(10, '✨ feat(Gallery): ajouter le tri par date', '2026-07-10T10:00:00Z', ['feature']),
+            $this->pr(11, '🛠️ chore(deps): bump symfony/framework-bundle', '2026-07-09T10:00:00Z', ['chore']),
+            $this->pr(12, '🔧 fix(Upload): corriger la barre de progression', '2026-07-08T10:00:00Z', ['bug']),
+            $this->pr(13, '✨ feat(NotYetMerged): en cours', null, ['feature']),
+        ];
+
+        $client = new MockHttpClient([new MockResponse(json_encode($prs))]);
+        $fetcher = new GitHubChangelogFetcher($client, new ArrayAdapter());
+
+        $entries = $fetcher->fetchEntries();
+
+        $this->assertCount(2, $entries);
+        $this->assertSame(10, $entries[0]['number']);
+        $this->assertSame(12, $entries[1]['number']);
+    }
+
+    public function testCleansEmojiAndConventionalCommitPrefixFromTitle(): void
+    {
+        $prs = [
+            $this->pr(20, "✨ feat(FolderZipArchiver): téléchargement d'un dossier entier en zip", '2026-07-20T10:00:00Z', ['feature']),
+        ];
+
+        $client = new MockHttpClient([new MockResponse(json_encode($prs))]);
+        $fetcher = new GitHubChangelogFetcher($client, new ArrayAdapter());
+
+        $entries = $fetcher->fetchEntries();
+
+        $this->assertSame("Téléchargement d'un dossier entier en zip", $entries[0]['title']);
+    }
+
+    public function testSortsEntriesByMergeDateDescending(): void
+    {
+        $prs = [
+            $this->pr(30, 'feat: ancien', '2026-01-01T10:00:00Z', ['feature']),
+            $this->pr(31, 'feat: récent', '2026-07-01T10:00:00Z', ['feature']),
+        ];
+
+        $client = new MockHttpClient([new MockResponse(json_encode($prs))]);
+        $fetcher = new GitHubChangelogFetcher($client, new ArrayAdapter());
+
+        $entries = $fetcher->fetchEntries();
+
+        $this->assertSame(31, $entries[0]['number']);
+        $this->assertSame(30, $entries[1]['number']);
+    }
+
+    public function testReturnsEmptyArrayWhenGitHubIsUnreachable(): void
+    {
+        $client = new MockHttpClient(static function (): void {
+            throw new \Symfony\Component\HttpClient\Exception\TransportException('network down');
+        });
+        $fetcher = new GitHubChangelogFetcher($client, new ArrayAdapter());
+
+        $this->assertSame([], $fetcher->fetchEntries());
+    }
+
+    public function testResultIsCachedAndDoesNotTriggerASecondHttpCall(): void
+    {
+        $prs = [$this->pr(40, 'feat: une feature', '2026-07-20T10:00:00Z', ['feature'])];
+        $callCount = 0;
+        $client = new MockHttpClient(function () use (&$callCount, $prs): MockResponse {
+            ++$callCount;
+
+            return new MockResponse(json_encode($prs));
+        });
+        $cache = new ArrayAdapter();
+        $fetcher = new GitHubChangelogFetcher($client, $cache);
+
+        $fetcher->fetchEntries();
+        $fetcher->fetchEntries();
+
+        $this->assertSame(1, $callCount, 'Un second appel doit être servi depuis le cache, pas relancer une requête HTTP.');
+    }
+}

--- a/tests/Web/ChangelogControllerTest.php
+++ b/tests/Web/ChangelogControllerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * #290 : page changelog listant les grands thèmes de l'historique du projet
+ * (date + titre + lien GitHub), sans détail technique.
+ */
+final class ChangelogControllerTest extends WebTestCase
+{
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function login(string $email = 'test@example.com', string $password = 'pwd12345'): void
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User($email, 'Test');
+        $user->setPassword($hasher->hashPassword($user, $password));
+        $this->em->persist($user);
+        $this->em->flush();
+        $this->em->clear();
+
+        $crawler = $this->client->request('GET', '/login');
+        $form = $crawler->selectButton('Se connecter')->form([
+            'email'    => $email,
+            'password' => $password,
+        ]);
+        $this->client->submit($form);
+        $this->client->followRedirect();
+    }
+
+    public function testChangelogPageIsAccessibleToAuthenticatedUser(): void
+    {
+        $this->login();
+
+        $this->client->request('GET', '/changelog');
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testChangelogPageListsEntriesWithGitHubLinks(): void
+    {
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/changelog');
+
+        $rows = $crawler->filter('table tbody tr');
+        $this->assertGreaterThan(0, $rows->count(), 'Le changelog doit afficher au moins une entrée.');
+
+        $githubLinks = $crawler->filter('table tbody tr a[href^="https://github.com/"]');
+        $this->assertSame($rows->count(), $githubLinks->count(), 'Chaque entrée doit avoir un lien GitHub associé.');
+    }
+
+    public function testChangelogPageRequiresAuthentication(): void
+    {
+        $this->client->request('GET', '/changelog');
+
+        $this->assertResponseRedirects('/login');
+    }
+}


### PR DESCRIPTION
## Résumé

Closes #290

- Page `/changelog` accessible depuis la navigation, listant les grandes évolutions (date, titre, lien PR)
- Alimentation **automatique** : chaque PR mergée labellisée `feature`/`bug`/`securité`/`performance` apparaît sans maintenance manuelle — le reste (chore, refactor, ci, docs, tests) reste filtré
- Titre nettoyé de l'emoji/préfixe conventionnel pour un affichage lisible côté utilisateur final
- Résultat mis en cache 1h (pas de dépendance à la disponibilité de l'API GitHub à chaque chargement)

## Test plan

- [x] TDD RED→GREEN sur chaque commit
- [x] Tests unitaires du fetcher via `MockHttpClient` (parsing, filtrage par label, tri, nettoyage de titre, tolérance panne réseau, cache) — aucun appel réseau réel
- [x] Test fonctionnel du contrôleur via un double de test (`FakeChangelogFetcher`), pas de dépendance à GitHub dans la CI
- [x] Suite complète : 820/821 (seul échec `TailwindBuildTest`, préexistant, sans rapport)