### PR TITLE
Couvrir toute la carte avec la vignette d'album

### DIFF
--- a/assets/styles/albums.css
+++ b/assets/styles/albums.css
@@ -18,10 +18,35 @@
   cursor: pointer;
 }
 
+.hc-album-card-thumb-wrap {
+  position: relative;
+  width: calc(100% + 32px);
+  height: 220px;
+  margin: -16px -16px -16px;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
 .hc-album-card-thumb {
   width: 100%;
-  aspect-ratio: 1;
+  height: 100%;
   object-fit: cover;
-  border-radius: 0.5rem;
   display: block;
+}
+
+/* Overlay dégradé + texte incrusté — noir/blanc fixes (indépendants du thème
+   clair/sombre de l'UI) : c'est un habillage de photo, pas un fond d'interface. */
+.hc-album-card-thumb-overlay {
+  position: absolute;
+  inset: auto 0 0 0;
+  padding: 24px 12px 10px;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.85), rgba(0, 0, 0, 0) 100%);
+}
+
+.hc-album-card-thumb-overlay .hc-item-name {
+  color: #fff;
+}
+
+.hc-album-card-thumb-overlay .hc-item-meta {
+  color: rgba(255, 255, 255, 0.75);
 }

--- a/templates/web/albums.html.twig
+++ b/templates/web/albums.html.twig
@@ -40,17 +40,25 @@
         {% set coverMedia = album.resolveCoverMedia() %}
         <a href="{{ path('app_album_detail', {id: album.id}) }}" data-testid="album-card" class="hc-item-card hc-album-card">
           {% if coverMedia %}
-            <img src="{{ path('app_media_thumbnail', {id: coverMedia.id}) }}"
-                 alt="" loading="lazy"
-                 class="hc-album-card-thumb mb-2"
-                 data-testid="album-card-thumbnail">
+            <div class="hc-album-card-thumb-wrap">
+              <img src="{{ path('app_media_thumbnail', {id: coverMedia.id}) }}"
+                   alt="" loading="lazy"
+                   class="hc-album-card-thumb"
+                   data-testid="album-card-thumbnail">
+              <div class="hc-album-card-thumb-overlay">
+                <div class="hc-item-name">{{ album.name }}</div>
+                <div class="hc-item-meta">
+                  {{ album.medias|length }} média{{ album.medias|length != 1 ? 's' : '' }}
+                </div>
+              </div>
+            </div>
           {% else %}
             <div class="hc-item-icon hc-item-icon--folder mb-2">{{ icons.icon('album', 16) }}</div>
+            <div class="hc-item-name">{{ album.name }}</div>
+            <div class="hc-item-meta">
+              {{ album.medias|length }} média{{ album.medias|length != 1 ? 's' : '' }}
+            </div>
           {% endif %}
-          <div class="hc-item-name">{{ album.name }}</div>
-          <div class="hc-item-meta">
-            {{ album.medias|length }} média{{ album.medias|length != 1 ? 's' : '' }}
-          </div>
         </a>
       {% endfor %}
     </div>


### PR DESCRIPTION
## Summary
- La vignette de couverture d'album ne couvrait pas toute la largeur/le haut de sa carte (padding de `.hc-item-card` visible autour de l'image).
- La vignette occupe désormais toute la carte (220px de haut, bords touchés), avec le nom et le nombre de médias incrustés en overlay (dégradé noir → transparent, texte blanc fixe indépendant du thème clair/sombre).

## Test plan
- [x] Vérifié visuellement en local (`/albums`) : vignette pleine largeur/hauteur, texte lisible en overlay, cas sans couverture (icône + texte classique) inchangé