### PR TITLE
✨ feat(Zoom): curseur reflétant le palier de zoom atteignable

### DIFF
--- a/assets/controllers/Zoom.js
+++ b/assets/controllers/Zoom.js
@@ -24,6 +24,11 @@ export default class Zoom {
         return this.scale > MIN_SCALE;
     }
 
+    /* Palier maximum atteint : le prochain clic réinitialisera au lieu de zoomer davantage. */
+    get isAtMaxZoom() {
+        return this.scale >= MAX_SCALE;
+    }
+
     /* originX/originY en % (0-100), position du clic relative à l'image. */
     toggleAt(originX, originY) {
         if (!this.isZoomed) {

--- a/assets/controllers/gallery_lightbox_controller.js
+++ b/assets/controllers/gallery_lightbox_controller.js
@@ -110,6 +110,7 @@ export default class extends Controller {
         this.imgTarget.style.transformOrigin = `${this.zoom.originX}% ${this.zoom.originY}%`;
         this.imgTarget.style.transform = `scale(${this.zoom.scale})`;
         this.imgTarget.classList.toggle('hc-lightbox-img--zoomed', this.zoom.isZoomed);
+        this.imgTarget.classList.toggle('hc-lightbox-img--max-zoomed', this.zoom.isAtMaxZoom);
     }
 
     prev() {

--- a/assets/styles/gallery.css
+++ b/assets/styles/gallery.css
@@ -308,7 +308,10 @@
   transition: transform 0.2s ease;
 }
 
-.hc-lightbox-img--zoomed {
+/* Palier maximum atteint : le prochain clic réinitialise, pas de zoom
+   supplémentaire possible — le curseur bascule sur zoom-out pour le signaler.
+   Zoomé mais pas encore au max : curseur zoom-in inchangé (on peut zoomer plus). */
+.hc-lightbox-img--max-zoomed {
   cursor: zoom-out;
 }
 

--- a/assets/tests/gallery-lightbox-zoom.test.js
+++ b/assets/tests/gallery-lightbox-zoom.test.js
@@ -119,4 +119,22 @@ describe('gallery-lightbox zoom', () => {
     clickAt(controller.imgTarget, 150, 75); // back to unzoomed
     expect(controller.imgTarget.classList.contains('hc-lightbox-img--zoomed')).toBe(false);
   });
+
+  test('cursor affordance reflects whether the next click zooms further or resets', () => {
+    const controller = getController();
+    controller.show(0);
+
+    // Pas zoomé : curseur zoom-in (état par défaut, pas de classe max)
+    expect(controller.imgTarget.classList.contains('hc-lightbox-img--max-zoomed')).toBe(false);
+
+    clickAt(controller.imgTarget, 150, 75); // scale 2, on peut encore zoomer
+    expect(controller.imgTarget.classList.contains('hc-lightbox-img--zoomed')).toBe(true);
+    expect(controller.imgTarget.classList.contains('hc-lightbox-img--max-zoomed')).toBe(false);
+
+    clickAt(controller.imgTarget, 150, 75); // scale 3 (max), le prochain clic va réinitialiser
+    expect(controller.imgTarget.classList.contains('hc-lightbox-img--max-zoomed')).toBe(true);
+
+    clickAt(controller.imgTarget, 150, 75); // retour à l'état non zoomé
+    expect(controller.imgTarget.classList.contains('hc-lightbox-img--max-zoomed')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Résumé

- `Zoom.js` : nouvelle propriété `isAtMaxZoom` (scale au plafond, le prochain clic va réinitialiser)
- Curseur zoom-in tant qu'on peut encore avancer d'un palier, zoom-out uniquement au dernier palier (classe `hc-lightbox-img--max-zoomed`)

Suite à #243 : le curseur restait `zoom-out` dès le premier clic zoomé, sans distinguer "on peut zoomer plus" de "le prochain clic réinitialise".

## Test plan

- [x] TDD RED → GREEN (1 nouveau test), suite Jest complète 201/201, aucune régression