### PR TITLE
Renommer un album

### DIFF
--- a/.github/avancement.md
+++ b/.github/avancement.md
@@ -6,6 +6,12 @@
 
 ---
 
+## ✅ Renommer un album (2026-07-22, #242)
+
+- `AlbumService::rename()` ajouté (délègue à `Album::setName()`, déjà existant avec trim/validation), route `POST /albums/{id}/rename` sur `AlbumWebController` (CSRF + `AlbumVoter::VIEW`, cohérent avec les autres actions d'édition d'album accessibles aux guests en partage write — `add-media`, `reorder`, `set-cover`, `import`).
+- UI : bouton crayon dans l'en-tête de `album_detail.html.twig`, `prompt()` natif pour saisir le nouveau nom (cohérent avec `confirm()` déjà utilisé pour la suppression), form POST classique + redirect — pas de nouveau contrôleur Stimulus.
+- TDD complet : `tests/Service/AlbumServiceTest.php` (happy path, nom vide/whitespace, non-save si invalide) + `tests/Web/AlbumRenameWebTest.php` (redirect, persistance, CSRF invalide → 403, autre utilisateur → 403, nom vide → 400).
+
 ## ✅ Déploiement, gestion des instances (2026-07-20)
 
 - **7ᵉ instance `baptiste.lenouvel.me`** ajoutée : base MySQL créée via `uapi Mysql create_database`/`set_privileges_on_database` (utilisateur partagé `ron2cuba_ronan`, comme les 6 autres instances — divergence constatée entre la doc `deploiement.md` qui documentait un utilisateur par instance et la pratique réelle), premier déploiement manuel, premier compte créé, puis ajoutée à `.deploy-targets` pour les mises à jour futures.

--- a/src/Controller/Web/AlbumWebController.php
+++ b/src/Controller/Web/AlbumWebController.php
@@ -170,6 +170,29 @@ final class AlbumWebController extends AbstractController
         return $this->redirectToRoute('app_album_detail', ['id' => $album->getId()->toRfc4122()]);
     }
 
+    #[Route('/albums/{id}/rename', name: 'app_album_rename', methods: ['POST'], requirements: ['id' => '[0-9a-f\-]+'])]
+    public function rename(string $id, Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('album-rename', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Jeton CSRF invalide.');
+        }
+
+        $album = $this->albumRepository->findById(Uuid::fromString($id))
+            ?? throw $this->createNotFoundException('Album introuvable.');
+
+        $this->denyAccessUnlessGranted(AlbumVoter::VIEW, $album);
+
+        $name = (string) $request->request->get('name', '');
+
+        try {
+            $this->albumService->rename($album, $name);
+        } catch (\InvalidArgumentException $e) {
+            throw new BadRequestHttpException($e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_album_detail', ['id' => $album->getId()->toRfc4122()]);
+    }
+
     #[Route('/albums/{id}', name: 'app_album_detail', requirements: ['id' => '[0-9a-f\-]+'])]
     public function detail(string $id): Response
     {

--- a/src/Interface/AlbumServiceInterface.php
+++ b/src/Interface/AlbumServiceInterface.php
@@ -29,4 +29,9 @@ interface AlbumServiceInterface
     public function reorder(Album $album, array $mediaIds): void;
 
     public function delete(Album $album): void;
+
+    /**
+     * @throws \InvalidArgumentException si le nom est vide ou uniquement des espaces
+     */
+    public function rename(Album $album, string $name): void;
 }

--- a/src/Service/AlbumService.php
+++ b/src/Service/AlbumService.php
@@ -110,6 +110,17 @@ final class AlbumService implements AlbumServiceInterface
     }
 
     /**
+     * Renomme un album.
+     *
+     * @throws \InvalidArgumentException si le nom est vide ou uniquement des espaces
+     */
+    public function rename(Album $album, string $name): void
+    {
+        $album->setName($name);
+        $this->repository->save($album);
+    }
+
+    /**
      * Supprime un album (et ses associations album_media — pas les médias eux-mêmes).
      */
     public function delete(Album $album): void

--- a/templates/web/album_detail.html.twig
+++ b/templates/web/album_detail.html.twig
@@ -22,6 +22,16 @@
     </div>
 
     <div class="flex gap-2" role="group" aria-label="Actions de l'album">
+      <form method="post" action="{{ path('app_album_rename', {id: album.id}) }}"
+            onsubmit="const n = window.prompt('Nouveau nom de l\'album', {{ album.name|json_encode|raw }}); if (!n || n === {{ album.name|json_encode|raw }}) return false; this.querySelector('input[name=name]').value = n;">
+        <input type="hidden" name="_token" value="{{ csrf_token('album-rename') }}">
+        <input type="hidden" name="name" value="">
+        <button type="submit" class="hc-item-action flex items-center justify-center w-11 h-11 rounded-md"
+                style="border:1px solid var(--hc-border); color: var(--hc-accent);"
+                title="Renommer l'album" aria-label="Renommer l'album">
+          {{ icons.icon('pencil', 20) }}
+        </button>
+      </form>
       <a href="{{ path('app_gallery', {album: album.id}) }}"
          class="hc-item-action flex items-center justify-center w-11 h-11 rounded-md"
          style="border:1px solid var(--hc-border); color: var(--hc-accent); text-decoration:none;"

--- a/tests/Service/AlbumServiceTest.php
+++ b/tests/Service/AlbumServiceTest.php
@@ -217,6 +217,56 @@ final class AlbumServiceTest extends TestCase
         $this->service->setCoverMedia($album, $foreignMedia);
     }
 
+    // --- rename() ---
+
+    public function testRenameSetsNewNameAndSaves(): void
+    {
+        $user  = $this->makeUser();
+        $album = new Album('Ancien nom', $user);
+
+        $this->repository
+            ->expects($this->once())
+            ->method('save')
+            ->with($album);
+
+        $this->service->rename($album, 'Nouveau nom');
+
+        $this->assertSame('Nouveau nom', $album->getName());
+    }
+
+    public function testRenameWithEmptyNameThrowsException(): void
+    {
+        $user  = $this->makeUser();
+        $album = new Album('Ancien nom', $user);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->service->rename($album, '');
+    }
+
+    public function testRenameWithWhitespaceOnlyNameThrowsException(): void
+    {
+        $user  = $this->makeUser();
+        $album = new Album('Ancien nom', $user);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->service->rename($album, '   ');
+    }
+
+    public function testRenameDoesNotSaveWhenNameInvalid(): void
+    {
+        $user  = $this->makeUser();
+        $album = new Album('Ancien nom', $user);
+
+        $this->repository->expects($this->never())->method('save');
+
+        try {
+            $this->service->rename($album, '');
+        } catch (\InvalidArgumentException) {
+        }
+    }
+
     // --- delete() ---
 
     public function testDeleteCallsRepositoryRemove(): void

--- a/tests/Web/AlbumRenameWebTest.php
+++ b/tests/Web/AlbumRenameWebTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\Album;
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Tests fonctionnels — renommage d'un album (#242).
+ * TDD RED → GREEN.
+ */
+final class AlbumRenameWebTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM album_media');
+        $conn->executeStatement('DELETE FROM albums');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createUser(string $email = 'rename@example.com'): User
+    {
+        return $this->createWebUser($email, 'secret123', 'Rename User');
+    }
+
+    private function createAlbum(User $user, string $name = 'Mon Album'): Album
+    {
+        $album = new Album($name, $user);
+        $this->em->persist($album);
+        $this->em->flush();
+
+        return $album;
+    }
+
+    private function renameToken(string $albumId): string
+    {
+        $crawler = $this->client->request('GET', '/albums/' . $albumId);
+
+        return $crawler->filter('form[action*="/rename"] input[name="_token"]')->first()->attr('value');
+    }
+
+    public function testRenameRedirectsToAlbumDetail(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $this->loginAs('rename@example.com');
+        $token = $this->renameToken($album->getId()->toRfc4122());
+
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/rename', [
+            '_token' => $token,
+            'name'   => 'Vacances 2026',
+        ]);
+
+        $this->assertResponseRedirects('/albums/' . $album->getId()->toRfc4122());
+    }
+
+    public function testRenamePersistsNewNameOnNextPageLoad(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $this->loginAs('rename@example.com');
+        $token = $this->renameToken($album->getId()->toRfc4122());
+
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/rename', [
+            '_token' => $token,
+            'name'   => 'Vacances 2026',
+        ]);
+
+        $crawler = $this->client->request('GET', '/albums/' . $album->getId()->toRfc4122());
+        $this->assertStringContainsString('Vacances 2026', $crawler->filter('body')->text());
+    }
+
+    public function testRenameWithoutCsrfTokenThrows403(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $this->loginAs('rename@example.com');
+
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/rename', [
+            'name' => 'Vacances 2026',
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testRenameForbiddenForOtherUser(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob   = $this->createUser('bob@example.com');
+        $album = $this->createAlbum($alice, 'Album Alice');
+        $this->em->flush();
+        $bobAlbum = $this->createAlbum($bob, 'Album Bob');
+        $this->em->flush();
+
+        $this->loginAs('bob@example.com');
+        $token = $this->renameToken($bobAlbum->getId()->toRfc4122());
+
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/rename', [
+            '_token' => $token,
+            'name'   => 'Piraté',
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testRenameWithEmptyNameReturns400(): void
+    {
+        $user  = $this->createUser();
+        $album = $this->createAlbum($user, 'Vacances');
+        $this->loginAs('rename@example.com');
+        $token = $this->renameToken($album->getId()->toRfc4122());
+
+        $this->client->request('POST', '/albums/' . $album->getId()->toRfc4122() . '/rename', [
+            '_token' => $token,
+            'name'   => '',
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+}


### PR DESCRIPTION
## Summary
- Ajoute `AlbumService::rename()` (délègue à `Album::setName()` déjà existant, trim/validation).
- Nouvelle route `POST /albums/{id}/rename` sur `AlbumWebController` (CSRF + `AlbumVoter::VIEW`, cohérent avec les autres actions d'édition d'album : add-media, reorder, set-cover, import).
- UI : bouton crayon dans l'en-tête de `album_detail.html.twig`, saisie via `prompt()` natif.

## Test plan
- [x] `./vendor/bin/phpunit --filter AlbumServiceTest` — happy path, nom vide/whitespace, non-save si invalide
- [x] `./vendor/bin/phpunit --filter AlbumRenameWebTest` — redirect, persistance, CSRF invalide → 403, autre utilisateur → 403, nom vide → 400
- [x] Suite complète verte (hors `TailwindBuildTest`, échec préexistant sur `main`, environnement local sans build Tailwind)

Closes #242