### PR TITLE
🛠️ chore(ShareLink): purge des liens de partage révoqués + réactivation

### DIFF
--- a/src/Command/ShareLinkPurgeRevokedCommand.php
+++ b/src/Command/ShareLinkPurgeRevokedCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\ShareLink;
+use App\Interface\ShareLinkRepositoryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Purge physiquement les ShareLink révoqués depuis plus de
+ * ShareLink::PURGE_AFTER_DAYS jours (cf. #244).
+ *
+ * La fenêtre de grâce laisse à l'owner le temps de réactiver un lien révoqué
+ * par erreur (cf. app_share_link_reactivate) avant suppression définitive.
+ * À exécuter périodiquement via crontab (cf. project_cron_messenger).
+ */
+#[AsCommand(name: 'app:share-link:purge-revoked', description: 'Purge les liens de partage révoqués depuis plus de 30 jours')]
+final class ShareLinkPurgeRevokedCommand extends Command
+{
+    public function __construct(
+        private readonly ShareLinkRepositoryInterface $shareLinkRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $threshold = (new \DateTimeImmutable())->modify('-' . ShareLink::PURGE_AFTER_DAYS . ' days');
+        $purged = $this->shareLinkRepository->deleteRevokedOlderThan($threshold);
+
+        $io->writeln(sprintf('%d lien(s) de partage purgé(s).', $purged));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/Web/ShareWebController.php
+++ b/src/Controller/Web/ShareWebController.php
@@ -219,6 +219,31 @@ final class ShareWebController extends AbstractController
         return $this->redirect('/partages');
     }
 
+    #[Route('/share-link-reactivate', name: 'app_share_link_reactivate', methods: ['POST'])]
+    public function reactivateLink(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('share-link-reactivate', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Jeton CSRF invalide.');
+        }
+
+        $linkId = (string) $request->request->get('linkId', '');
+        $link = $this->shareLinkRepository->find(Uuid::fromString($linkId))
+            ?? throw $this->createNotFoundException('Lien introuvable.');
+
+        /** @var User $user */
+        $user = $this->getUser();
+        if (!$link->getOwner()->getId()->equals($user->getId())) {
+            throw $this->createAccessDeniedException('Vous n\'êtes pas le propriétaire de ce lien.');
+        }
+
+        $link->reactivate();
+        $this->em->flush();
+
+        $this->addFlash('success', 'Lien de partage réactivé.');
+
+        return $this->redirect('/partages');
+    }
+
     #[Route('/share-revoke', name: 'app_share_revoke', methods: ['POST'])]
     public function revoke(Request $request): Response
     {

--- a/src/Entity/ShareLink.php
+++ b/src/Entity/ShareLink.php
@@ -28,6 +28,9 @@ use Symfony\Component\Uid\Uuid;
 #[ORM\Table(name: 'share_links')]
 class ShareLink
 {
+    /** Délai de grâce avant purge définitive d'un lien révoqué (cf. app:share-link:purge-revoked). */
+    public const PURGE_AFTER_DAYS = 30;
+
     #[ORM\Id]
     #[ORM\Column(type: 'uuid', unique: true)]
     private Uuid $id;
@@ -121,6 +124,11 @@ class ShareLink
         $this->revokedAt = new \DateTimeImmutable();
     }
 
+    public function reactivate(): void
+    {
+        $this->revokedAt = null;
+    }
+
     public function isExpired(): bool
     {
         return $this->expiresAt !== null && $this->expiresAt < new \DateTimeImmutable();
@@ -129,6 +137,19 @@ class ShareLink
     public function isActive(): bool
     {
         return $this->revokedAt === null && !$this->isExpired();
+    }
+
+    /** Jours restants avant purge définitive, ou null si le lien n'est pas révoqué. */
+    public function daysUntilPurge(): ?int
+    {
+        if ($this->revokedAt === null) {
+            return null;
+        }
+
+        $purgeAt = $this->revokedAt->modify(sprintf('+%d days', self::PURGE_AFTER_DAYS));
+        $secondsRemaining = $purgeAt->getTimestamp() - (new \DateTimeImmutable())->getTimestamp();
+
+        return max(0, (int) ceil($secondsRemaining / 86400));
     }
 
     /**

--- a/src/Interface/ShareLinkRepositoryInterface.php
+++ b/src/Interface/ShareLinkRepositoryInterface.php
@@ -27,4 +27,7 @@ interface ShareLinkRepositoryInterface
 
     /** Supprime tous les liens pointant vers cette ressource (nettoyage à la suppression). */
     public function deleteByResource(string $resourceType, Uuid $resourceId): void;
+
+    /** Purge les liens révoqués depuis avant $threshold. Retourne le nombre de liens supprimés. */
+    public function deleteRevokedOlderThan(\DateTimeImmutable $threshold): int;
 }

--- a/src/Repository/ShareLinkRepository.php
+++ b/src/Repository/ShareLinkRepository.php
@@ -75,4 +75,16 @@ class ShareLinkRepository extends ServiceEntityRepository implements ShareLinkRe
             ->getQuery()
             ->execute();
     }
+
+    /** Purge les liens révoqués depuis avant $threshold (cf. app:share-link:purge-revoked). */
+    public function deleteRevokedOlderThan(\DateTimeImmutable $threshold): int
+    {
+        return (int) $this->createQueryBuilder('sl')
+            ->delete()
+            ->where('sl.revokedAt IS NOT NULL')
+            ->andWhere('sl.revokedAt < :threshold')
+            ->setParameter('threshold', $threshold)
+            ->getQuery()
+            ->execute();
+    }
 }

--- a/templates/web/shares.html.twig
+++ b/templates/web/shares.html.twig
@@ -100,6 +100,9 @@
                   {% else %}
                     {{ row.link.isActive ? 'expire le ' ~ row.link.expiresAt|date('d/m/Y') : 'révoqué/expiré le ' ~ row.link.expiresAt|date('d/m/Y') }}
                   {% endif %}
+                  {% if row.link.revokedAt %}
+                    · sera supprimé automatiquement dans {{ row.link.daysUntilPurge }} j
+                  {% endif %}
                 </div>
               </div>
             </div>
@@ -109,6 +112,14 @@
                 <input type="hidden" name="linkId" value="{{ row.link.id }}">
                 <button type="submit" class="hc-item-action hc-item-action--danger" style="background:none; border:none; cursor:pointer; font-size:0.8125rem; font-weight:600;">
                   Révoquer
+                </button>
+              </form>
+            {% elseif row.link.revokedAt %}
+              <form method="post" action="{{ path('app_share_link_reactivate') }}">
+                <input type="hidden" name="_token" value="{{ csrf_token('share-link-reactivate') }}">
+                <input type="hidden" name="linkId" value="{{ row.link.id }}">
+                <button type="submit" class="hc-item-action" style="background:none; border:none; cursor:pointer; font-size:0.8125rem; font-weight:600;">
+                  Réactiver
                 </button>
               </form>
             {% endif %}

--- a/tests/Command/ShareLinkPurgeRevokedCommandTest.php
+++ b/tests/Command/ShareLinkPurgeRevokedCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\ShareLinkPurgeRevokedCommand;
+use App\Entity\ShareLink;
+use App\Interface\ShareLinkRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Purge des ShareLink révoqués depuis plus de ShareLink::PURGE_AFTER_DAYS
+ * jours (cf. #244) : garde une fenêtre de grâce permettant la réactivation
+ * (cf. app_share_link_reactivate) avant suppression physique définitive.
+ */
+final class ShareLinkPurgeRevokedCommandTest extends TestCase
+{
+    public function testPurgesRevokedLinksOlderThanRetentionWindow(): void
+    {
+        $repository = $this->createMock(ShareLinkRepositoryInterface::class);
+        $repository->expects($this->once())
+            ->method('deleteRevokedOlderThan')
+            ->with($this->callback(function (\DateTimeImmutable $threshold) {
+                $expected = (new \DateTimeImmutable())->modify('-' . ShareLink::PURGE_AFTER_DAYS . ' days');
+
+                return abs($expected->getTimestamp() - $threshold->getTimestamp()) < 5;
+            }))
+            ->willReturn(3);
+
+        $tester = $this->commandTester($repository);
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('3', $tester->getDisplay());
+    }
+
+    private function commandTester(ShareLinkRepositoryInterface $repository): CommandTester
+    {
+        $command = new ShareLinkPurgeRevokedCommand($repository);
+        $application = new Application();
+        $application->addCommand($command);
+
+        return new CommandTester($application->find('app:share-link:purge-revoked'));
+    }
+}

--- a/tests/Repository/ShareLinkRepositoryTest.php
+++ b/tests/Repository/ShareLinkRepositoryTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Repository;
+
+use App\Entity\Share;
+use App\Entity\ShareLink;
+use App\Entity\User;
+use App\Repository\ShareLinkRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class ShareLinkRepositoryTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private ShareLinkRepository $repository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $this->repository = static::getContainer()->get(ShareLinkRepository::class);
+
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM share_links');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createUser(string $email): User
+    {
+        $user = new User($email, 'Test User');
+        $user->setPassword('irrelevant-hash');
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+
+    private function createLink(User $owner, string $selector): ShareLink
+    {
+        return new ShareLink(
+            $owner,
+            Share::RESOURCE_FILE,
+            Uuid::v7(),
+            $selector,
+            hash('sha256', 'plain-token'),
+            null,
+        );
+    }
+
+    private function setRevokedAt(ShareLink $link, \DateTimeImmutable $revokedAt): void
+    {
+        $ref = new \ReflectionProperty(ShareLink::class, 'revokedAt');
+        $ref->setValue($link, $revokedAt);
+    }
+
+    public function testDeleteRevokedOlderThanRemovesOldRevokedLinks(): void
+    {
+        $owner = $this->createUser('owner-sl-repo@example.com');
+
+        $old = $this->createLink($owner, 'selectorold00000000000000000000');
+        $this->setRevokedAt($old, new \DateTimeImmutable('-31 days'));
+        $this->em->persist($old);
+        $this->em->flush();
+
+        $this->repository->deleteRevokedOlderThan(new \DateTimeImmutable('-30 days'));
+        $this->em->clear();
+
+        $this->assertNull($this->repository->find($old->getId()));
+    }
+
+    public function testDeleteRevokedOlderThanLeavesRecentlyRevokedLinksIntact(): void
+    {
+        $owner = $this->createUser('owner-sl-repo2@example.com');
+
+        $recent = $this->createLink($owner, 'selectorrecent0000000000000000');
+        $this->setRevokedAt($recent, new \DateTimeImmutable('-1 day'));
+        $this->em->persist($recent);
+        $this->em->flush();
+
+        $this->repository->deleteRevokedOlderThan(new \DateTimeImmutable('-30 days'));
+        $this->em->clear();
+
+        $this->assertNotNull($this->repository->find($recent->getId()));
+    }
+
+    public function testDeleteRevokedOlderThanLeavesActiveLinksIntact(): void
+    {
+        $owner = $this->createUser('owner-sl-repo3@example.com');
+
+        $active = $this->createLink($owner, 'selectoractive0000000000000000');
+        $this->em->persist($active);
+        $this->em->flush();
+
+        $this->repository->deleteRevokedOlderThan(new \DateTimeImmutable('-30 days'));
+        $this->em->clear();
+
+        $this->assertNotNull($this->repository->find($active->getId()));
+    }
+}

--- a/tests/Unit/Entity/ShareLinkTest.php
+++ b/tests/Unit/Entity/ShareLinkTest.php
@@ -123,4 +123,40 @@ final class ShareLinkTest extends TestCase
 
         $this->assertFalse($link->isActive());
     }
+
+    public function testReactivateClearsRevokedAt(): void
+    {
+        $link = new ShareLink(
+            $this->makeOwner(),
+            Share::RESOURCE_FILE,
+            Uuid::v7(),
+            'selector0000000000000000000000',
+            hash('sha256', 'plain-token'),
+            new \DateTimeImmutable('+7 days'),
+        );
+
+        $link->revoke();
+        $link->reactivate();
+
+        $this->assertNull($link->getRevokedAt());
+        $this->assertTrue($link->isActive());
+    }
+
+    public function testReactivateOnExpiredLinkStaysInactive(): void
+    {
+        $link = new ShareLink(
+            $this->makeOwner(),
+            Share::RESOURCE_FILE,
+            Uuid::v7(),
+            'selector0000000000000000000000',
+            hash('sha256', 'plain-token'),
+            new \DateTimeImmutable('-1 second'),
+        );
+
+        $link->revoke();
+        $link->reactivate();
+
+        $this->assertNull($link->getRevokedAt());
+        $this->assertFalse($link->isActive());
+    }
 }

--- a/tests/Web/ShareLinkReactivateWebTest.php
+++ b/tests/Web/ShareLinkReactivateWebTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Share;
+use App\Entity\ShareLink;
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class ShareLinkReactivateWebTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM share_links');
+        $conn->executeStatement('DELETE FROM shares');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createOwner(string $email = 'reactivate-owner@example.com'): User
+    {
+        return $this->createWebUser($email, 'secret123', 'Owner');
+    }
+
+    private function createRevokedLink(User $owner, ?\DateTimeImmutable $revokedAt = null): ShareLink
+    {
+        $folder = new Folder('Docs', $owner);
+        $folder->setVisibility(Folder::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($folder);
+        $file = new File('photo.jpg', 'image/jpeg', 1024, 'test/photo.jpg', $folder, $owner);
+        $file->setVisibility(File::VISIBILITY_LINK_ALLOWED);
+        $this->em->persist($file);
+        $this->em->flush();
+
+        $link = new ShareLink(
+            $owner,
+            Share::RESOURCE_FILE,
+            $file->getId(),
+            bin2hex(random_bytes(16)),
+            hash('sha256', 'valid-plain-token'),
+            new \DateTimeImmutable('+7 days'),
+        );
+        $link->revoke();
+
+        if ($revokedAt !== null) {
+            $ref = new \ReflectionProperty(ShareLink::class, 'revokedAt');
+            $ref->setValue($link, $revokedAt);
+        }
+
+        $this->em->persist($link);
+        $this->em->flush();
+
+        return $link;
+    }
+
+    private function reactivateToken(): string
+    {
+        $crawler = $this->client->request('GET', '/partages');
+
+        return $crawler->filter('form[action*="/share-link-reactivate"] input[name="_token"]')->first()->attr('value');
+    }
+
+    public function testOwnerCanReactivateTheirRevokedLink(): void
+    {
+        $owner = $this->createOwner();
+        $link = $this->createRevokedLink($owner);
+        $this->loginAs('reactivate-owner@example.com');
+
+        $token = $this->reactivateToken();
+
+        $this->client->request('POST', '/share-link-reactivate', [
+            '_token' => $token,
+            'linkId' => $link->getId()->toRfc4122(),
+        ]);
+
+        $this->assertResponseRedirects('/partages');
+
+        $this->em->clear();
+        $reloaded = $this->em->getRepository(ShareLink::class)->find($link->getId());
+        $this->assertTrue($reloaded->isActive());
+    }
+
+    public function testNonOwnerCannotReactivateLink(): void
+    {
+        $owner = $this->createOwner();
+        $link = $this->createRevokedLink($owner);
+        $attacker = $this->createWebUser('reactivate-attacker@example.com', 'secret123', 'Attacker');
+        $this->createRevokedLink($attacker);
+
+        $this->loginAs('reactivate-attacker@example.com');
+        $token = $this->reactivateToken();
+
+        $this->client->request('POST', '/share-link-reactivate', [
+            '_token' => $token,
+            'linkId' => $link->getId()->toRfc4122(),
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testSharesPageShowsReactivateButtonAndPurgeCountdownForRevokedLink(): void
+    {
+        $owner = $this->createOwner();
+        // Révoqué il y a 5 jours : il reste 25 jours avant purge (fenêtre 30j).
+        $this->createRevokedLink($owner, new \DateTimeImmutable('-5 days'));
+        $this->loginAs('reactivate-owner@example.com');
+
+        $crawler = $this->client->request('GET', '/partages');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('form[action*="/share-link-reactivate"] button[type="submit"]');
+        $row = $crawler->filter('[data-testid="share-link-row"]')->text();
+        $this->assertStringContainsString('supprimé', $row);
+        $this->assertStringContainsString('25 j', $row);
+    }
+}


### PR DESCRIPTION
## Résumé

- `ShareLink::reactivate()` + `daysUntilPurge()` : soft-delete conservé, réactivation possible pendant une fenêtre de grâce de 30 jours (symétrique à `Share::reactivate()`, #305)
- `ShareLinkRepository::deleteRevokedOlderThan()` : purge physique des liens révoqués depuis plus de `ShareLink::PURGE_AFTER_DAYS`
- UI `/partages` : bouton « Réactiver » sur un lien révoqué + décompte « sera supprimé automatiquement dans X j »
- `app:share-link:purge-revoked` : commande console à brancher sur un cron SSH (comme le worker Messenger) pour la purge périodique

Closes #244

## Test plan

- [x] `./vendor/bin/phpunit` — suite complète verte (864/864)
- [x] TDD RED → GREEN sur chaque composant (entité, repository, controller, commande)
- [ ] Ajouter la commande `app:share-link:purge-revoked` au crontab de chaque instance déployée (hors scope de cette PR)