### PR TITLE
🔧 fix(FileCard,FolderCard): retirer le libellé débordant du bouton Déplacer

### DIFF
--- a/templates/components/FileCard.html.twig
+++ b/templates/components/FileCard.html.twig
@@ -56,11 +56,9 @@
 			<a href="#"
 			   role="button"
 			   data-testid="move-file-btn-{{ item.id }}"
-			   class="move-btn group relative hc-item-action hc-item-action--move flex items-center gap-1.5"
+			   class="move-btn hc-item-action hc-item-action--move"
 			   title="Déplacer {{ (item.originalName ?? item.name)|e('html') }}"
-			   onclick="openGlobalMoveModal('file', '{{ item.id }}', '{{ (item.originalName ?? item.name)|e('js') }}'); return false;"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-arrow-up-right"><line x1="7" y1="17" x2="17" y2="7"/><polyline points="7 7 17 7 17 17"/></svg>
-				<span class="hidden group-hover:inline text-xs font-medium whitespace-nowrap">Déplacer {{ (item.originalName ?? item.name)|e('html') }}</span>
-			</a>
+			   onclick="openGlobalMoveModal('file', '{{ item.id }}', '{{ (item.originalName ?? item.name)|e('js') }}'); return false;"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-arrow-up-right"><line x1="7" y1="17" x2="17" y2="7"/><polyline points="7 7 17 7 17 17"/></svg></a>
 			<form method="post" action="{{ path('app_file_delete', { id: item.id }) }}"
 			      onsubmit="return confirm('Supprimer « {{ item.originalName|e('js') }} » ?')">
 				<input type="hidden" name="_token" value="{{ csrf_token('delete-file') }}">

--- a/templates/components/FolderCard.html.twig
+++ b/templates/components/FolderCard.html.twig
@@ -13,11 +13,10 @@
 		        data-folder-id="{{ item.id }}"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-pencil"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg></button>
 		<button type="button"
 		        data-testid="move-folder-btn-{{ item.id }}"
-		        class="move-btn group relative hc-item-action hc-item-action--move flex items-center gap-1.5"
+		        class="move-btn hc-item-action hc-item-action--move"
 		        title="Déplacer {{ item.name|e('html') }}"
 		        onclick="openGlobalMoveModal('folder', '{{ item.id }}', '{{ item.name|e('js') }}')">
 			<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-arrow-up-right"><line x1="7" y1="17" x2="17" y2="7"/><polyline points="7 7 17 7 17 17"/></svg>
-			<span class="hidden group-hover:inline text-xs font-medium whitespace-nowrap">Déplacer {{ item.name|e('html') }}</span>
 		</button>
 		<button type="button"
 		        id="share-open-btn-{{ item.id }}"

--- a/tests/Web/MoveModalWebTest.php
+++ b/tests/Web/MoveModalWebTest.php
@@ -51,6 +51,31 @@ final class MoveModalWebTest extends WebTestCase
         $this->assertSelectorExists('[data-testid^="move-file-btn-"]', 'Le bouton déplacer fichier doit exister');
     }
 
+    // ─── #281 : le libellé au survol débordait sur les cartes voisines ─────
+
+    public function testMoveFolderButtonHasNoOverflowingHoverLabel(): void
+    {
+        // Le title natif du navigateur porte déjà "Déplacer <nom>" : le span
+        // affiché en plus au survol (whitespace-nowrap, sans largeur
+        // contrainte) débordait de la carte pour les noms longs.
+        $this->client->request('GET', '/explorer');
+
+        $this->assertSelectorNotExists(
+            '[data-testid^="move-folder-btn-"] span',
+            'Le bouton déplacer dossier ne doit plus afficher de libellé au survol (redondant avec le title)',
+        );
+    }
+
+    public function testMoveFileButtonHasNoOverflowingHoverLabel(): void
+    {
+        $this->client->request('GET', '/explorer?folder=' . $this->folderId);
+
+        $this->assertSelectorNotExists(
+            '[data-testid^="move-file-btn-"] span',
+            'Le bouton déplacer fichier ne doit plus afficher de libellé au survol (redondant avec le title)',
+        );
+    }
+
     public function testGlobalMoveModalExistsInDOM(): void
     {
         $this->client->request('GET', '/explorer');


### PR DESCRIPTION
## Summary
Corrige #281 : le libellé "Déplacer <nom>" affiché au survol du bouton (en plus du `title` natif) débordait du cadre de la carte quand le nom du fichier/dossier était long (`whitespace-nowrap`, sans largeur contrainte).
- Suppression du `<span>` redondant sur `FileCard` et `FolderCard` — le `title` natif du navigateur affiche déjà "Déplacer <nom>" au survol.
- Cohérent avec les autres boutons d'action (rename, share, delete, download) qui n'ont jamais eu ce libellé étendu.

## Test plan
- [x] `testMoveFolderButtonHasNoOverflowingHoverLabel` / `testMoveFileButtonHasNoOverflowingHoverLabel`
- [x] Suite complète `phpunit` : 848 tests OK