### PR TITLE
✨ feat(ChangelogController): historique complet paginé

### DIFF
--- a/src/Controller/Web/ChangelogController.php
+++ b/src/Controller/Web/ChangelogController.php
@@ -6,26 +6,38 @@ namespace App\Controller\Web;
 
 use App\Interface\ChangelogFetcherInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * #290 : grands thèmes de l'historique du projet (date + titre + lien
- * GitHub), alimenté automatiquement depuis les PR mergées.
+ * GitHub), alimenté automatiquement depuis les PR mergées. Paginé : l'API
+ * GitHub peut renvoyer des dizaines de thèmes sur toute l'histoire du projet.
  */
 #[IsGranted('ROLE_USER')]
 final class ChangelogController extends AbstractController
 {
+    private const PER_PAGE = 20;
+
     public function __construct(
         private readonly ChangelogFetcherInterface $changelogFetcher,
     ) {}
 
     #[Route('/changelog', name: 'app_changelog', methods: ['GET'])]
-    public function index(): Response
+    public function index(Request $request): Response
     {
+        $allEntries = $this->changelogFetcher->fetchEntries();
+        $totalPages = max(1, (int) ceil(count($allEntries) / self::PER_PAGE));
+
+        $page = max(1, min($totalPages, $request->query->getInt('page', 1)));
+        $offset = ($page - 1) * self::PER_PAGE;
+
         return $this->render('web/changelog.html.twig', [
-            'entries' => $this->changelogFetcher->fetchEntries(),
+            'entries' => array_slice($allEntries, $offset, self::PER_PAGE),
+            'currentPage' => $page,
+            'totalPages' => $totalPages,
         ]);
     }
 }

--- a/src/Service/GitHubChangelogFetcher.php
+++ b/src/Service/GitHubChangelogFetcher.php
@@ -22,6 +22,10 @@ final class GitHubChangelogFetcher implements ChangelogFetcherInterface
     private const RELEVANT_LABELS = ['feature', 'bug', 'securité', 'performance'];
     private const CACHE_TTL_SECONDS = 3600;
     private const CACHE_KEY = 'changelog_github_entries';
+    private const PER_PAGE = 100;
+    // Garde-fou : 20 pages = 2000 PR, largement au-delà de l'historique actuel
+    // du dépôt — évite une boucle infinie si l'API se comporte anormalement.
+    private const MAX_PAGES = 20;
 
     public function __construct(
         private readonly HttpClientInterface $httpClient,
@@ -42,22 +46,7 @@ final class GitHubChangelogFetcher implements ChangelogFetcherInterface
      */
     private function fetchFromGitHub(): array
     {
-        try {
-            $response = $this->httpClient->request('GET', sprintf(
-                'https://api.github.com/repos/%s/pulls?state=closed&per_page=100&sort=updated&direction=desc',
-                self::REPO,
-            ), [
-                'headers' => ['Accept' => 'application/vnd.github+json'],
-            ]);
-
-            $pulls = $response->toArray(false);
-        } catch (\Throwable) {
-            return [];
-        }
-
-        if (!is_array($pulls)) {
-            return [];
-        }
+        $pulls = $this->fetchAllPages();
 
         $entries = [];
         foreach ($pulls as $pull) {
@@ -90,6 +79,51 @@ final class GitHubChangelogFetcher implements ChangelogFetcherInterface
 
             return $entry;
         }, $entries);
+    }
+
+    /**
+     * Parcourt toutes les pages de PR jusqu'à épuisement (#290 : l'historique
+     * complet dépasse les 100 PR d'une seule page GitHub) — s'arrête dès
+     * qu'une page renvoie moins de PER_PAGE éléments (dernière page atteinte).
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function fetchAllPages(): array
+    {
+        $all = [];
+
+        for ($page = 1; $page <= self::MAX_PAGES; ++$page) {
+            try {
+                $response = $this->httpClient->request('GET', sprintf(
+                    'https://api.github.com/repos/%s/pulls?state=closed&per_page=%d&page=%d&sort=created&direction=desc',
+                    self::REPO,
+                    self::PER_PAGE,
+                    $page,
+                ), [
+                    'headers' => ['Accept' => 'application/vnd.github+json'],
+                ]);
+
+                $pulls = $response->toArray(false);
+            } catch (\Throwable) {
+                break;
+            }
+
+            if (!is_array($pulls) || count($pulls) === 0) {
+                break;
+            }
+
+            foreach ($pulls as $pull) {
+                if (is_array($pull)) {
+                    $all[] = $pull;
+                }
+            }
+
+            if (count($pulls) < self::PER_PAGE) {
+                break;
+            }
+        }
+
+        return $all;
     }
 
     /**

--- a/templates/web/changelog.html.twig
+++ b/templates/web/changelog.html.twig
@@ -40,6 +40,24 @@
         {% endif %}
     </div>
 
+    {% if totalPages > 1 %}
+        <div data-testid="changelog-pagination" class="flex items-center justify-between">
+            {% if currentPage > 1 %}
+                <a href="{{ path('app_changelog', {page: currentPage - 1}) }}" class="btn btn-soft">← Précédent</a>
+            {% else %}
+                <span></span>
+            {% endif %}
+
+            <span style="color: var(--hc-text-secondary, var(--hc-text))">Page {{ currentPage }} / {{ totalPages }}</span>
+
+            {% if currentPage < totalPages %}
+                <a href="{{ path('app_changelog', {page: currentPage + 1}) }}" class="btn btn-soft">Suivant →</a>
+            {% else %}
+                <span></span>
+            {% endif %}
+        </div>
+    {% endif %}
+
 </div>
 
 {% endblock %}

--- a/tests/Fake/FakeChangelogFetcher.php
+++ b/tests/Fake/FakeChangelogFetcher.php
@@ -12,21 +12,23 @@ use App\Interface\ChangelogFetcherInterface;
  */
 final class FakeChangelogFetcher implements ChangelogFetcherInterface
 {
+    public function __construct(private readonly int $count = 45)
+    {
+    }
+
     public function fetchEntries(): array
     {
-        return [
-            [
-                'number' => 291,
-                'title' => 'Neutraliser les PDF actifs',
-                'date' => '2026-07-20',
-                'url' => 'https://github.com/ronan-develop/home-cloud/pull/291',
-            ],
-            [
-                'number' => 280,
-                'title' => 'Corriger le viewer PDF',
-                'date' => '2026-07-19',
-                'url' => 'https://github.com/ronan-develop/home-cloud/pull/280',
-            ],
-        ];
+        $entries = [];
+        for ($i = 0; $i < $this->count; ++$i) {
+            $number = 300 - $i;
+            $entries[] = [
+                'number' => $number,
+                'title' => "Thème historique numéro {$i}",
+                'date' => '2026-07-' . str_pad((string) max(1, 20 - $i % 20), 2, '0', \STR_PAD_LEFT),
+                'url' => "https://github.com/ronan-develop/home-cloud/pull/{$number}",
+            ];
+        }
+
+        return $entries;
     }
 }

--- a/tests/Unit/Service/GitHubChangelogFetcherTest.php
+++ b/tests/Unit/Service/GitHubChangelogFetcherTest.php
@@ -88,6 +88,30 @@ final class GitHubChangelogFetcherTest extends TestCase
         $this->assertSame([], $fetcher->fetchEntries());
     }
 
+    /**
+     * L'historique complet peut dépasser les 100 PR par page de l'API GitHub
+     * — il faut paginer jusqu'à épuisement pour ne pas perdre les thèmes les
+     * plus anciens (#290, retour utilisateur : "tout depuis le début").
+     */
+    public function testPaginatesThroughAllPagesUntilExhausted(): void
+    {
+        $fullPage = array_map(
+            fn (int $i) => $this->pr($i, "feat: theme {$i}", '2026-01-01T10:00:00Z', ['feature']),
+            range(1, 100),
+        );
+        $lastPage = [$this->pr(101, 'feat: dernier thème', '2026-01-01T10:00:00Z', ['feature'])];
+
+        $client = new MockHttpClient([
+            new MockResponse(json_encode($fullPage)),
+            new MockResponse(json_encode($lastPage)),
+        ]);
+        $fetcher = new GitHubChangelogFetcher($client, new ArrayAdapter());
+
+        $entries = $fetcher->fetchEntries();
+
+        $this->assertCount(101, $entries);
+    }
+
     public function testResultIsCachedAndDoesNotTriggerASecondHttpCall(): void
     {
         $prs = [$this->pr(40, 'feat: une feature', '2026-07-20T10:00:00Z', ['feature'])];

--- a/tests/Web/ChangelogControllerTest.php
+++ b/tests/Web/ChangelogControllerTest.php
@@ -75,4 +75,36 @@ final class ChangelogControllerTest extends WebTestCase
 
         $this->assertResponseRedirects('/login');
     }
+
+    /**
+     * #290 (retour utilisateur) : l'historique complet doit être disponible,
+     * mais paginé plutôt qu'affiché en une seule page géante. FakeChangelogFetcher
+     * fournit 45 entrées de test — la page 1 doit en afficher un sous-ensemble.
+     */
+    public function testChangelogPageIsPaginated(): void
+    {
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/changelog');
+
+        $rows = $crawler->filter('table tbody tr');
+        $this->assertLessThan(45, $rows->count(), 'La page 1 ne doit pas afficher les 45 entrées d\'un coup.');
+
+        $pagination = $crawler->filter('[data-testid="changelog-pagination"]');
+        $this->assertGreaterThan(0, $pagination->count(), 'Des contrôles de pagination doivent être visibles.');
+    }
+
+    public function testChangelogPageSecondPageShowsDifferentEntries(): void
+    {
+        $this->login();
+
+        $crawlerPage1 = $this->client->request('GET', '/changelog');
+        $firstEntryPage1 = trim($crawlerPage1->filter('table tbody tr')->first()->text());
+
+        $crawlerPage2 = $this->client->request('GET', '/changelog?page=2');
+        $firstEntryPage2 = trim($crawlerPage2->filter('table tbody tr')->first()->text());
+
+        $this->assertResponseIsSuccessful();
+        $this->assertNotSame($firstEntryPage1, $firstEntryPage2, 'La page 2 doit afficher des entrées différentes de la page 1.');
+    }
 }


### PR DESCRIPTION
## Résumé

Retour utilisateur sur #290 :

- Le fetcher paginait sur une seule page GitHub (100 PR max) — parcourt maintenant toutes les pages jusqu'à épuisement, pour couvrir tout l'historique depuis le début du projet (garde-fou 20 pages = 2000 PR)
- Le changelog reste groupé par thème (filtre label feature/bug/securité/performance déjà en place, pas de régression vers l'affichage brut des commits)
- Affichage paginé côté page (20 entrées/page, `?page=N`) plutôt qu'une liste géante en un seul chargement

## Test plan

- [x] TDD RED→GREEN sur chaque ajout
- [x] Suite complète : 823/823 (aucun échec, y compris TailwindBuildTest)