### PR TITLE
Éviter l'OOM Killer pendant composer install au déploiement

### DIFF
--- a/.claude/deploiement.md
+++ b/.claude/deploiement.md
@@ -60,7 +60,9 @@ bash bin/deploy-all.sh
 ```
 
 Chaîne exécutée sur chaque serveur :
-`git pull` → `composer install --no-dev` → `cache:clear` → `migrations` → `asset-map:compile`
+`git pull` → `composer install --no-dev --no-scripts` → `cache:clear` → `assets:install` → `importmap:install` → `migrations` → `asset-map:compile`
+
+`--no-scripts` évite l'exécution des scripts post-install Symfony Flex (`auto-scripts` : `cache:clear`, `assets:install %PUBLIC_DIR%`, `importmap:install`) pendant `composer install` — ajouté suite à des `Killed` (OOM) répétés sur le mutualisé o2switch pendant cette phase (2026-07-22), alors que le `composer install` en lui-même n'était pas en cause (`Nothing to install, update or remove`, dépendances déjà à jour). Les 3 commandes sautées sont rappelées explicitement ensuite, une par une (moins gourmand qu'un `composer install` qui les enchaîne toutes en une seule fois) — ne pas en retirer une sans vérifier qu'elle est bien redondante ailleurs dans le script.
 
 ### Premier déploiement de toutes les instances
 

--- a/bin/deploy-all.sh
+++ b/bin/deploy-all.sh
@@ -149,8 +149,10 @@ JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
 JWT_PASSPHRASE=${JWT_PASSPHRASE}
 MAILER_DSN=${MAILER_DSN_PRESET:-null://null}
 ENVEOF
-            ${COMPOSER_BIN} install --no-interaction --prefer-dist --no-progress --no-dev
+            ${COMPOSER_BIN} install --no-interaction --prefer-dist --no-progress --no-dev --no-scripts
             ${PHP_BIN} bin/console cache:clear --env=prod
+            ${PHP_BIN} bin/console assets:install public --env=prod
+            ${PHP_BIN} bin/console importmap:install --env=prod
             ${PHP_BIN} bin/console doctrine:migrations:migrate --no-interaction --env=prod
             ${PHP_BIN} bin/console lexik:jwt:generate-keypair --skip-if-exists --env=prod
             ${PHP_BIN} bin/console asset-map:compile
@@ -185,8 +187,10 @@ ENVEOF
             cd ${DEPLOY_PATH}
             mkdir -p var/log
             git pull origin ${GIT_BRANCH}
-            ${COMPOSER_BIN} install --no-interaction --prefer-dist --no-progress --no-dev
+            ${COMPOSER_BIN} install --no-interaction --prefer-dist --no-progress --no-dev --no-scripts
             ${PHP_BIN} bin/console cache:clear --env=prod
+            ${PHP_BIN} bin/console assets:install public --env=prod
+            ${PHP_BIN} bin/console importmap:install --env=prod
             ${PHP_BIN} bin/console doctrine:migrations:migrate --no-interaction --env=prod
             ${PHP_BIN} bin/console asset-map:compile
             echo '<!-- Deployed: '$(date '+%Y-%m-%d %H:%M:%S')' -->' > templates/deploy-info.html.twig


### PR DESCRIPTION
## Summary
- `composer install --no-dev` tuait (Killed, OOM) sur le mutualisé o2switch pendant les scripts post-install Symfony Flex (`auto-scripts` : `cache:clear`, `assets:install`, `importmap:install`), rencontré sur `yannick.lenouvel.me` et `damien.lenouvel.me` le 2026-07-22 — la résolution des dépendances elle-même n'était pas en cause (`Nothing to install, update or remove`).
- `--no-scripts` ajouté à `composer install` (mode init et mise à jour), les 3 commandes sautées (`cache:clear`, `assets:install public`, `importmap:install`) rappelées explicitement une par une ensuite — réduit le pic mémoire en évitant qu'elles s'enchaînent toutes dans le même process composer.
- `.claude/deploiement.md` mis à jour en conséquence.

## Test plan
- [x] `bash -n bin/deploy-all.sh` — syntaxe valide
- [x] Déploiement réel testé en conditions réelles avant ce fix : 5/7 instances OK, 2 échecs OOM (yannick, damien), retentées avec succès après coupure VPN — ce fix vise à éviter la récidive
- [ ] À confirmer au prochain déploiement réel que `--no-scripts` réduit bien le pic mémoire sur les instances concernées