### PR TITLE
fix(auth): créer les comptes sans mot de passe en clair + exposer le reset password

### DIFF
--- a/.claude/deploiement.md
+++ b/.claude/deploiement.md
@@ -131,8 +131,11 @@ Après `--init` ou `bin/deploy.sh`, **en SSH** :
 ssh -i ~/.ssh/o2switch ron2cuba@lenouvel.me
 cd /home9/ron2cuba/<prenom>.lenouvel.me
 
-# Créer le premier utilisateur admin
-php bin/console app:create-user '<email>' '<password>' <prenom> --env=prod
+# Créer le premier utilisateur admin sans mot de passe :
+# la commande affiche un lien de définition de mot de passe (valable 1h)
+# à ouvrir dans le navigateur — évite de taper un mot de passe en clair
+# sur la ligne de commande / dans l'historique bash SSH.
+php bin/console app:create-user '<email>' <prenom> --env=prod
 ```
 
 > `lexik:jwt:generate-keypair` et `asset-map:compile` sont déjà gérés par les scripts.

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ composer build-assets
 symfony server:start
 ```
 
-Créer un compte :
+Créer un compte (mot de passe optionnel : s'il est omis, un lien de définition de mot de passe est affiché) :
 
 ```bash
-php bin/console app:create-user 'vous@example.com' '<mot-de-passe>' 'Prénom'
+php bin/console app:create-user 'vous@example.com' 'Prénom' '<mot-de-passe>'
 ```
 
 ## Tests

--- a/assets/styles/login.css
+++ b/assets/styles/login.css
@@ -70,6 +70,15 @@
 	color: var(--hc-text-2);
 }
 
+.login-forgot-link {
+	color: var(--hc-accent);
+	text-decoration: none;
+}
+
+.login-forgot-link:hover {
+	text-decoration: underline;
+}
+
 .login-submit {
 	width: 100%;
 	justify-content: center;

--- a/src/Command/CreateUserCommand.php
+++ b/src/Command/CreateUserCommand.php
@@ -13,6 +13,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
 
 #[AsCommand(name: 'app:create-user', description: 'Crée un utilisateur')]
 class CreateUserCommand extends Command
@@ -20,6 +22,8 @@ class CreateUserCommand extends Command
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly UserPasswordHasherInterface $hasher,
+        private readonly ResetPasswordHelperInterface $resetPasswordHelper,
+        private readonly UrlGeneratorInterface $urlGenerator,
     ) {
         parent::__construct();
     }
@@ -28,8 +32,8 @@ class CreateUserCommand extends Command
     {
         $this
             ->addArgument('email', InputArgument::REQUIRED, 'Email')
-            ->addArgument('password', InputArgument::REQUIRED, 'Mot de passe')
-            ->addArgument('displayName', InputArgument::OPTIONAL, 'Nom affiché', 'User');
+            ->addArgument('displayName', InputArgument::OPTIONAL, 'Nom affiché', 'User')
+            ->addArgument('password', InputArgument::OPTIONAL, 'Mot de passe (omis : le compte est créé sans mot de passe, à définir via un lien de réinitialisation)');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -37,9 +41,28 @@ class CreateUserCommand extends Command
         $io = new SymfonyStyle($input, $output);
 
         $user = new User($input->getArgument('email'), $input->getArgument('displayName'));
-        $user->setPassword($this->hasher->hashPassword($user, $input->getArgument('password')));
+        $password = $input->getArgument('password');
 
         $this->em->persist($user);
+
+        if ($password === null) {
+            $this->em->flush();
+
+            $resetToken = $this->resetPasswordHelper->generateResetToken($user);
+            $resetUrl = $this->urlGenerator->generate(
+                'web_reset_password_confirm',
+                ['token' => $resetToken->getToken()],
+                UrlGeneratorInterface::ABSOLUTE_URL,
+            );
+
+            $io->success('User créé : ' . $user->getEmail());
+            $io->writeln('Définissez le mot de passe ici (lien valable 1h) :');
+            $io->writeln($resetUrl);
+
+            return Command::SUCCESS;
+        }
+
+        $user->setPassword($this->hasher->hashPassword($user, $password));
         $this->em->flush();
 
         $io->success('User créé : ' . $user->getEmail());

--- a/templates/reset_password/request.html.twig
+++ b/templates/reset_password/request.html.twig
@@ -7,7 +7,7 @@
     <h2 class="text-2xl font-bold mb-4 text-center">Réinitialiser mon mot de passe</h2>
     <form id="reset-password-form" class="flex flex-col gap-4">
         <input type="email" name="email" id="email" required placeholder="Votre email" class="px-4 py-2 rounded-xl border focus:outline-none focus:ring-2 focus:ring-blue-400/50" />
-        <button type="submit" class="bg-blue-500 text-white rounded-xl py-2 font-semibold hover:bg-blue-600 transition-all">Envoyer le lien</button>
+        <button type="submit" class="btn btn-primary">Envoyer le lien</button>
     </form>
     <div id="reset-password-message" class="mt-4"></div>
 </div>

--- a/templates/web/login.html.twig
+++ b/templates/web/login.html.twig
@@ -46,6 +46,7 @@
           <input type="checkbox" style="accent-color:var(--hc-accent)">
           <span>Se souvenir</span>
         </label>
+        <a href="{{ path('web_reset_password') }}" class="login-forgot-link">Mot de passe oublié ?</a>
       </div>
 
       <button type="submit" class="btn btn-primary login-submit">

--- a/tests/ResetPasswordControllerTest.php
+++ b/tests/ResetPasswordControllerTest.php
@@ -75,6 +75,25 @@ class ResetPasswordControllerTest extends WebTestCase
     }
 
     /**
+     * Anti-énumération de comptes : un email qui n'existe pas en base ne doit
+     * ni envoyer de mail, ni faire échouer la requête différemment d'un email
+     * existant — sinon on peut deviner quels comptes existent selon la réponse.
+     */
+    public function testRequestResetPasswordWithUnknownEmailSendsNoEmailButReturnsGenericSuccess(): void
+    {
+        $this->client->request('POST', '/api/request-reset-password', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['email' => 'inconnu@example.com']));
+
+        self::assertResponseIsSuccessful();
+        self::assertEmailCount(0);
+
+        $data = json_decode($this->client->getResponse()->getContent(), true);
+        self::assertArrayHasKey('message', $data);
+        self::assertSame('Si un compte existe, un email a été envoyé.', $data['message']);
+    }
+
+    /**
      * F6 de l'audit sécurité : le mail de réinitialisation envoyait le token
      * brut en texte simple, avec un expéditeur non routable. Doit désormais
      * être un email HTML contenant un LIEN (pas le token nu) vers une page

--- a/tests/Unit/Command/CreateUserCommandTest.php
+++ b/tests/Unit/Command/CreateUserCommandTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Command;
+
+use App\Command\CreateUserCommand;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
+
+final class CreateUserCommandTest extends TestCase
+{
+    private function makeHasherStub(): UserPasswordHasherInterface
+    {
+        $stub = $this->createMock(UserPasswordHasherInterface::class);
+        $stub->method('hashPassword')->willReturnCallback(
+            fn (User $user, string $plainPassword) => 'hashed-' . $plainPassword,
+        );
+
+        return $stub;
+    }
+
+    private function makeResetPasswordHelperStub(): ResetPasswordHelperInterface
+    {
+        $stub = $this->createMock(ResetPasswordHelperInterface::class);
+        $stub->method('generateResetToken')
+            ->willReturn(new ResetPasswordToken('fake-token', new \DateTimeImmutable('+1 hour'), time()));
+
+        return $stub;
+    }
+
+    private function makeUrlGeneratorStub(): UrlGeneratorInterface
+    {
+        $stub = $this->createMock(UrlGeneratorInterface::class);
+        $stub->method('generate')->willReturn('https://prenom.lenouvel.me/reset-password/fake-token');
+
+        return $stub;
+    }
+
+    private function makeCommand(
+        ?EntityManagerInterface $em = null,
+        ?UserPasswordHasherInterface $hasher = null,
+        ?ResetPasswordHelperInterface $resetPasswordHelper = null,
+        ?UrlGeneratorInterface $urlGenerator = null,
+    ): CreateUserCommand {
+        $em ??= $this->createMock(EntityManagerInterface::class);
+        $hasher ??= $this->makeHasherStub();
+        $resetPasswordHelper ??= $this->makeResetPasswordHelperStub();
+        $urlGenerator ??= $this->makeUrlGeneratorStub();
+
+        return new CreateUserCommand($em, $hasher, $resetPasswordHelper, $urlGenerator);
+    }
+
+    public function testCreatesUserWithoutPasswordWhenArgumentOmittedAndPrintsResetUrl(): void
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $persistedUser = null;
+        $em->expects($this->once())->method('persist')->willReturnCallback(
+            function (User $user) use (&$persistedUser) {
+                $persistedUser = $user;
+            }
+        );
+        $em->expects($this->once())->method('flush');
+
+        $command = $this->makeCommand(em: $em);
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'email'       => 'admin@example.com',
+            'displayName' => 'prenom',
+        ]);
+
+        $this->assertSame('', $persistedUser->getPassword());
+        $this->assertStringContainsString(
+            'https://prenom.lenouvel.me/reset-password/fake-token',
+            $tester->getDisplay(),
+        );
+    }
+
+    public function testCreatesUserWithHashedPasswordWhenArgumentProvided(): void
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $persistedUser = null;
+        $em->expects($this->once())->method('persist')->willReturnCallback(
+            function (User $user) use (&$persistedUser) {
+                $persistedUser = $user;
+            }
+        );
+        $em->expects($this->once())->method('flush');
+
+        $command = $this->makeCommand(em: $em);
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'email'       => 'admin@example.com',
+            'password'    => 'S3cret!',
+            'displayName' => 'prenom',
+        ]);
+
+        $this->assertSame('hashed-S3cret!', $persistedUser->getPassword());
+        $this->assertStringNotContainsString('reset-password', $tester->getDisplay());
+    }
+}

--- a/tests/Unit/Command/CreateUserCommandTest.php
+++ b/tests/Unit/Command/CreateUserCommandTest.php
@@ -97,11 +97,11 @@ final class CreateUserCommandTest extends TestCase
         $tester = new CommandTester($command);
         $tester->execute([
             'email'       => 'admin@example.com',
-            'password'    => 'S3cret!',
+            'password'    => 'irrelevant-plain-password',
             'displayName' => 'prenom',
         ]);
 
-        $this->assertSame('hashed-S3cret!', $persistedUser->getPassword());
+        $this->assertSame('hashed-irrelevant-plain-password', $persistedUser->getPassword());
         $this->assertStringNotContainsString('reset-password', $tester->getDisplay());
     }
 }


### PR DESCRIPTION
## Résumé

- `app:create-user` : le mot de passe devient optionnel. S'il est omis (cas du provisioning d'une nouvelle instance en SSH), le compte est créé sans mot de passe (`password=''`, structurellement impossible à authentifier — même mécanisme que `GuestAccountCreator`) et un lien de réinitialisation est affiché directement dans le terminal, plutôt que de taper un mot de passe en clair visible dans l'historique bash SSH.
- Le lien « Mot de passe oublié ? » (déjà implémenté côté backend) est maintenant exposé sur `/login`, avec le bouton du formulaire de demande de reset harmonisé sur `.btn-primary`.
- Ajout d'un test verrouillant le comportement anti-énumération déjà en place (email inconnu → aucun mail envoyé, réponse générique).

## Test plan

- [x] Suite complète : 852/852 tests verts
- [x] Tests unitaires dédiés `CreateUserCommandTest` (avec/sans mot de passe)
- [x] Vérifié en HTTP que le lien `/login` → `/reset-password` fonctionne
- [ ] Parcours email complet (demande → réception → clic → confirmation → connexion) à vérifier manuellement dans un navigateur

Closes #276
Closes #308