### PR TITLE
✨ feat(GalleryLightbox): zoom sur une photo au clic

### DIFF
--- a/assets/controllers/Zoom.js
+++ b/assets/controllers/Zoom.js
@@ -1,0 +1,46 @@
+const MIN_SCALE = 1;
+const MAX_SCALE = 3;
+const STEP = 1;
+
+/**
+ * État de zoom d'une image (échelle + point d'origine du zoom). Ne connaît
+ * rien du DOM ni de Stimulus : reçoit juste les coordonnées du clic (en %).
+ * Séparé du contrôleur pour rester testable isolément et éviter un
+ * contrôleur monolithique (même approche que Slideshow.js).
+ *
+ * Zoom par paliers : chaque clic avance d'un cran (1x → 2x → 3x), un clic
+ * au-delà du plafond revient à l'état non zoomé. L'origine reste celle du
+ * premier clic tant qu'on progresse dans les paliers — seul un retour à 1x
+ * (ou reset()) la recentre, pour éviter un "saut" visuel à chaque clic.
+ */
+export default class Zoom {
+    constructor() {
+        this.scale = MIN_SCALE;
+        this.originX = 50;
+        this.originY = 50;
+    }
+
+    get isZoomed() {
+        return this.scale > MIN_SCALE;
+    }
+
+    /* originX/originY en % (0-100), position du clic relative à l'image. */
+    toggleAt(originX, originY) {
+        if (!this.isZoomed) {
+            this.originX = originX;
+            this.originY = originY;
+        }
+
+        this.scale += STEP;
+
+        if (this.scale > MAX_SCALE) {
+            this.reset();
+        }
+    }
+
+    reset() {
+        this.scale = MIN_SCALE;
+        this.originX = 50;
+        this.originY = 50;
+    }
+}

--- a/assets/controllers/gallery_lightbox_controller.js
+++ b/assets/controllers/gallery_lightbox_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus';
 import Slideshow from './Slideshow.js';
+import Zoom from './Zoom.js';
 import { buildExifPanelHtml } from '../js/exif-panel.js';
 
 /* Lightbox de la galerie médias : ouvre le média en plein écran au clic
@@ -15,6 +16,7 @@ export default class extends Controller {
         this.current = -1;
         this.slideshowPausedForVideo = false;
         this.slideshow = new Slideshow(() => this.next());
+        this.zoom = new Zoom();
 
         this.links.forEach((el, index) => {
             el.addEventListener('click', (e) => {
@@ -45,6 +47,8 @@ export default class extends Controller {
         if (index < 0 || index >= this.srcs.length) return;
         this.videoTarget.pause();
         this.current = index;
+        this.zoom.reset();
+        this.applyZoom();
 
         const isVideo = this.mediaTypes[this.current] === 'video';
 
@@ -91,6 +95,21 @@ export default class extends Controller {
 
         this.infoTarget.innerHTML = html;
         this.infoTarget.hidden = html === '';
+    }
+
+    toggleZoom(event) {
+        const rect = this.imgTarget.getBoundingClientRect();
+        const originX = ((event.clientX - rect.left) / rect.width) * 100;
+        const originY = ((event.clientY - rect.top) / rect.height) * 100;
+
+        this.zoom.toggleAt(originX, originY);
+        this.applyZoom();
+    }
+
+    applyZoom() {
+        this.imgTarget.style.transformOrigin = `${this.zoom.originX}% ${this.zoom.originY}%`;
+        this.imgTarget.style.transform = `scale(${this.zoom.scale})`;
+        this.imgTarget.classList.toggle('hc-lightbox-img--zoomed', this.zoom.isZoomed);
     }
 
     prev() {

--- a/assets/styles/gallery.css
+++ b/assets/styles/gallery.css
@@ -303,6 +303,15 @@
   object-fit: contain;
 }
 
+.hc-lightbox-img {
+  cursor: zoom-in;
+  transition: transform 0.2s ease;
+}
+
+.hc-lightbox-img--zoomed {
+  cursor: zoom-out;
+}
+
 .hc-lightbox-close {
   position: absolute;
   top: 1.5rem;

--- a/assets/tests/gallery-lightbox-zoom.test.js
+++ b/assets/tests/gallery-lightbox-zoom.test.js
@@ -1,0 +1,122 @@
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { Application } from '@hotwired/stimulus';
+import GalleryLightboxController from '../controllers/gallery_lightbox_controller.js';
+
+/**
+ * Zoom de la lightbox galerie : clic sur la photo pour zoomer sur le point
+ * cliqué, clics suivants pour zoomer davantage (paliers), jusqu'à un
+ * plafond puis retour à l'état non zoomé. Reset au changement de photo.
+ * L'origine du zoom reste celle du premier clic tant qu'on reste zoomé.
+ */
+describe('gallery-lightbox zoom', () => {
+  let application;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <a data-lightbox data-media-type="photo" data-full-src="/a.jpg"></a>
+      <a data-lightbox data-media-type="photo" data-full-src="/b.jpg"></a>
+      <a data-lightbox data-media-type="video" data-full-src="/c.mp4"></a>
+      <div id="lightbox" data-controller="gallery-lightbox">
+        <button data-gallery-lightbox-target="prev" data-action="gallery-lightbox#prev"></button>
+        <img data-gallery-lightbox-target="img" data-action="click->gallery-lightbox#toggleZoom">
+        <video data-gallery-lightbox-target="video" controls></video>
+        <button data-gallery-lightbox-target="next" data-action="gallery-lightbox#next"></button>
+        <button data-gallery-lightbox-target="play" data-action="gallery-lightbox#togglePlay"></button>
+      </div>
+    `;
+
+    HTMLMediaElement.prototype.play = jest.fn();
+    HTMLMediaElement.prototype.pause = jest.fn();
+
+    application = Application.start();
+    application.register('gallery-lightbox', GalleryLightboxController);
+  });
+
+  afterEach(() => {
+    application.stop();
+  });
+
+  function getController() {
+    const el = document.getElementById('lightbox');
+    return application.getControllerForElementAndIdentifier(el, 'gallery-lightbox');
+  }
+
+  function clickAt(imgTarget, clientX, clientY, width = 200, height = 100) {
+    imgTarget.getBoundingClientRect = () => ({
+      left: 0, top: 0, width, height, right: width, bottom: height,
+    });
+    imgTarget.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX, clientY }));
+  }
+
+  test('clicking the image zooms in centered on the clicked point', () => {
+    const controller = getController();
+    controller.show(0);
+
+    clickAt(controller.imgTarget, 150, 75);
+
+    expect(controller.imgTarget.style.transform).toBe('scale(2)');
+    expect(controller.imgTarget.style.transformOrigin).toBe('75% 75%');
+  });
+
+  test('clicking again while zoomed increases the zoom level further', () => {
+    const controller = getController();
+    controller.show(0);
+
+    clickAt(controller.imgTarget, 150, 75);
+    expect(controller.imgTarget.style.transform).toBe('scale(2)');
+
+    clickAt(controller.imgTarget, 10, 10);
+
+    expect(controller.imgTarget.style.transform).toBe('scale(3)');
+  });
+
+  test('clicking again while zoomed keeps the origin of the first click', () => {
+    const controller = getController();
+    controller.show(0);
+
+    clickAt(controller.imgTarget, 150, 75);
+    expect(controller.imgTarget.style.transformOrigin).toBe('75% 75%');
+
+    clickAt(controller.imgTarget, 10, 10);
+
+    expect(controller.imgTarget.style.transformOrigin).toBe('75% 75%');
+  });
+
+  test('clicking past the max zoom level resets to the unzoomed state', () => {
+    const controller = getController();
+    controller.show(0);
+
+    clickAt(controller.imgTarget, 150, 75); // scale 2
+    clickAt(controller.imgTarget, 10, 10); // scale 3 (max)
+    clickAt(controller.imgTarget, 10, 10); // back to unzoomed
+
+    expect(controller.imgTarget.style.transform).toBe('scale(1)');
+    expect(controller.imgTarget.style.transformOrigin).toBe('50% 50%');
+  });
+
+  test('changing photo resets the zoom', () => {
+    const controller = getController();
+    controller.show(0);
+    clickAt(controller.imgTarget, 150, 75);
+    expect(controller.imgTarget.style.transform).toBe('scale(2)');
+
+    controller.show(1);
+
+    expect(controller.imgTarget.style.transform).toBe('scale(1)');
+    expect(controller.imgTarget.style.transformOrigin).toBe('50% 50%');
+  });
+
+  test('adds a zoomed class while zoomed and removes it once back to unzoomed', () => {
+    const controller = getController();
+    controller.show(0);
+
+    clickAt(controller.imgTarget, 150, 75); // scale 2
+    expect(controller.imgTarget.classList.contains('hc-lightbox-img--zoomed')).toBe(true);
+
+    clickAt(controller.imgTarget, 150, 75); // scale 3 (max)
+    expect(controller.imgTarget.classList.contains('hc-lightbox-img--zoomed')).toBe(true);
+
+    clickAt(controller.imgTarget, 150, 75); // back to unzoomed
+    expect(controller.imgTarget.classList.contains('hc-lightbox-img--zoomed')).toBe(false);
+  });
+});

--- a/templates/components/GalleryLightbox.html.twig
+++ b/templates/components/GalleryLightbox.html.twig
@@ -4,7 +4,7 @@
   <button data-gallery-lightbox-target="prev" data-action="gallery-lightbox#prev" class="hc-lightbox-nav hc-lightbox-nav--prev" aria-label="Média précédent">
     <svg width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="15 6 9 12 15 18"/></svg>
   </button>
-  <img data-gallery-lightbox-target="img" src="" alt="" class="hc-lightbox-img">
+  <img data-gallery-lightbox-target="img" data-action="click->gallery-lightbox#toggleZoom" src="" alt="" class="hc-lightbox-img">
   <video data-gallery-lightbox-target="video" controls class="hc-lightbox-video" style="display: none;"></video>
   <button data-gallery-lightbox-target="next" data-action="gallery-lightbox#next" class="hc-lightbox-nav hc-lightbox-nav--next" aria-label="Média suivant">
     <svg width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="9 6 15 12 9 18"/></svg>


### PR DESCRIPTION
## Résumé

- `Zoom.js` (nouveau) : classe pure (sans DOM ni Stimulus), sur le modèle de `Slideshow.js` — état de zoom par paliers (1x→2x→3x), origine centrée sur le point cliqué, testable isolément
- Clic sur la photo dans la lightbox : zoome davantage à chaque clic (jusqu'à 3x), origine fixée au premier clic tant qu'on progresse dans les paliers, un clic au-delà du plafond revient à l'état non zoomé
- Reset automatique du zoom au changement de photo
- Pas de pixelisation : la lightbox charge déjà le fichier source pleine résolution (`app_media_full`), le zoom CSS agrandit l'affichage, pas les pixels

Scope volontairement réduit suite à clarifications : pas de zoom clavier (`+`/`-`), zoom uniquement au clic — le point de zoom est celui du clic, pas un suivi continu de la souris façon loupe.

Closes #243

## Test plan

- [x] TDD RED → GREEN sur `Zoom.js` (6 tests) + suite Jest complète (200/200, aucune régression)
- [x] Vérification manuelle en navigateur (Playwright) : clic zoome sur le point précis, clics successifs augmentent le zoom en gardant l'origine, clic au-delà du plafond dézoome, changement de photo reset le zoom