### PR TITLE
✨ feat(viewer): PDF/média en plein écran (#310)

### DIFF
--- a/.github/avancement.md
+++ b/.github/avancement.md
@@ -6,6 +6,14 @@
 
 ---
 
+## ✅ Viewer PDF/média en plein écran (2026-07-22, #310, branche `feat/310-pdf-viewer-fullscreen`)
+
+- `PdfViewerModal.html.twig` et `MediaViewerModal.html.twig` (#311) occupaient l'écran avec une marge (`max-w-5xl max-h-[90vh] mx-4 rounded-3xl`) au lieu du plein écran attendu par #310. Classes remplacées par `w-screen h-screen` (coins arrondis retirés, plus de sens à 100vw/100vh).
+- Mécanisme d'ouverture/fermeture inchangé : `Modal.open/close` (`assets/js/modal.js`), pas de migration vers le WebComponent `<hc-modal>` (son `sizeMap.fullscreen` n'est pas branché sur ces deux modales et changer l'API aurait cassé les tests JS existants).
+- Vérifié visuellement via Playwright (desktop 1440px + mobile 375px, PDF et image) : plein écran conforme, sans marge, header/bouton Fermer bien positionnés.
+- **Limitation découverte, non corrigée dans ce ticket** : ni la touche Échap ni le clic sur l'overlay ne ferment ces deux modales (seul le bouton "Fermer" fonctionne) — absent de `modal.js`/`pdf-viewer-modal.js`/`media-viewer-modal.js` **avant** ce changement, donc pas une régression introduite ici. Le ticket #310 présupposait à tort que ce mécanisme existait déjà. Décision : rester dans le scope CSS (XS), traiter Échap/overlay dans un ticket séparé si souhaité.
+- Aucun test unitaire modifié : changement purement CSS, `testViewButtonAppearsOnlyForPdfFiles` et `pdf-viewer-modal.test.js` restent verts sans modification (filet de non-régression).
+
 ## ✅ Viewer média (image/vidéo) dans « Mes fichiers » (2026-07-22, #311, PR #331)
 
 - Bouton "Visualiser" ajouté sur les cartes fichier image/vidéo dans `FileCard.html.twig`, sur le même modèle que le bouton PDF existant (#241) — `data-testid="view-media-btn-{id}"`, distinction image/vidéo par `mimeType`.

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ php.ini
 # Métadonnées de provenance générées par Windows/WSL
 *:Zone.Identifier
 .secrets.*
+.prompt

--- a/templates/components/MediaViewerModal.html.twig
+++ b/templates/components/MediaViewerModal.html.twig
@@ -4,8 +4,8 @@
      tabindex="-1"
      aria-modal="true"
      role="dialog">
-  <div class="bg-white/10 backdrop-blur-2xl border border-white/20 rounded-3xl
-              shadow-2xl p-4 w-full h-full max-w-5xl max-h-[90vh] mx-4 flex flex-col">
+  <div class="bg-white/10 backdrop-blur-2xl border border-white/20
+              shadow-2xl p-4 w-screen h-screen flex flex-col">
 
     <div class="flex items-center justify-between mb-3">
       <h2 class="text-white text-lg font-semibold truncate" id="media-viewer-name">ce fichier</h2>

--- a/templates/components/PdfViewerModal.html.twig
+++ b/templates/components/PdfViewerModal.html.twig
@@ -4,8 +4,8 @@
      tabindex="-1"
      aria-modal="true"
      role="dialog">
-  <div class="bg-white/10 backdrop-blur-2xl border border-white/20 rounded-3xl
-              shadow-2xl p-4 w-full h-full max-w-5xl max-h-[90vh] mx-4 flex flex-col">
+  <div class="bg-white/10 backdrop-blur-2xl border border-white/20
+              shadow-2xl p-4 w-screen h-screen flex flex-col">
 
     <div class="flex items-center justify-between mb-3">
       <h2 class="text-white text-lg font-semibold truncate" id="pdf-viewer-name">ce document</h2>


### PR DESCRIPTION
## Summary
- `PdfViewerModal.html.twig` et `MediaViewerModal.html.twig` passent en plein écran (`w-screen h-screen`, coins arrondis retirés) au lieu de `max-w-5xl max-h-[90vh] mx-4 rounded-3xl`
- Mécanisme d'ouverture/fermeture inchangé (`Modal`/`assets/js/modal.js`) — pas de migration vers le WebComponent `<hc-modal>`, non branché sur ces deux modales
- Vérifié visuellement (Playwright, desktop 1440px + mobile 375px) : plein écran conforme, header/bouton Fermer bien positionnés

Closes #310

## Limitation connue (hors scope, non introduite par ce changement)
Ni Échap ni le clic sur l'overlay ne ferment ces deux modales — absent de `modal.js`/`pdf-viewer-modal.js`/`media-viewer-modal.js` **avant** ce changement (seul le bouton "Fermer" fonctionnait déjà). Le ticket #310 présupposait à tort que ce mécanisme existait. Décision prise avec l'utilisateur : rester dans le scope CSS (XS), traiter Échap/overlay séparément si souhaité.

## Test plan
- [x] `./vendor/bin/phpunit --filter testViewButtonAppearsOnlyForPdfFiles` — OK
- [x] `npm test -- pdf-viewer-modal media-viewer` — 6 tests OK
- [x] Vérification visuelle desktop (1440px) PDF + image — OK
- [x] Vérification visuelle mobile (375px) PDF + image — OK
- [x] Bouton "Fermer" fonctionnel sur les deux modales