### PR TITLE
📝 docs: rattraper avancement.md, corriger cicd.md (faux, déploiement manuel)

### DIFF
--- a/.claude/cicd.md
+++ b/.claude/cicd.md
@@ -7,15 +7,16 @@
 | PHPUnit + MariaDB       | push / PR sur `main`  | PHP 8.4, MariaDB 10.11       |
 | Jest (JS)               | push / PR sur `main`  | Node.js 22 (LTS)             |
 | `composer audit`        | dans le job PHP       | avant les tests              |
-| Déploiement webhook     | CI ✅ sur `main`       | déclenché automatiquement    |
-| Déploiement manuel      | `workflow_dispatch`   | via GitHub Actions           |
 
 ## Déploiement
 
-Webhook PHP sur `ronan.lenouvel.me` — déclenché automatiquement après CI verte sur `main`.
+**Manuel, pas automatique** — `bash bin/deploy-all.sh` après merge sur `main` (CI verte requise avant de lancer). o2switch bloque les IPs des runners GitHub Actions (whitelist SSH obligatoire), donc aucun déclenchement automatique n'est possible depuis GitHub aujourd'hui.
 
-Détail du workflow : `.github/DEPLOY_WORKFLOW.md`  
-Secrets nécessaires : `.github/DEPLOY_SECRETS.md`
+Un webhook PHP (`public/deploy.php`) existe dans le repo mais est **cassé et inutilisé** (signature HMAC invalide depuis plusieurs jours au 2026-07-20) — ne pas s'y fier, ni supposer qu'un push sur `main` déploie quoi que ce soit automatiquement.
+
+Piste d'automatisation via GitHub Actions + l'API `SshWhitelist` d'o2switch (whitelist dynamique de l'IP du runner) : voir #288 (en pause, décision actée de rester en manuel pour l'instant).
+
+Détail complet : `.claude/deploiement.md`.
 
 ## Suivi d'avancement
 

--- a/.claude/deploiement.md
+++ b/.claude/deploiement.md
@@ -8,7 +8,20 @@ Cible : hébergement mutualisé **o2switch**, un sous-domaine par instance (`<pr
 
 SSH depuis la machine locale via les scripts `bin/`.
 
-> Le déploiement automatique GitHub Actions (webhook) ne fonctionne **pas** sur o2switch — les IPs Microsoft Azure (GitHub Actions) sont bloquées par le firewall. Les scripts SSH sont la seule méthode fiable.
+> Le déploiement automatique GitHub Actions (webhook) ne fonctionne **pas** sur o2switch — les IPs des runners GitHub Actions sont bloquées par le firewall SSH. Les scripts SSH sont la seule méthode fiable aujourd'hui (#288, en pause). Le webhook `public/deploy.php` existe dans le repo mais est cassé et inutilisé.
+
+### Piège IP dynamique / VPN d'entreprise
+
+Sans IP fixe (FAI grand public ou VPN d'entreprise désactivé), l'IP change entre deux sessions et le SSH se bloque silencieusement (timeout, pas de refus explicite) si elle n'est plus whitelistée dans cPanel → Sécurité → Accès SSH → Autorisation SSH. Un VPN d'entreprise peut à l'inverse bloquer l'accès à cPanel lui-même — pas de solution simple aux deux contraintes à la fois.
+
+o2switch expose une micro-API `SshWhitelist` (port cPanel 2083, indépendante du port SSH 22) pour whitelister une IP dynamiquement sans accès SSH préalable — utile en dépannage :
+
+```bash
+curl -s -u "<user_cpanel>:<mdp_cpanel>" \
+  "https://<serveur>.o2switch.net:2083/execute/SshWhitelist/add?address=$(curl -4 -s ifconfig.me)&port=22"
+```
+
+Authentification recommandée par o2switch : token API cPanel ("Manage API Tokens") — indisponible sur ce compte au 2026-07-20 ("bloqué à des fins de sécurité" selon le support), d'où le repli sur les identifiants cPanel classiques ci-dessus. Max 5 exceptions simultanées sur le compte.
 
 ---
 

--- a/.github/DEPLOY_SECRETS.md
+++ b/.github/DEPLOY_SECRETS.md
@@ -1,5 +1,7 @@
 # Configuration des secrets GitHub pour le déploiement
 
+> **État (2026-07-20) : secrets présents mais inutilisés.** `gh secret list` confirme que `DEPLOY_SSH_*`, `DEPLOY_PRENOM`, `DEPLOY_DB_PASSWORD` (créés 2026-03-08) et `DEPLOY_WEBHOOK_SECRET`/`DEPLOY_WEBHOOK_URL` (créés 2026-04-11) existent bien côté GitHub — mais aucun des deux mécanismes qu'ils devaient alimenter n'est actif : `deploy.yml` n'a jamais été committé (seul `ci.yml` existe), et le webhook `public/deploy.php` reçoit une signature invalide depuis plusieurs jours (401 sur toutes les livraisons récentes). Le déploiement réel passe par `bin/deploy-all.sh` en SSH manuel — voir `.claude/deploiement.md`.
+
 ## Secrets requis (Settings → Secrets and variables → Actions)
 
 ### SSH

--- a/.github/DEPLOY_WORKFLOW.md
+++ b/.github/DEPLOY_WORKFLOW.md
@@ -1,5 +1,7 @@
 # Déploiement sécurisé — bin/deploy.sh
 
+> **État (2026-07-20) : non implémenté.** Le workflow GitHub Actions décrit ci-dessous (`.github/workflows/deploy.yml`) n'a jamais été committé — seul `ci.yml` existe. Le déploiement réel se fait manuellement via `bin/deploy-all.sh` (voir `.claude/deploiement.md`). Ce document reste une référence technique valide si l'automatisation est reprise un jour (cf. #288, en pause).
+
 Ce document décrit le workflow du script `bin/deploy.sh` et fournit un exemple sécurisé de workflow GitHub Actions (manuel) pour déclencher le déploiement sans risquer d'écraser une base existante.
 
 ---

--- a/.github/avancement.md
+++ b/.github/avancement.md
@@ -2,7 +2,53 @@
 
 > Dernière mise à jour : 2026-07-20
 
-> **Status git :** `main` — dernière PR mergée #271 (`feat/#270-async-share-email`)
+> **Status git :** `main` — dernière PR mergée #298 (`fix/changelog-markdown-heading-artifact`)
+
+---
+
+## ✅ Déploiement, gestion des instances (2026-07-20)
+
+- **7ᵉ instance `baptiste.lenouvel.me`** ajoutée : base MySQL créée via `uapi Mysql create_database`/`set_privileges_on_database` (utilisateur partagé `ron2cuba_ronan`, comme les 6 autres instances — divergence constatée entre la doc `deploiement.md` qui documentait un utilisateur par instance et la pratique réelle), premier déploiement manuel, premier compte créé, puis ajoutée à `.deploy-targets` pour les mises à jour futures.
+- **Webhook de déploiement cassé découvert** : `public/deploy.php` (déclenché par un webhook GitHub natif, pas une Action) recevait un 401 "Invalid signature" sur toutes les livraisons depuis plusieurs jours — secret désynchronisé entre GitHub et le serveur. N'était de toute façon plus le mécanisme réel de déploiement (voir ci-dessous), corrigé dans la doc (`cicd.md`, `DEPLOY_WORKFLOW.md`, `DEPLOY_SECRETS.md`).
+- **Ticket #288** (industrialiser le déploiement via GitHub Actions) : bloqué par l'absence d'IP fixe pour un runner self-hosted. Piste alternative trouvée : l'API `SshWhitelist` d'o2switch (port cPanel 2083) permet de whitelister dynamiquement l'IP d'un runner GitHub-hosted avant chaque déploiement. Authentification recommandée (token API cPanel) indisponible sur ce compte ("bloqué à des fins de sécurité" — réponse du support). **Décision actée : rester sur le déploiement manuel `bin/deploy-all.sh` pour l'instant**, ticket laissé ouvert pour référence.
+- **Piège IP dynamique / VPN d'entreprise** identifié en pratique : sans IP fixe, le SSH se bloque silencieusement (timeout) dès que l'IP whitelistée change — rencontré 3 fois dans la même session. L'API `SshWhitelist` permet de re-whitelister sans accès SSH préalable (identifiants cPanel classiques en repli, le token étant indisponible).
+- `bin/deploy-all.sh` avait perdu son bit exécutable (PR #289).
+
+## ✅ Page changelog auto-alimentée (2026-07-20, #290)
+
+Page `/changelog`, accessible depuis la navigation, listant les grandes évolutions du projet.
+
+- `GitHubChangelogFetcher` (PR #292) : interroge l'API GitHub (PR mergées), filtre par label `feature`/`bug`/`securité`/`performance` — le reste (chore, refactor, ci, docs, tests) reste filtré comme bruit interne. Résultat mis en cache 1h (`cache.app`), aucune table dédiée en base — GitHub reste la seule source de vérité.
+- **Historique complet paginé** (PR #294) : le fetcher parcourt désormais toutes les pages GitHub jusqu'à épuisement (garde-fou 20 pages) plutôt que de se limiter aux 100 PR les plus récentes ; affichage paginé côté page (20 entrées/page).
+- **Dates au format français** (PR #296) : `jj/mm/aaaa` plutôt que l'ISO brut renvoyé par l'API.
+- **`PrTitleCleaner` extrait du fetcher** (PR #297, SRP) : le nettoyage de titre (retrait emoji + préfixe conventionnel `type(scope):`) est un service indépendant (`PrTitleCleanerInterface`), injecté par DIP. Corrige au passage plusieurs bugs réels : emoji suivi d'un variation selector (`🛡️` = U+1F6E1 + U+FE0F) non reconnu, titre avec emoji mais sans deux-points, titre en prose avec un deux-points plus loin dans la phrase.
+- **`#` markdown en tête de titre** (PR #298) : un `#` collé par erreur devant l'emoji sur d'anciens titres de PR (ex: `# 🏷️ PR : ...`) bloquait aussi la détection de l'emoji — corrigé.
+- **Ticket #293** ouvert : notification visuelle (icône + badge) pour signaler de nouvelles entrées changelog — décision actée que le marqueur "dernière visite" ira sur `User` (DB), pas en `localStorage`.
+
+## ✅ Sécurité — viewer PDF et fichiers actifs (2026-07-20, #280/#286)
+
+- **#280 / PR #287** : `X-Frame-Options: DENY` et `frame-ancestors 'none'` bloquaient l'iframe same-origin du viewer PDF (#241) — dérogation strictement scopée à `/files/{id}/view` (`SAMEORIGIN`/`frame-ancestors 'self'`), les autres routes gardent la protection anti-clickjacking complète.
+- **#286 / PR #291** : un PDF peut embarquer du JavaScript exécutable (`/OpenAction`, `/AA`, `/JS`, `/Launch`) — détecté à l'upload (recherche de motif délimité, évite le faux positif `/JSON` confondu avec `/JS`) et neutralisé comme les autres types dangereux (même mécanisme que HTML/SVG). Limite documentée : les objets compressés en flux `/ObjStm` échappent à cette détection (heuristique, pas un vrai parseur PDF).
+- **Bug latéral découvert et corrigé** (même PR #291) : un PDF valide mais dont l'en-tête `%PDF-` est décalé au-delà de l'octet 0 (ex: fichier téléchargé depuis un site tiers ayant laissé fuiter du texte de debug en préfixe) était servi en `application/octet-stream` par `finfo`, forçant un téléchargement au lieu du rendu inline malgré la tolérance de la norme PDF (ISO 32000-1 §7.5.2, en-tête toléré dans les 1024 premiers octets). `PdfSignatureDetector` reproduit cette tolérance.
+- **Tickets de suivi ouverts** : #285 (dérogation CSP basée sur le path plutôt que `_route`, fragile), #276 (redirection changement de mot de passe à la première connexion — toujours pas implémenté, pertinent pour tout compte créé avec un mot de passe temporaire).
+
+## ✅ Centralisation des factories (2026-07-20, PR #295)
+
+`ShareLinkFactory` (`App\Security` → `App\Factory`) et `MediaFullResponseFactory` (`App\Service` → `App\Factory`) déplacées vers `src/Factory/`, cohérent avec `FolderTreeFactory` déjà présente à cet endroit. Déplacement pur, aucun changement de comportement.
+
+## ✅ Téléchargement de dossier en ZIP (2026-07-20, PR #274)
+
+`FolderZipArchiver` : télécharger un dossier entier (avec sa structure) en une seule archive.
+
+## ✅ Glisser-déposer un dossier local (2026-07-20, PR #279)
+
+Upload d'un dossier complet depuis le disque, avec sa structure, par glisser-déposer dans l'explorateur.
+
+## ✅ Fix barre de progression upload multiple (2026-07-20, PR #275)
+
+## ⚠️ Ticket ouvert — révocation d'un partage par compte (2026-07-20, #299)
+
+Aucune route de révocation n'existe pour un `Share` (partage par compte à un invité) — seul `ShareLink` (lien public) peut être révoqué. Trou fonctionnel de bout en bout (backend + frontend), pas juste un oubli d'UI.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ php bin/console app:create-user 'vous@example.com' '<mot-de-passe>' 'Prénom'
 
 ```bash
 composer dev-check            # build des assets + suite PHP complète
-./vendor/bin/phpunit          # 738 tests
-npm test                      # 17 suites Jest
+./vendor/bin/phpunit          # 832 tests
+npm test                      # 25 suites Jest
 ```
 
 La méthodologie TDD est suivie sans exception : le test échoue d'abord, sinon il ne prouve rien. Voir [.claude/tdd.md](.claude/tdd.md).

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,9 +8,11 @@ Ce que fait HomeCloud, du point de vue de celui qui l'utilise.
 
 Un explorateur classique — arborescence de dossiers, upload par glisser-déposer, renommage, déplacement, suppression.
 
-- **Upload** : plusieurs fichiers à la fois, avec barre de progression et file d'attente. Le dépôt d'un fichier sur un dossier l'y range directement.
-- **Types acceptés** : tout, sauf les exécutables (liste noire, pas liste blanche — un cloud personnel n'a pas à deviner ce que vous stockez).
+- **Upload** : plusieurs fichiers à la fois, avec barre de progression et file d'attente. Le dépôt d'un fichier sur un dossier l'y range directement — y compris un dossier entier glissé depuis le disque, avec sa structure.
+- **Types acceptés** : tout, sauf les exécutables (liste noire, pas liste blanche — un cloud personnel n'a pas à deviner ce que vous stockez). Les fichiers dangereux (scripts, HTML/SVG actifs, PDF avec JavaScript embarqué) sont neutralisés plutôt que rejetés : conservés, mais non exécutables/prévisualisables.
 - **Organisation** : dossiers imbriqués, un nom de fichier étant unique au sein d'un même dossier.
+- **Visualisation** : un PDF s'ouvre directement dans le navigateur, sans téléchargement préalable.
+- **Téléchargement** : un dossier entier se télécharge en une seule archive ZIP.
 
 ## Galerie
 
@@ -19,7 +21,7 @@ Les photos et vidéos, sorties de leur arborescence et présentées par date.
 - **Vignettes** générées automatiquement à l'upload, en tâche de fond.
 - **Lightbox** plein écran, navigation au clavier, diaporama.
 - **Filtres** par type (photo / vidéo) et tri par date.
-- **Métadonnées EXIF** extraites automatiquement : date de prise de vue, modèle d'appareil, coordonnées GPS.
+- **Métadonnées EXIF** extraites automatiquement : date de prise de vue, modèle d'appareil, coordonnées GPS, et pour un photographe — ouverture, vitesse, ISO, focale, objectif (JPEG et RAW, sauf CR3).
 
 ### Fichiers RAW
 
@@ -29,7 +31,7 @@ Un navigateur ne sait pas afficher un RAW, et un fichier de 50 Mo n'a rien à fa
 
 Une photo prise en portrait est automatiquement remise à l'endroit — l'appareil se contente d'enregistrer la rotation, il ne l'applique pas.
 
-> Limite connue : les EXIF d'un RAW ne sont pas encore lus (date, appareil et GPS restent vides pour ces photos). La vignette et l'affichage, eux, fonctionnent.
+> Limite connue : les CR3 (Canon, encodage ISO-BMFF) n'exposent pas encore ces métadonnées — champs vides, sans erreur. Vignette et affichage fonctionnent pour tous les formats RAW supportés.
 
 ## Albums
 
@@ -75,6 +77,7 @@ Recherche par nom sur les fichiers et les dossiers, depuis la barre supérieure.
 - **Mot de passe oublié** : réinitialisation par email.
 - **Thème clair / sombre**, suivant par défaut la préférence du système.
 - **Responsive** : barre latérale sur desktop, tab-bar sur mobile.
+- **Changelog** : page dédiée listant les grandes évolutions du projet, alimentée automatiquement depuis les PR mergées sur GitHub.
 
 ## API
 

--- a/docs/technique.md
+++ b/docs/technique.md
@@ -17,15 +17,16 @@ Deux portes d'entrée, une seule logique métier. L'interface web et l'API ne pa
 
 ## Structure de `src/`
 
-| Dossier       | Rôle                                                             |
-|---------------|------------------------------------------------------------------|
-| `Controller/` | HTTP uniquement — lit la requête, délègue, rend la réponse       |
-| `Service/`    | Logique métier, testable sans HTTP ni base                       |
-| `Repository/` | Accès aux données                                                |
-| `State/`      | Processors et providers API Platform                             |
-| `Security/`   | Authentification, ownership, contrôle d'accès aux partages       |
-| `Interface/`  | Contrats — les services dépendent d'abstractions, pas de classes |
-| `Entity/`     | Entités Doctrine                                                 |
+| Dossier       | Rôle                                                                       |
+|---------------|-----------------------------------------------------------------------------|
+| `Controller/` | HTTP uniquement — lit la requête, délègue, rend la réponse                 |
+| `Service/`    | Logique métier, testable sans HTTP ni base                                 |
+| `Factory/`    | Construction d'objets complexes/conditionnels (`ShareLinkFactory`, `MediaFullResponseFactory`) |
+| `Repository/` | Accès aux données                                                          |
+| `State/`      | Processors et providers API Platform                                       |
+| `Security/`   | Authentification, ownership, contrôle d'accès aux partages                 |
+| `Interface/`  | Contrats — les services dépendent d'abstractions, pas de classes           |
+| `Entity/`     | Entités Doctrine                                                           |
 | `Message/`    | Messages Symfony Messenger (traitement asynchrone)               |
 
 Un contrôleur qui contient de la logique métier est un bug de conception : il devient intestable sans requête HTTP, et la logique n'est plus réutilisable entre le web et l'API.
@@ -135,6 +136,6 @@ Les migrations sont générées par `make:migration` (diff automatique), jamais 
 
 ## Déploiement
 
-Push sur `main` avec CI verte → déploiement automatique. Hébergement mutualisé o2switch : pas d'accès root, donc pas d'`apt install` — toute dépendance système est exclue par principe.
+Manuel (`bin/deploy-all.sh` en SSH, après CI verte sur `main`) — o2switch bloque les IPs des runners GitHub Actions, aucune automatisation possible aujourd'hui. Hébergement mutualisé : pas d'accès root, donc pas d'`apt install` — toute dépendance système est exclue par principe.
 
 Détail dans [.claude/deploiement.md](../.claude/deploiement.md) et [.claude/cicd.md](../.claude/cicd.md).


### PR DESCRIPTION
## Résumé

Audit demandé de la doc du repo — plusieurs fichiers désynchronisés, un factuellement faux :

- **`.claude/cicd.md`** affirmait un déploiement automatique via webhook après CI verte — faux, le webhook est cassé et inutilisé, le déploiement réel est manuel (`bin/deploy-all.sh`)
- **`.github/avancement.md`** n'avait pas bougé depuis #271 — rattrapé jusqu'à #299
- **`.claude/deploiement.md`** : piège IP dynamique/VPN entreprise + API `SshWhitelist` documentés
- **`docs/technique.md`** : `Factory/` ajouté à la structure `src/`, section Déploiement corrigée
- **`docs/features.md`** : limite EXIF RAW obsolète corrigée, viewer PDF/zip dossier/changelog ajoutés
- **`README.md`** : nombre de tests obsolète corrigé (738 → 832)
- **`DEPLOY_WORKFLOW.md`/`DEPLOY_SECRETS.md`** : annotés "non implémenté" plutôt que réécrits (référence valide si #288 reprend)

## Test plan

- [x] Aucun changement de code — doc uniquement
- [x] Suite complète toujours verte : 832/832