### PR TITLE
🔧 fix(deploy-all.sh): builder et envoyer le CSS Tailwind à jour

### DIFF
--- a/bin/deploy-all.sh
+++ b/bin/deploy-all.sh
@@ -168,6 +168,17 @@ ENVEOF
 
     else
         # ── Mise à jour ───────────────────────────────────────────────────────
+        # Tailwind build en local puis scp : le binaire natif ne tourne pas de
+        # façon fiable sur o2switch (mutualisé), cf. bin/deploy.sh.
+        info "Build Tailwind (local)…"
+        php bin/console tailwind:build --minify
+
+        info "Envoi de app.built.css…"
+        ssh ${SSH_KEY_OPTS} -p "${SSH_PORT}" "${SSH_USER}@${SSH_HOST}" "mkdir -p ${DEPLOY_PATH}/var/tailwind"
+        scp ${SSH_KEY_OPTS} -P "${SSH_PORT}" \
+            var/tailwind/app.built.css \
+            "${SSH_USER}@${SSH_HOST}:${DEPLOY_PATH}/var/tailwind/app.built.css"
+
         info "git pull + composer + cache + migrations + assets…"
         if ssh ${SSH_KEY_OPTS} -p "${SSH_PORT}" "${SSH_USER}@${SSH_HOST}" "
             set -e


### PR DESCRIPTION
## Résumé

- `bin/deploy-all.sh` (mode mise à jour) ne régénérait jamais `var/tailwind/app.built.css` — gitignoré, jamais mis à jour par `git pull` côté serveur, donc le CSS servi en prod restait figé depuis le premier `--init` de chaque instance
- Bug découvert concrètement via le curseur de zoom (#243) : figé en prod sur l'ancienne règle `.hc-lightbox-img--zoomed`, alors que le code source déployé (JS + template) était bien à jour
- Reprend le pattern déjà en place dans `bin/deploy.sh` : build Tailwind en local (le binaire natif ne tourne pas de façon fiable sur le mutualisé o2switch) puis `scp` du résultat avant le `git pull` distant

## Test plan

- [x] Vérifié en local : rebuild `composer build-assets`, le curseur de zoom (`+`/`-`) reflète maintenant correctement chaque palier (testé via Playwright)
- [x] Suite Jest (201/201) et PHPUnit inchangées, aucune régression
- [ ] Après merge, prochain `bin/deploy-all.sh` doit régénérer et pousser le CSS à jour sur les 7 instances