### PR TITLE
🔧 fix(ShareWebController): permettre la révocation d'un partage par compte

### DIFF
--- a/src/Controller/Web/ShareWebController.php
+++ b/src/Controller/Web/ShareWebController.php
@@ -219,6 +219,27 @@ final class ShareWebController extends AbstractController
         return $this->redirect('/partages');
     }
 
+    #[Route('/share-revoke', name: 'app_share_revoke', methods: ['POST'])]
+    public function revoke(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('share-revoke', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Jeton CSRF invalide.');
+        }
+
+        $shareId = (string) $request->request->get('shareId', '');
+        $share = $this->shareRepository->find(Uuid::fromString($shareId))
+            ?? throw $this->createNotFoundException('Partage introuvable.');
+
+        $this->ownershipChecker->denyUnlessOwner($share);
+
+        $this->em->remove($share);
+        $this->em->flush();
+
+        $this->addFlash('success', 'Partage révoqué.');
+
+        return $this->redirect('/partages');
+    }
+
     private function resolveResourceNameForLink(\App\Entity\ShareLink $link): string
     {
         try {

--- a/src/Entity/Share.php
+++ b/src/Entity/Share.php
@@ -19,7 +19,9 @@ use Symfony\Component\Uid\Uuid;
  *   sans FK Doctrine (évite la complexité d'une union de tables).
  * - permission (read|write) : read = voir/télécharger, write = lire + uploader.
  * - expiresAt nullable : accès permanent si null, révocation automatique si défini.
- * - Révocation manuelle via DELETE /api/v1/shares/{id}.
+ * - Révocation manuelle via POST /share-revoke (ShareWebController::revoke) :
+ *   suppression directe de l'entité (pas de soft-delete comme ShareLink,
+ *   la vérification d'accès ne se fait que sur expiresAt).
  */
 #[ORM\Entity(repositoryClass: ShareRepository::class)]
 #[ORM\Table(name: 'shares')]

--- a/templates/web/shares.html.twig
+++ b/templates/web/shares.html.twig
@@ -47,6 +47,13 @@
                 {% endif %}
               </div>
             </div>
+            <form method="post" action="{{ path('app_share_revoke') }}">
+              <input type="hidden" name="_token" value="{{ csrf_token('share-revoke') }}">
+              <input type="hidden" name="shareId" value="{{ row.share.id }}">
+              <button type="submit" class="hc-item-action hc-item-action--danger" style="background:none; border:none; cursor:pointer; font-size:0.8125rem; font-weight:600;">
+                Révoquer
+              </button>
+            </form>
           </div>
         {% endfor %}
       </div>

--- a/tests/Web/ShareWebTest.php
+++ b/tests/Web/ShareWebTest.php
@@ -463,4 +463,118 @@ final class ShareWebTest extends WebTestCase
         $shares = $this->em->getRepository(Share::class)->findBy(['resourceId' => $album->getId()]);
         $this->assertCount(0, $shares);
     }
+
+    // ─── Révocation d'un partage par compte (#299) ──────────────────────────
+
+    private function revokeShareToken(): string
+    {
+        $crawler = $this->client->request('GET', '/partages');
+
+        return $crawler->filter('form[action*="/share-revoke"] input[name="_token"]')->first()->attr('value');
+    }
+
+    public function testOwnerCanRevokeTheirShare(): void
+    {
+        $owner = $this->createUser();
+        $guest = $this->createUser('guest-revoke@example.com');
+        $folder = new Folder('Dossier à révoquer', $owner);
+        $this->em->persist($folder);
+        $this->em->flush();
+
+        $share = new Share($owner, $guest, Share::RESOURCE_FOLDER, $folder->getId(), Share::PERMISSION_READ);
+        $this->em->persist($share);
+        $this->em->flush();
+        $shareId = $share->getId();
+
+        $this->login();
+        $token = $this->revokeShareToken();
+
+        $this->client->request('POST', '/share-revoke', [
+            '_token'  => $token,
+            'shareId' => $shareId->toRfc4122(),
+        ]);
+
+        $this->assertResponseRedirects('/partages');
+
+        $this->assertNull($this->em->getRepository(Share::class)->find($shareId));
+    }
+
+    public function testNonOwnerCannotRevokeShare(): void
+    {
+        $owner = $this->createUser();
+        $guest = $this->createUser('guest-revoke2@example.com');
+        $folder = new Folder('Dossier protégé', $owner);
+        $this->em->persist($folder);
+        $this->em->flush();
+
+        $share = new Share($owner, $guest, Share::RESOURCE_FOLDER, $folder->getId(), Share::PERMISSION_READ);
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $attacker = $this->createUser('attacker-revoke@example.com');
+        $attackerGuest = $this->createUser('attacker-guest@example.com');
+        $attackerFolder = new Folder('Dossier attaquant', $attacker);
+        $this->em->persist($attackerFolder);
+        $this->em->flush();
+        // Le token CSRF est lié à la session : l'attaquant a besoin de son
+        // propre partage pour obtenir un token valide dans SA session.
+        $attackerShare = new Share($attacker, $attackerGuest, Share::RESOURCE_FOLDER, $attackerFolder->getId(), Share::PERMISSION_READ);
+        $this->em->persist($attackerShare);
+        $this->em->flush();
+
+        $this->login('attacker-revoke@example.com');
+        $token = $this->revokeShareToken();
+
+        $this->client->request('POST', '/share-revoke', [
+            '_token'  => $token,
+            'shareId' => $share->getId()->toRfc4122(),
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+        $this->assertNotNull($this->em->getRepository(Share::class)->find($share->getId()));
+    }
+
+    public function testGuestLosesAccessAfterShareIsRevoked(): void
+    {
+        $owner = $this->createUser();
+        $guest = $this->createUser('guest-access-revoke@example.com');
+        $folder = new Folder('Dossier accès', $owner);
+        $this->em->persist($folder);
+        $this->em->flush();
+
+        $share = new Share($owner, $guest, Share::RESOURCE_FOLDER, $folder->getId(), Share::PERMISSION_READ);
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $this->login();
+        $token = $this->revokeShareToken();
+
+        $this->client->request('POST', '/share-revoke', [
+            '_token'  => $token,
+            'shareId' => $share->getId()->toRfc4122(),
+        ]);
+
+        $shareRepository = $this->em->getRepository(Share::class);
+        $this->assertNull($shareRepository->findActiveShare($guest, Share::RESOURCE_FOLDER, $folder->getId(), Share::PERMISSION_READ));
+    }
+
+    public function testSharesPageShowsRevokeButtonForOutgoingShares(): void
+    {
+        $owner = $this->createUser();
+        $guest = $this->createUser('guest-btn@example.com');
+        $folder = new Folder('Dossier bouton', $owner);
+        $this->em->persist($folder);
+        $this->em->flush();
+
+        $share = new Share($owner, $guest, Share::RESOURCE_FOLDER, $folder->getId(), Share::PERMISSION_READ);
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/partages');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-testid="share-row-outgoing"] form[action*="/share-revoke"] button[type="submit"]');
+    }
 }


### PR DESCRIPTION
## Summary
- Corrige #299 : aucune action de révocation n'existait pour les partages par compte (`Share`), contrairement aux liens publics (`ShareLink`).
- Ajoute la route `POST /share-revoke` dans `ShareWebController` (CSRF + vérification ownership, suppression directe de l'entité `Share`).
- Ajoute le bouton "Révoquer" dans la section "Mes partages" de `shares.html.twig`, sur le même modèle que `app_share_link_revoke`.

## Test plan
- [x] `testOwnerCanRevokeTheirShare` — happy path
- [x] `testNonOwnerCannotRevokeShare` — 403 si non-propriétaire
- [x] `testGuestLosesAccessAfterShareIsRevoked` — l'invité perd l'accès immédiatement après révocation
- [x] `testSharesPageShowsRevokeButtonForOutgoingShares` — bouton présent dans le template
- [x] Suite complète `phpunit` : 836 tests OK