### PR TITLE
chore(env): retirer .env.dev du tracking git

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,4 +1,0 @@
-
-###> symfony/framework-bundle ###
-APP_SECRET=26a20534ee7b1b72d826fa34e04c7f10
-###< symfony/framework-bundle ###

--- a/.env.dev.example
+++ b/.env.dev.example
@@ -1,0 +1,5 @@
+
+###> symfony/framework-bundle ###
+# OBLIGATOIRE — générer avec : openssl rand -hex 32
+APP_SECRET=CHANGE_ME_generate_with_openssl_rand_hex_32
+###< symfony/framework-bundle ###

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.env.local
 /.env.local.php
 /.env.*.local
+/.env.dev
 /config/secrets/prod/prod.decrypt.private.php
 /public/bundles/
 /var/


### PR DESCRIPTION
## Résumé

`.env.dev` était versionné depuis le commit initial du projet, avec `APP_SECRET` en clair. Alertes GitGuardian récurrentes sur ce fichier depuis plusieurs mois.

Secret sans enjeu réel (dev uniquement, jamais utilisé en prod — `.env` de prod a `APP_SECRET` vide), donc pas de rotation nécessaire. Mais le fichier ne devrait pas rester versionné : retiré du tracking (`git rm --cached`), ajouté à `.gitignore` (même pattern que `.env.local`), et `.env.dev.example` créé comme modèle pour les futurs clones du dépôt.

## Test plan

- [x] Suite complète : 852/852 tests verts
- [x] `.env.dev` reste présent localement sur disque (juste retiré du tracking), l'environnement dev continue de fonctionner sans changement