### PR TITLE
🛠️ chore(SecurityHeadersListener): baser la dérogation clickjacking sur le nom de route

### DIFF
--- a/src/EventListener/SecurityHeadersListener.php
+++ b/src/EventListener/SecurityHeadersListener.php
@@ -34,6 +34,9 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * route dans une <iframe> same-origin — DENY/'none' bloquerait cet embedding
  * même en same-origin. Remplacé par SAMEORIGIN/'self' UNIQUEMENT sur cette
  * route, pour ne pas affaiblir la protection anti-clickjacking ailleurs.
+ * Identifiée par nom de route (_route), pas par un regex sur le path (#285) :
+ * le nom de route est la source de vérité unique, un renommage du path dans
+ * l'attribut #[Route] n'affecte plus la dérogation.
  */
 #[AsEventListener(event: KernelEvents::RESPONSE)]
 final class SecurityHeadersListener
@@ -49,7 +52,7 @@ final class SecurityHeadersListener
         }
 
         $path = $event->getRequest()->getPathInfo();
-        $isFileViewRoute = (bool) preg_match('#^/files/[^/]+/view$#', $path);
+        $isFileViewRoute = $event->getRequest()->attributes->get('_route') === 'app_file_view';
 
         $headers = $event->getResponse()->headers;
         $headers->set('X-Content-Type-Options', 'nosniff');

--- a/tests/Unit/EventListener/SecurityHeadersListenerTest.php
+++ b/tests/Unit/EventListener/SecurityHeadersListenerTest.php
@@ -13,10 +13,13 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 final class SecurityHeadersListenerTest extends TestCase
 {
-    private function buildEvent(string $path = '/api/v1/users'): ResponseEvent
+    private function buildEvent(string $path = '/api/v1/users', ?string $route = null): ResponseEvent
     {
         $kernel = $this->createMock(HttpKernelInterface::class);
         $request = Request::create($path);
+        if ($route !== null) {
+            $request->attributes->set('_route', $route);
+        }
         $response = new Response();
 
         return new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response);
@@ -141,7 +144,7 @@ final class SecurityHeadersListenerTest extends TestCase
      */
     public function testFileViewRouteAllowsSameOriginFraming(): void
     {
-        $event = $this->buildEvent('/files/0198c1b2-6b8b-7f3e-8a1a-000000000001/view');
+        $event = $this->buildEvent('/files/0198c1b2-6b8b-7f3e-8a1a-000000000001/view', 'app_file_view');
         (new SecurityHeadersListener('test'))($event);
 
         $headers = $event->getResponse()->headers;
@@ -151,7 +154,22 @@ final class SecurityHeadersListenerTest extends TestCase
 
     public function testOtherFrontRoutesStillDenyFraming(): void
     {
-        $event = $this->buildEvent('/files/0198c1b2-6b8b-7f3e-8a1a-000000000001/download');
+        $event = $this->buildEvent('/files/0198c1b2-6b8b-7f3e-8a1a-000000000001/download', 'app_file_download');
+        (new SecurityHeadersListener('test'))($event);
+
+        $headers = $event->getResponse()->headers;
+        $this->assertSame('DENY', $headers->get('X-Frame-Options'));
+        $this->assertStringContainsString("frame-ancestors 'none'", $headers->get('Content-Security-Policy'));
+    }
+
+    /**
+     * #285 : la dérogation était basée sur un regex du path, dupliqué de
+     * l'attribut #[Route] — une route différente qui matcherait
+     * accidentellement le même pattern de path ne doit pas en bénéficier.
+     */
+    public function testPathMatchingFileViewPatternButDifferentRouteNameDoesNotGetDeroga(): void
+    {
+        $event = $this->buildEvent('/files/0198c1b2-6b8b-7f3e-8a1a-000000000001/view', 'app_some_other_route');
         (new SecurityHeadersListener('test'))($event);
 
         $headers = $event->getResponse()->headers;


### PR DESCRIPTION
## Summary
Corrige #285 : la dérogation `X-Frame-Options`/`frame-ancestors` pour le viewer PDF (#280) détectait la route via un `preg_match` sur le path, dupliqué de l'attribut `#[Route]` de `app_file_view` — deux sources de vérité à synchroniser manuellement.
- Remplace le regex par un check sur `_route` (résolu par le routeur Symfony), source de vérité unique.
- Un renommage du path dans l'attribut `#[Route]` n'affecte plus la dérogation ; seul un renommage du `name:` la ferait (plus rare, intentionnel).

## Test plan
- [x] Tests existants adaptés pour injecter `_route` dans la requête de test (`buildEvent` accepte désormais un nom de route)
- [x] Nouveau test caractérisant l'angle mort corrigé : un path matchant le pattern mais une route différente ne bénéficie plus de la dérogation
- [x] Suite complète `phpunit` : 849 tests OK