### PR TITLE
🎨 style(changelog): afficher les dates au format français (jj/mm/aaaa)

### DIFF
--- a/templates/web/changelog.html.twig
+++ b/templates/web/changelog.html.twig
@@ -26,7 +26,7 @@
                 <tbody>
                     {% for entry in entries %}
                         <tr style="border-bottom: 1px solid var(--hc-border)">
-                            <td class="py-2 pr-4 whitespace-nowrap" style="color: var(--hc-text-secondary, var(--hc-text))">{{ entry.date }}</td>
+                            <td class="py-2 pr-4 whitespace-nowrap" style="color: var(--hc-text-secondary, var(--hc-text))">{{ entry.date|date('d/m/Y') }}</td>
                             <td class="py-2 pr-4" style="color: var(--hc-text)">{{ entry.title }}</td>
                             <td class="py-2">
                                 <a href="{{ entry.url }}" target="_blank" rel="noopener noreferrer" class="hc-nav-item" style="display: inline-flex; padding: 0.25rem 0.5rem">

--- a/tests/Web/ChangelogControllerTest.php
+++ b/tests/Web/ChangelogControllerTest.php
@@ -77,6 +77,22 @@ final class ChangelogControllerTest extends WebTestCase
     }
 
     /**
+     * Les dates viennent de l'API GitHub au format ISO (Y-m-d) — affichées
+     * en français (jj/mm/aaaa) plutôt que le format ISO brut.
+     */
+    public function testChangelogPageDisplaysDatesInFrenchFormat(): void
+    {
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/changelog');
+
+        $firstRowText = $crawler->filter('table tbody tr')->first()->text();
+
+        $this->assertMatchesRegularExpression('/\d{2}\/\d{2}\/\d{4}/', $firstRowText);
+        $this->assertDoesNotMatchRegularExpression('/\d{4}-\d{2}-\d{2}/', $firstRowText);
+    }
+
+    /**
      * #290 (retour utilisateur) : l'historique complet doit être disponible,
      * mais paginé plutôt qu'affiché en une seule page géante. FakeChangelogFetcher
      * fournit 45 entrées de test — la page 1 doit en afficher un sous-ensemble.


### PR DESCRIPTION
## Résumé

L'API GitHub renvoie les dates au format ISO (\`Y-m-d\`) — affichage brut peu lisible pour un utilisateur final. Filtre Twig \`date('d/m/Y')\` appliqué.

## Test plan

- [x] Test RED→GREEN ajouté (vérifie le format jj/mm/aaaa, absence du format ISO brut)
- [x] Suite complète : 824/824