### PR TITLE
♻️ refactor(PrTitleCleaner): extraire le nettoyage de titre du fetcher (SRP)

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -21,6 +21,7 @@ services:
     App\Interface\UserRepositoryInterface:        '@App\Repository\UserRepository'
     App\Interface\ShareRepositoryInterface:       '@App\Repository\ShareRepository'
     App\Interface\ChangelogFetcherInterface:      '@App\Service\GitHubChangelogFetcher'
+    App\Interface\PrTitleCleanerInterface:        '@App\Service\PrTitleCleaner'
     App\Interface\ShareLinkRepositoryInterface:   '@App\Repository\ShareLinkRepository'
     App\Interface\ShareLinkAccessCheckerInterface: '@App\Security\ShareLinkAccessChecker'
     App\Interface\ResourceLocatorInterface:       '@App\Security\ResourceLocator'

--- a/src/Interface/PrTitleCleanerInterface.php
+++ b/src/Interface/PrTitleCleanerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+interface PrTitleCleanerInterface
+{
+    public function clean(string $title): string;
+}

--- a/src/Service/GitHubChangelogFetcher.php
+++ b/src/Service/GitHubChangelogFetcher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service;
 
 use App\Interface\ChangelogFetcherInterface;
+use App\Interface\PrTitleCleanerInterface;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -30,6 +31,7 @@ final class GitHubChangelogFetcher implements ChangelogFetcherInterface
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         private readonly CacheInterface $cache,
+        private readonly PrTitleCleanerInterface $titleCleaner,
     ) {}
 
     public function fetchEntries(): array
@@ -65,7 +67,7 @@ final class GitHubChangelogFetcher implements ChangelogFetcherInterface
 
             $entries[] = [
                 'number' => (int) $pull['number'],
-                'title' => $this->cleanTitle((string) $pull['title']),
+                'title' => $this->titleCleaner->clean((string) $pull['title']),
                 'date' => substr((string) $pull['merged_at'], 0, 10),
                 'url' => (string) $pull['html_url'],
                 'mergedAt' => (string) $pull['merged_at'],
@@ -124,28 +126,5 @@ final class GitHubChangelogFetcher implements ChangelogFetcherInterface
         }
 
         return $all;
-    }
-
-    /**
-     * Retire l'emoji et le préfixe conventionnel ("type(scope): ") d'un titre
-     * de PR pour un affichage lisible côté utilisateur final (ex: "✨
-     * feat(FolderZipArchiver): télécharger un dossier en zip" → "Télécharger
-     * un dossier en zip").
-     */
-    private function cleanTitle(string $title): string
-    {
-        $cleaned = preg_replace(
-            '/^(\p{So}\s*)?[a-zA-Zàâäéèêëïîôöùûüç]+(\([^)]*\))?\s*:\s*/u',
-            '',
-            trim($title),
-        ) ?? $title;
-
-        $cleaned = trim($cleaned);
-
-        if ($cleaned === '') {
-            return trim($title);
-        }
-
-        return mb_strtoupper(mb_substr($cleaned, 0, 1)) . mb_substr($cleaned, 1);
     }
 }

--- a/src/Service/PrTitleCleaner.php
+++ b/src/Service/PrTitleCleaner.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Interface\PrTitleCleanerInterface;
+
+/**
+ * Nettoie un titre de PR GitHub pour un affichage lisible côté utilisateur
+ * final (ex: "✨ feat(FolderZipArchiver): télécharger un dossier en zip" →
+ * "Télécharger un dossier en zip").
+ *
+ * Deux étapes indépendantes, appliquées séparément :
+ * - retrait de l'emoji en tête (avec son éventuel variation selector U+FE0F,
+ *   ex: "🛡️" = U+1F6E1 + U+FE0F — sans lui, l'emoji reste accolé au texte)
+ * - retrait du préfixe conventionnel "type(scope): " s'il est présent
+ *
+ * Les traiter indépendamment évite qu'un titre sans préfixe conventionnel
+ * (ex: "✅ Feature Move folder/File", sans deux-points) ne conserve son emoji
+ * simplement parce que le motif complet ne correspondait pas.
+ */
+final class PrTitleCleaner implements PrTitleCleanerInterface
+{
+    public function clean(string $title): string
+    {
+        $withoutEmoji = $this->stripLeadingEmoji(trim($title));
+        $withoutPrefix = $this->stripConventionalPrefix($withoutEmoji);
+
+        $cleaned = trim($withoutPrefix);
+        if ($cleaned === '') {
+            return trim($title);
+        }
+
+        return mb_strtoupper(mb_substr($cleaned, 0, 1)) . mb_substr($cleaned, 1);
+    }
+
+    private function stripLeadingEmoji(string $title): string
+    {
+        return preg_replace('/^[\p{So}\x{FE0F}\x{200D}]+\s*/u', '', $title) ?? $title;
+    }
+
+    private function stripConventionalPrefix(string $title): string
+    {
+        return preg_replace(
+            '/^[a-zA-Zàâäéèêëïîôöùûüç]+(\([^)]*\))?\s*:\s*/u',
+            '',
+            $title,
+        ) ?? $title;
+    }
+}

--- a/tests/Unit/Service/GitHubChangelogFetcherTest.php
+++ b/tests/Unit/Service/GitHubChangelogFetcherTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Service;
 
 use App\Service\GitHubChangelogFetcher;
+use App\Service\PrTitleCleaner;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -39,7 +40,7 @@ final class GitHubChangelogFetcherTest extends TestCase
         ];
 
         $client = new MockHttpClient([new MockResponse(json_encode($prs))]);
-        $fetcher = new GitHubChangelogFetcher($client, new ArrayAdapter());
+        $fetcher = new GitHubChangelogFetcher($client, new ArrayAdapter(), new PrTitleCleaner());
 
         $entries = $fetcher->fetchEntries();
 
@@ -55,7 +56,7 @@ final class GitHubChangelogFetcherTest extends TestCase
         ];
 
         $client = new MockHttpClient([new MockResponse(json_encode($prs))]);
-        $fetcher = new GitHubChangelogFetcher($client, new ArrayAdapter());
+        $fetcher = new GitHubChangelogFetcher($client, new ArrayAdapter(), new PrTitleCleaner());
 
         $entries = $fetcher->fetchEntries();
 
@@ -70,7 +71,7 @@ final class GitHubChangelogFetcherTest extends TestCase
         ];
 
         $client = new MockHttpClient([new MockResponse(json_encode($prs))]);
-        $fetcher = new GitHubChangelogFetcher($client, new ArrayAdapter());
+        $fetcher = new GitHubChangelogFetcher($client, new ArrayAdapter(), new PrTitleCleaner());
 
         $entries = $fetcher->fetchEntries();
 
@@ -83,7 +84,7 @@ final class GitHubChangelogFetcherTest extends TestCase
         $client = new MockHttpClient(static function (): void {
             throw new \Symfony\Component\HttpClient\Exception\TransportException('network down');
         });
-        $fetcher = new GitHubChangelogFetcher($client, new ArrayAdapter());
+        $fetcher = new GitHubChangelogFetcher($client, new ArrayAdapter(), new PrTitleCleaner());
 
         $this->assertSame([], $fetcher->fetchEntries());
     }
@@ -105,7 +106,7 @@ final class GitHubChangelogFetcherTest extends TestCase
             new MockResponse(json_encode($fullPage)),
             new MockResponse(json_encode($lastPage)),
         ]);
-        $fetcher = new GitHubChangelogFetcher($client, new ArrayAdapter());
+        $fetcher = new GitHubChangelogFetcher($client, new ArrayAdapter(), new PrTitleCleaner());
 
         $entries = $fetcher->fetchEntries();
 
@@ -122,7 +123,7 @@ final class GitHubChangelogFetcherTest extends TestCase
             return new MockResponse(json_encode($prs));
         });
         $cache = new ArrayAdapter();
-        $fetcher = new GitHubChangelogFetcher($client, $cache);
+        $fetcher = new GitHubChangelogFetcher($client, $cache, new PrTitleCleaner());
 
         $fetcher->fetchEntries();
         $fetcher->fetchEntries();

--- a/tests/Unit/Service/PrTitleCleanerTest.php
+++ b/tests/Unit/Service/PrTitleCleanerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\PrTitleCleaner;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Extrait de GitHubChangelogFetcher (SRP) : le nettoyage de titre de PR est une
+ * responsabilité indépendante, pas celle du fetcher. Corrige au passage un bug
+ * où l'emoji ne disparaissait pas sur certains titres réels de l'historique du
+ * dépôt.
+ */
+final class PrTitleCleanerTest extends TestCase
+{
+    public function testStripsEmojiAndConventionalPrefix(): void
+    {
+        $result = (new PrTitleCleaner())->clean(
+            "✨ feat(FolderZipArchiver): téléchargement d'un dossier entier en zip",
+        );
+
+        $this->assertSame("Téléchargement d'un dossier entier en zip", $result);
+    }
+
+    /**
+     * Bug réel : un emoji suivi d'un variation selector (U+FE0F, ex: le
+     * bouclier "🛡️" = U+1F6E1 + U+FE0F) n'était pas reconnu par l'ancienne
+     * regex, qui n'autorisait qu'un seul point de code \p{So} avant l'espace —
+     * le "️" bloquait le match entier et l'emoji restait affiché.
+     */
+    public function testStripsEmojiFollowedByVariationSelector(): void
+    {
+        $result = (new PrTitleCleaner())->clean(
+            "🛡️ fix(security): signature FileVoter::voteOnAttribute conforme à l'API",
+        );
+
+        $this->assertSame("Signature FileVoter::voteOnAttribute conforme à l'API", $result);
+    }
+
+    /**
+     * Bug réel : un titre avec emoji mais sans préfixe conventionnel
+     * "type(scope): " (pas de deux-points) laissait l'emoji intact, car
+     * l'ancienne regex ne matchait l'emoji QUE si tout le motif complet
+     * (type + scope + deux-points) suivait aussi.
+     */
+    public function testStripsEmojiEvenWithoutConventionalPrefix(): void
+    {
+        $result = (new PrTitleCleaner())->clean('✅ Feature Move folder/File');
+
+        $this->assertSame('Feature Move folder/File', $result);
+    }
+
+    /**
+     * Bug réel : un titre en prose avec deux-points plus loin dans la phrase
+     * (pas un préfixe "type:") ne devait pas être tronqué au premier mot, mais
+     * l'emoji en tête devait quand même disparaître.
+     */
+    public function testStripsEmojiFromProseTitleWithUnrelatedColon(): void
+    {
+        $result = (new PrTitleCleaner())->clean('✨ Fonctionnalité principale : Gestion des photos');
+
+        $this->assertSame('Fonctionnalité principale : Gestion des photos', $result);
+    }
+
+    public function testLeavesTitleWithoutEmojiOrPrefixUnchanged(): void
+    {
+        $result = (new PrTitleCleaner())->clean(
+            'Servir la preview JPEG des RAW en plein écran (lightbox, diaporama, partages)',
+        );
+
+        $this->assertSame(
+            'Servir la preview JPEG des RAW en plein écran (lightbox, diaporama, partages)',
+            $result,
+        );
+    }
+
+    public function testStripsConventionalPrefixWithoutEmoji(): void
+    {
+        $result = (new PrTitleCleaner())->clean('fix(dashboard): palette, layout et redirection post-login');
+
+        $this->assertSame('Palette, layout et redirection post-login', $result);
+    }
+}


### PR DESCRIPTION
## Résumé

Retour utilisateur : le nettoyage d'emoji/préfixe ne fonctionnait pas sur tous les titres, et cette responsabilité n'avait pas sa place dans `GitHubChangelogFetcher` (SRP).

- Extraction dans `PrTitleCleaner` + `PrTitleCleanerInterface`, injecté par DIP (comme toutes les dépendances du projet)
- `GitHubChangelogFetcher` ne fait plus que fetch/filtre/tri, plus de nettoyage de texte
- **Bug corrigé** : l'ancienne regex ne retirait l'emoji QUE si le motif complet `type(scope): ` suivait aussi. Trois cas réels de l'historique du dépôt qui échouaient :
  - emoji + variation selector (`🛡️` = U+1F6E1 + U+FE0F) → emoji restait affiché
  - titre avec emoji mais sans deux-points (`✅ Feature Move folder/File`) → emoji restait affiché
  - titre en prose avec un deux-points plus loin dans la phrase (`✨ Fonctionnalité principale : Gestion des photos`) → emoji restait affiché

  Emoji et préfixe conventionnel sont désormais retirés indépendamment l'un de l'autre.

## Test plan

- [x] TDD RED→GREEN : 6 nouveaux tests sur `PrTitleCleaner` couvrant les 3 cas de bug réels + non-régression
- [x] Suite complète : 830/830