### PR TITLE
🔧 fix(PrTitleCleaner): retirer le "#" markdown en tête des titres de PR

### DIFF
--- a/src/Service/PrTitleCleaner.php
+++ b/src/Service/PrTitleCleaner.php
@@ -24,7 +24,8 @@ final class PrTitleCleaner implements PrTitleCleanerInterface
 {
     public function clean(string $title): string
     {
-        $withoutEmoji = $this->stripLeadingEmoji(trim($title));
+        $withoutHeadingMarker = $this->stripLeadingMarkdownHeadingMarker(trim($title));
+        $withoutEmoji = $this->stripLeadingEmoji($withoutHeadingMarker);
         $withoutPrefix = $this->stripConventionalPrefix($withoutEmoji);
 
         $cleaned = trim($withoutPrefix);
@@ -33,6 +34,16 @@ final class PrTitleCleaner implements PrTitleCleanerInterface
         }
 
         return mb_strtoupper(mb_substr($cleaned, 0, 1)) . mb_substr($cleaned, 1);
+    }
+
+    /**
+     * Un "#" markdown collé par erreur en tête d'un titre de PR (ex:
+     * "# 🏷️ PR : ...") bloque sinon la détection de l'emoji qui suit — "#"
+     * n'est ni un symbole \p{So} ni un espace.
+     */
+    private function stripLeadingMarkdownHeadingMarker(string $title): string
+    {
+        return preg_replace('/^#+\s*/u', '', $title) ?? $title;
     }
 
     private function stripLeadingEmoji(string $title): string

--- a/tests/Unit/Service/PrTitleCleanerTest.php
+++ b/tests/Unit/Service/PrTitleCleanerTest.php
@@ -82,4 +82,29 @@ final class PrTitleCleanerTest extends TestCase
 
         $this->assertSame('Palette, layout et redirection post-login', $result);
     }
+
+    /**
+     * Bug réel (retour utilisateur sur le rendu du changelog) : un "#" de titre
+     * markdown collé par erreur en tête du titre de PR (ex: "# 🏷️ PR : ...")
+     * bloquait la détection de l'emoji qui suivait, puisque le "#" n'est ni un
+     * symbole \p{So} ni un caractère blanc.
+     */
+    /**
+     * "PR :" est ici traité comme un préfixe conventionnel générique
+     * ("type:"), au même titre que "fix:"/"feat:" — résultat plus propre
+     * pour l'utilisateur final qu'un "PR :" redondant conservé tel quel.
+     */
+    public function testStripsLeadingMarkdownHeadingMarkerBeforeEmoji(): void
+    {
+        $result = (new PrTitleCleaner())->clean('# 🏷️ PR : Move Folder/File UI — Sidebar + Modal');
+
+        $this->assertSame('Move Folder/File UI — Sidebar + Modal', $result);
+    }
+
+    public function testStripsLeadingMarkdownHeadingMarkerBeforeEmojiAndProseColon(): void
+    {
+        $result = (new PrTitleCleaner())->clean('# ✨ Fonctionnalité principale : Gestion des photos');
+
+        $this->assertSame('Fonctionnalité principale : Gestion des photos', $result);
+    }
 }


### PR DESCRIPTION
## Résumé

Retour utilisateur sur le rendu du changelog — deux titres réels de l'historique affichaient encore un artefact :

- \`# 🏷️ PR : Move Folder/File UI — Sidebar + Modal\` → emoji non retiré
- \`# ✨ Fonctionnalité principale : Gestion des photos\` → emoji non retiré

Cause : un "#" markdown collé en tête du titre bloquait la détection de l'emoji qui suit ("#" n'est ni un symbole \`\p{So}\` ni un espace pour la regex existante).

Un troisième artefact repéré (\`Titre de la PR ✨ feat(FolderRename): ...\`, PR #109) est un texte de template laissé tel quel — spécifique à cette PR, pas un motif générique fiable à coder ; recommandé de renommer directement le titre sur GitHub plutôt que d'ajouter une heuristique fragile.

## Test plan

- [x] TDD RED→GREEN : 2 nouveaux tests sur les titres réels qui échouaient
- [x] Suite complète : 832/832