### PR TITLE
ci: passer à actions/checkout@v5 et actions/setup-node@v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ main ]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   php:
     runs-on: ubuntu-latest
@@ -29,7 +26,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🐘 Setup PHP
         uses: shivammathur/setup-php@v2
@@ -83,10 +80,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 


### PR DESCRIPTION
## Résumé

Corrige l'avertissement CI :
> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4.

Passage à `@v5` pour les deux actions (ciblent Node 24 nativement). Retire aussi `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`, qui était un contournement du même problème (#147) devenu inutile.

## Test plan

- [ ] CI verte sur cette PR, plus d'avertissement de dépréciation Node.js