### PR TITLE
fix(security): rate limiting sur la soumission du token de reset

### DIFF
--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -8,3 +8,7 @@ framework:
             policy: 'sliding_window'
             limit: 5
             interval: '15 minutes'
+        reset_password_submit:
+            policy: 'sliding_window'
+            limit: 5
+            interval: '15 minutes'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -153,6 +153,7 @@ services:
     App\Controller\Api\ResetPasswordController:
         arguments:
             $resetPasswordRequestLimiter: '@limiter.reset_password_request'
+            $resetPasswordSubmitLimiter: '@limiter.reset_password_submit'
 
 when@dev:
     services:

--- a/src/Controller/Api/ResetPasswordController.php
+++ b/src/Controller/Api/ResetPasswordController.php
@@ -23,6 +23,7 @@ class ResetPasswordController extends AbstractController
         private EntityManagerInterface $entityManager,
         private \App\Interface\PasswordResetServiceInterface $passwordResetService,
         private RateLimiterFactory $resetPasswordRequestLimiter,
+        private RateLimiterFactory $resetPasswordSubmitLimiter,
     ) {}
 
     /**
@@ -50,6 +51,11 @@ class ResetPasswordController extends AbstractController
     #[Route('/api/reset-password', name: 'api_reset_password', methods: ['POST'])]
     public function apiResetPassword(Request $request): Response
     {
+        $limiter = $this->resetPasswordSubmitLimiter->create($request->getClientIp());
+        if (!$limiter->consume(1)->isAccepted()) {
+            throw new TooManyRequestsHttpException(null, 'Trop de tentatives. Réessayez plus tard.');
+        }
+
         $data = json_decode($request->getContent(), true);
         $token = $data['token'] ?? null;
         $newPassword = $data['password'] ?? null;

--- a/tests/ResetPasswordControllerTest.php
+++ b/tests/ResetPasswordControllerTest.php
@@ -149,6 +149,28 @@ class ResetPasswordControllerTest extends WebTestCase
     }
 
     /**
+     * Brute-force du token : le bundle SymfonyCasts vérifie la longueur (40
+     * caractères) et l'expiration du token, mais ne limite pas le nombre de
+     * tentatives de validation — sans rate limiting applicatif, une IP peut
+     * boucler indéfiniment sur /api/reset-password avec des tokens devinés.
+     */
+    public function testResetPasswordSubmitIsRateLimited(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->client->request('POST', '/api/reset-password', [], [], [
+                'CONTENT_TYPE' => 'application/json',
+            ], json_encode(['token' => "invalid-token-$i", 'password' => 'NewPassword123!']));
+            self::assertResponseStatusCodeSame(400);
+        }
+
+        $this->client->request('POST', '/api/reset-password', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['token' => 'invalid-token-6', 'password' => 'NewPassword123!']));
+
+        self::assertResponseStatusCodeSame(429);
+    }
+
+    /**
      * F6 de l'audit sécurité : le mail de réinitialisation envoyait le token
      * brut en texte simple, avec un expéditeur non routable. Doit désormais
      * être un email HTML contenant un LIEN (pas le token nu) vers une page


### PR DESCRIPTION
## Résumé

Vérifié : `SymfonyCasts\ResetPasswordBundle` ne limite pas les tentatives de validation de token sur `/api/reset-password` — seules la longueur (40 caractères) et l'expiration sont vérifiées. Sans limite applicative, une IP peut boucler indéfiniment en devinant des tokens.

Rate limiter `reset_password_submit` (5 requêtes / 15 min, sliding window, clé = IP) ajouté, même pattern que `reset_password_request` (#314), vérifié avant toute logique métier.

## Test plan

- [x] Suite complète : 855/855 tests verts
- [x] Test dédié : dépassement du seuil avec tokens invalides en boucle → 429 après 5 tentatives

Closes #315