### PR TITLE
✨ feat(MediaViewerModal): viewer image/vidéo dans « Mes fichiers »

### DIFF
--- a/.github/avancement.md
+++ b/.github/avancement.md
@@ -1,10 +1,20 @@
 # 📋 Avancement — HomeCloud API
 
-> Dernière mise à jour : 2026-07-20
+> Dernière mise à jour : 2026-07-22
 
-> **Status git :** `main` — dernière PR mergée #298 (`fix/changelog-markdown-heading-artifact`)
+> **Status git :** `main` — dernière PR mergée #298 (`fix/changelog-markdown-heading-artifact`) ; PR #331 en revue (`feat/311-media-viewer`)
 
 ---
+
+## 🚧 Viewer média (image/vidéo) dans « Mes fichiers » (2026-07-22, #311, PR #331 en revue)
+
+- Bouton "Visualiser" ajouté sur les cartes fichier image/vidéo dans `FileCard.html.twig`, sur le même modèle que le bouton PDF existant (#241) — `data-testid="view-media-btn-{id}"`, distinction image/vidéo par `mimeType`.
+- Nouvelle modale `MediaViewerModal.html.twig` (`<img>`/`<video controls>` natifs, un seul élément affiché à la fois selon le type) et `assets/js/media-viewer-modal.js` — même helper `Modal` (`assets/js/modal.js`) que les autres modales du projet.
+- Fermeture vidéo : `pause()` + `removeAttribute('src')` + `load()`, pas seulement `about:blank` (suffisant pour l'iframe PDF mais insuffisant pour un `<video>` — sans ça le flux continue de streamer/décoder en arrière-plan).
+- Aucune modification serveur : réutilise `app_file_view`, déjà générique (`DISPOSITION_INLINE` + ownership) depuis #241.
+- TDD : `testViewButtonAppearsOnlyForImageAndVideoFiles` (`ExplorerPageTest.php`) + `media-viewer-modal.test.js` (4 cas Jest : ouverture image, ouverture vidéo, fermeture propre, bascule image↔vidéo).
+- Reste à faire avant merge : vérification manuelle en navigateur (desktop + mobile), non effectuée en local (pas de compte de test disponible sur le serveur dev) — prévue sur `ronan.lenouvel.me` après merge.
+- **Ticket #310 découvert en parallèle** (viewer PDF en plein écran, demandé par l'utilisateur, déjà ouvert) : la modale PDF actuelle est contrainte (`max-w-5xl max-h-[90vh]`), pas encore traité.
 
 ## ✅ Renommer un album (2026-07-22, #242)
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ php bin/console app:create-user 'vous@example.com' 'Prénom' '<mot-de-passe>'
 
 ```bash
 composer dev-check            # build des assets + suite PHP complète
-./vendor/bin/phpunit          # 832 tests
-npm test                      # 25 suites Jest
+./vendor/bin/phpunit          # 874 tests
+npm test                      # 27 suites Jest
 ```
 
 La méthodologie TDD est suivie sans exception : le test échoue d'abord, sinon il ne prouve rien. Voir [.claude/tdd.md](.claude/tdd.md).

--- a/assets/app.js
+++ b/assets/app.js
@@ -8,6 +8,7 @@ import './js/folder-children.js';
 import './js/rename.js';
 import './js/delete-folder-modal.js';
 import './js/pdf-viewer-modal.js';
+import './js/media-viewer-modal.js';
 import { initUploadModal } from './js/upload-modal.js';
 import { initExplorerDrop } from './js/explorer-drop.js';
 

--- a/assets/js/media-viewer-modal.js
+++ b/assets/js/media-viewer-modal.js
@@ -1,0 +1,59 @@
+import { Modal } from './modal.js';
+
+/**
+ * Ouvre la modale de visualisation image/vidéo.
+ *
+ * Aucune librairie JS de rendu : l'élément <img>/<video> pointe vers
+ * app_file_view, qui sert le fichier en Content-Disposition: inline.
+ *
+ * @param {string} viewUrl URL de app_file_view pour ce fichier
+ * @param {string} fileName Nom affiché dans la modale
+ * @param {'image'|'video'} type Type de média à afficher
+ */
+window.openMediaViewerModal = function (viewUrl, fileName, type) {
+	const img = document.getElementById('media-viewer-image');
+	const video = document.getElementById('media-viewer-video');
+	const nameEl = document.getElementById('media-viewer-name');
+
+	if (!img || !video) return;
+
+	if (type === 'video') {
+		video.src = viewUrl;
+		video.classList.remove('hidden');
+		img.classList.add('hidden');
+		img.src = '';
+	} else {
+		img.src = viewUrl;
+		img.classList.remove('hidden');
+		video.classList.add('hidden');
+		video.pause();
+		video.removeAttribute('src');
+		video.load();
+	}
+
+	if (nameEl) {
+		nameEl.textContent = fileName || 'ce fichier';
+	}
+
+	Modal.open('media-viewer-modal');
+};
+
+window.closeMediaViewerModal = function () {
+	const img = document.getElementById('media-viewer-image');
+	const video = document.getElementById('media-viewer-video');
+
+	if (video) {
+		// pause() seul ne suffit pas : sans removeAttribute('src') + load(), le
+		// navigateur continue de streamer/décoder la vidéo en arrière-plan.
+		video.pause();
+		video.removeAttribute('src');
+		video.load();
+		video.classList.add('hidden');
+	}
+	if (img) {
+		img.src = '';
+		img.classList.add('hidden');
+	}
+
+	Modal.close('media-viewer-modal');
+};

--- a/assets/tests/media-viewer-modal.test.js
+++ b/assets/tests/media-viewer-modal.test.js
@@ -1,0 +1,78 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+jest.unstable_mockModule('../js/modal.js', () => ({
+  Modal: {
+    open: jest.fn(),
+    close: jest.fn(),
+  },
+}));
+
+const { Modal } = await import('../js/modal.js');
+await import('../js/media-viewer-modal.js');
+
+describe('media-viewer-modal behavior', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    window.HTMLMediaElement.prototype.pause = jest.fn();
+    window.HTMLMediaElement.prototype.load = jest.fn();
+
+    document.body.innerHTML = `
+      <span id="media-viewer-name"></span>
+      <img id="media-viewer-image" class="hidden" src="">
+      <video id="media-viewer-video" class="hidden" src=""></video>
+    `;
+  });
+
+  test('opening an image shows the img element and hides the video', () => {
+    window.openMediaViewerModal('/files/abc-123/view', 'photo.jpg', 'image');
+
+    const img = document.getElementById('media-viewer-image');
+    const video = document.getElementById('media-viewer-video');
+
+    expect(img.src).toContain('/files/abc-123/view');
+    expect(img.classList.contains('hidden')).toBe(false);
+    expect(video.classList.contains('hidden')).toBe(true);
+    expect(document.getElementById('media-viewer-name').textContent).toBe('photo.jpg');
+    expect(Modal.open).toHaveBeenCalledWith('media-viewer-modal');
+  });
+
+  test('opening a video shows the video element and hides the img', () => {
+    window.openMediaViewerModal('/files/def-456/view', 'clip.mp4', 'video');
+
+    const img = document.getElementById('media-viewer-image');
+    const video = document.getElementById('media-viewer-video');
+
+    expect(video.src).toContain('/files/def-456/view');
+    expect(video.classList.contains('hidden')).toBe(false);
+    expect(img.classList.contains('hidden')).toBe(true);
+    expect(document.getElementById('media-viewer-name').textContent).toBe('clip.mp4');
+    expect(Modal.open).toHaveBeenCalledWith('media-viewer-modal');
+  });
+
+  test('closing after a video stops playback and releases the source', () => {
+    window.openMediaViewerModal('/files/def-456/view', 'clip.mp4', 'video');
+    window.closeMediaViewerModal();
+
+    const video = document.getElementById('media-viewer-video');
+    const img = document.getElementById('media-viewer-image');
+
+    expect(video.pause).toHaveBeenCalled();
+    expect(video.load).toHaveBeenCalled();
+    expect(video.hasAttribute('src')).toBe(false);
+    expect(video.classList.contains('hidden')).toBe(true);
+    expect(img.getAttribute('src')).toBe('');
+    expect(Modal.close).toHaveBeenCalledWith('media-viewer-modal');
+  });
+
+  test('switching from video to image hides the previously shown video', () => {
+    window.openMediaViewerModal('/files/def-456/view', 'clip.mp4', 'video');
+    window.openMediaViewerModal('/files/abc-123/view', 'photo.jpg', 'image');
+
+    const img = document.getElementById('media-viewer-image');
+    const video = document.getElementById('media-viewer-video');
+
+    expect(img.classList.contains('hidden')).toBe(false);
+    expect(video.classList.contains('hidden')).toBe(true);
+  });
+});

--- a/docs/features.md
+++ b/docs/features.md
@@ -11,7 +11,7 @@ Un explorateur classique — arborescence de dossiers, upload par glisser-dépos
 - **Upload** : plusieurs fichiers à la fois, avec barre de progression et file d'attente. Le dépôt d'un fichier sur un dossier l'y range directement — y compris un dossier entier glissé depuis le disque, avec sa structure.
 - **Types acceptés** : tout, sauf les exécutables (liste noire, pas liste blanche — un cloud personnel n'a pas à deviner ce que vous stockez). Les fichiers dangereux (scripts, HTML/SVG actifs, PDF avec JavaScript embarqué) sont neutralisés plutôt que rejetés : conservés, mais non exécutables/prévisualisables.
 - **Organisation** : dossiers imbriqués, un nom de fichier étant unique au sein d'un même dossier.
-- **Visualisation** : un PDF s'ouvre directement dans le navigateur, sans téléchargement préalable.
+- **Visualisation** : un PDF, une image ou une vidéo s'ouvre directement dans le navigateur, sans téléchargement préalable — affichage à la demande, un fichier à la fois (pas de navigation vers les fichiers voisins).
 - **Téléchargement** : un dossier entier se télécharge en une seule archive ZIP.
 
 ## Galerie

--- a/templates/components/FileCard.html.twig
+++ b/templates/components/FileCard.html.twig
@@ -44,6 +44,12 @@
 			        class="hc-item-action hc-item-action--move"
 			        title="Visualiser {{ item.originalName ?? item.name|e('html') }}"
 			        onclick="openPdfViewerModal('{{ path('app_file_view', { id: item.id }) }}', '{{ (item.originalName ?? item.name)|e('js') }}')"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></button>
+			{% elseif item.mimeType starts with 'image/' or item.mimeType starts with 'video/' %}
+			<button type="button"
+			        data-testid="view-media-btn-{{ item.id }}"
+			        class="hc-item-action hc-item-action--move"
+			        title="Visualiser {{ item.originalName ?? item.name|e('html') }}"
+			        onclick="openMediaViewerModal('{{ path('app_file_view', { id: item.id }) }}', '{{ (item.originalName ?? item.name)|e('js') }}', '{{ item.mimeType starts with 'image/' ? 'image' : 'video' }}')"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></button>
 			{% endif %}
 			<a href="{{ path('app_file_download', { id: item.id }) }}"
 			   class="hc-item-action hc-item-action--move"

--- a/templates/components/MediaViewerModal.html.twig
+++ b/templates/components/MediaViewerModal.html.twig
@@ -1,0 +1,30 @@
+{# Modale de visualisation image/vidéo — lecteurs natifs du navigateur #}
+<div id="media-viewer-modal"
+     class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+     tabindex="-1"
+     aria-modal="true"
+     role="dialog">
+  <div class="bg-white/10 backdrop-blur-2xl border border-white/20 rounded-3xl
+              shadow-2xl p-4 w-full h-full max-w-5xl max-h-[90vh] mx-4 flex flex-col">
+
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="text-white text-lg font-semibold truncate" id="media-viewer-name">ce fichier</h2>
+      <button type="button"
+              onclick="closeMediaViewerModal()"
+              class="px-3 py-1.5 rounded-xl text-white/70 hover:text-white hover:bg-white/10 transition-colors">
+        Fermer
+      </button>
+    </div>
+
+    <div class="flex-1 flex items-center justify-center overflow-hidden">
+      <img id="media-viewer-image"
+           src=""
+           alt=""
+           class="hidden max-w-full max-h-full object-contain rounded-xl">
+      <video id="media-viewer-video"
+             controls
+             class="hidden max-w-full max-h-full rounded-xl"></video>
+    </div>
+
+  </div>
+</div>

--- a/templates/web/layout.html.twig
+++ b/templates/web/layout.html.twig
@@ -4,6 +4,7 @@
 <twig:DeleteFolderModal />
 <twig:RenameModal />
 <twig:PdfViewerModal />
+<twig:MediaViewerModal />
 
 {% endblock %}
 {% extends 'base.html.twig' %}

--- a/tests/Web/ExplorerPageTest.php
+++ b/tests/Web/ExplorerPageTest.php
@@ -419,4 +419,49 @@ final class ExplorerPageTest extends WebTestCase
             'Un fichier non-PDF ne doit pas avoir de bouton "Visualiser"'
         );
     }
+
+    public function testViewButtonAppearsOnlyForImageAndVideoFiles(): void
+    {
+        $user = $this->createUser();
+
+        $folder = new Folder('Médias', $user);
+        $this->em->persist($folder);
+        $this->em->flush();
+        $folderId = $folder->getId()->toRfc4122();
+
+        $this->login();
+        $token = $this->uploadCsrfToken();
+
+        $imgTmp = tempnam(sys_get_temp_dir(), 'hc_img_') . '.jpg';
+        file_put_contents($imgTmp, 'fake jpeg content');
+        $imgUpload = new UploadedFile($imgTmp, 'photo.jpg', 'image/jpeg', null, true);
+        $this->client->request('POST', '/files/upload', ['folder_id' => $folderId, '_token' => $token], ['file' => $imgUpload]);
+        $this->client->followRedirect();
+
+        $videoTmp = tempnam(sys_get_temp_dir(), 'hc_vid_') . '.mp4';
+        file_put_contents($videoTmp, 'fake mp4 content');
+        $videoUpload = new UploadedFile($videoTmp, 'clip.mp4', 'video/mp4', null, true);
+        $this->client->request('POST', '/files/upload', ['folder_id' => $folderId, '_token' => $this->uploadCsrfToken()], ['file' => $videoUpload]);
+        $this->client->followRedirect();
+
+        $txtTmp = tempnam(sys_get_temp_dir(), 'hc_txt_') . '.txt';
+        file_put_contents($txtTmp, 'contenu texte');
+        $txtUpload = new UploadedFile($txtTmp, 'notes.txt', 'text/plain', null, true);
+        $this->client->request('POST', '/files/upload', ['folder_id' => $folderId, '_token' => $this->uploadCsrfToken()], ['file' => $txtUpload]);
+        $crawler = $this->client->followRedirect();
+
+        $this->assertResponseIsSuccessful();
+
+        $imgFile = $this->em->getRepository(\App\Entity\File::class)->findOneBy(['originalName' => 'photo.jpg']);
+        $videoFile = $this->em->getRepository(\App\Entity\File::class)->findOneBy(['originalName' => 'clip.mp4']);
+        $txtFile = $this->em->getRepository(\App\Entity\File::class)->findOneBy(['originalName' => 'notes.txt']);
+
+        $this->assertSelectorExists('[data-testid="view-media-btn-' . $imgFile->getId()->toRfc4122() . '"]');
+        $this->assertSelectorExists('[data-testid="view-media-btn-' . $videoFile->getId()->toRfc4122() . '"]');
+        $this->assertCount(
+            0,
+            $crawler->filter('[data-testid="view-media-btn-' . $txtFile->getId()->toRfc4122() . '"]'),
+            'Un fichier texte ne doit pas avoir de bouton de visualisation média'
+        );
+    }
 }


### PR DESCRIPTION
## Résumé

- Ajoute un bouton "Visualiser" sur les cartes fichier image/vidéo dans « Mes fichiers » (sur le modèle du bouton PDF existant, #241)
- Nouvelle modale `MediaViewerModal` (`<img>`/`<video>` natifs, un seul affiché à la fois selon le type)
- Fermeture propre de la vidéo (`pause()` + `removeAttribute('src')` + `load()`) pour ne pas laisser le flux tourner en arrière-plan
- Réutilise la route `app_file_view` existante (déjà générique, aucune modification serveur)

Closes #311

## Plan de test

- [x] `./vendor/bin/phpunit` — 874 tests OK (dont nouveau `testViewButtonAppearsOnlyForImageAndVideoFiles`)
- [x] `npm test` — 116 tests OK (dont nouveau `media-viewer-modal.test.js`, 4 cas : ouverture image, ouverture vidéo, fermeture propre, bascule image↔vidéo)
- [ ] Vérification manuelle en navigateur (desktop + mobile) — à faire après merge/déploiement sur ronan.lenouvel.me