### PR TITLE
✨ feat: vignettes médias — images et vidéos (#312)

### DIFF
--- a/.github/avancement.md
+++ b/.github/avancement.md
@@ -6,6 +6,21 @@
 
 ---
 
+## 🚧 Vignettes médias — explorer et vidéo (en cours, #312, branche `feat/312-vignettes-medias`)
+
+- **Volet 1** ✅ : afficher les vignettes images dans « Mes fichiers ». Images existantes, câblage pur.
+  - `ExplorerController` charge les Media en une requête, indexés par File.id (pas de N+1).
+  - `FileCard.html.twig` affiche `<img>` quand `Media.thumbnailPath` existe, sinon icône SVG.
+  - CSS : `.hc-item-icon--thumb` + `.hc-item-thumb-img` (cover-fit, 320×320px).
+  - Test : `testFileCardShowsThumbnailWhenMediaExists` (vérifie l'affichage réel).
+- **Volet 2** 🚧 : extraire et afficher les vignettes vidéo. Volet 1 mergeable seul ; volet 2 en dev.
+  - Exceptions + interfaces + VO : `VideoThumbnailExtractionException`, `VideoThumbnailExtractorInterface`, `ExtractedVideoFrame`.
+  - Implémentation : `VideoDurationProbe` (ffprobe), `VideoFrameGrabber` (ffmpeg), `FfmpegVideoThumbnailExtractor` (façade, 50 %).
+  - Câblage `ThumbnailService` : branchement vidéo en premier (avant RAW), dégradation gracieuse.
+  - `MediaProcessor` : génère la vignette pour les vidéos, pas d'EXIF.
+  - Tests : `ThumbnailServiceVideoTest` (4 cas), `VideoThumbnailExtractorWiringTest`, `FfmpegVideoThumbnailExtractorTest` (skipé, ffmpeg absent localement).
+  - Déploiement : script `bin/install-ffmpeg.sh` (idempotent, non-bloquant), intégré à `deploy-all.sh`/`deploy.sh` ; ffmpeg ajouté au CI (`.github/workflows/ci.yml`).
+
 ## ✅ Viewer PDF/média en plein écran (2026-07-22, #310, branche `feat/310-pdf-viewer-fullscreen`)
 
 - `PdfViewerModal.html.twig` et `MediaViewerModal.html.twig` (#311) occupaient l'écran avec une marge (`max-w-5xl max-h-[90vh] mx-4 rounded-3xl`) au lieu du plein écran attendu par #310. Classes remplacées par `w-screen h-screen` (coins arrondis retirés, plus de sens à 100vw/100vh).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: 📥 Checkout code
         uses: actions/checkout@v5
 
+      - name: 🎬 Ensure ffmpeg
+        run: ffmpeg -version >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y ffmpeg; }
+
       - name: 🐘 Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/assets/styles/explorer.css
+++ b/assets/styles/explorer.css
@@ -44,6 +44,13 @@
 .hc-item-icon--folder { background: var(--hc-indigo-soft); color: var(--hc-indigo); }
 .hc-item-icon--image  { background: var(--hc-accent-soft); color: var(--hc-accent); }
 .hc-item-icon--doc    { background: var(--hc-green-soft);  color: var(--hc-green); }
+.hc-item-icon--thumb  { background: var(--hc-surface-2); overflow: hidden; padding: 0; }
+
+.hc-item-thumb-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
 
 /* ── Pastille icône import (dropzone) — variante large ── */
 .hc-item-icon--lg {

--- a/bin/deploy-all.sh
+++ b/bin/deploy-all.sh
@@ -150,6 +150,7 @@ JWT_PASSPHRASE=${JWT_PASSPHRASE}
 MAILER_DSN=${MAILER_DSN_PRESET:-null://null}
 ENVEOF
             ${COMPOSER_BIN} install --no-interaction --prefer-dist --no-progress --no-dev --no-scripts
+            bash bin/install-ffmpeg.sh || echo '⚠ ffmpeg non installé — vignettes vidéo indisponibles'
             ${PHP_BIN} bin/console cache:clear --env=prod
             ${PHP_BIN} bin/console assets:install public --env=prod
             ${PHP_BIN} bin/console importmap:install --env=prod
@@ -188,6 +189,7 @@ ENVEOF
             mkdir -p var/log
             git pull origin ${GIT_BRANCH}
             ${COMPOSER_BIN} install --no-interaction --prefer-dist --no-progress --no-dev --no-scripts
+            bash bin/install-ffmpeg.sh || echo '⚠ ffmpeg non installé — vignettes vidéo indisponibles'
             ${PHP_BIN} bin/console cache:clear --env=prod
             ${PHP_BIN} bin/console assets:install public --env=prod
             ${PHP_BIN} bin/console importmap:install --env=prod

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -200,7 +200,7 @@ if [[ "$UPDATE_MODE" == true ]]; then
     { error "❌ Erreur lors du déploiement."; exit 1; }
 else
     info "Mode primo déploiement : clonage repo + setup"
-    ssh ${SSH_KEY_OPTS} -p "${SSH_PORT}" "${SSH_USER}@${SSH_HOST}" "mkdir -p ${DEPLOY_PATH} && cd ${DEPLOY_PATH} && git clone ${GIT_REPO} . && composer install --no-interaction --prefer-dist --no-progress" && \
+    ssh ${SSH_KEY_OPTS} -p "${SSH_PORT}" "${SSH_USER}@${SSH_HOST}" "mkdir -p ${DEPLOY_PATH} && cd ${DEPLOY_PATH} && git clone ${GIT_REPO} . && composer install --no-interaction --prefer-dist --no-progress && bash bin/install-ffmpeg.sh || echo '⚠ ffmpeg non installé — vignettes vidéo indisponibles'" && \
     success "✅ Déploiement réussi !" || \
     { error "❌ Erreur lors du déploiement."; exit 1; }
 fi

--- a/bin/install-ffmpeg.sh
+++ b/bin/install-ffmpeg.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Installe un binaire ffmpeg/ffprobe statique dans var/bin/.
+# o2switch est mutualisé : pas de root, pas d'apt. Idempotent et non bloquant —
+# une absence de ffmpeg dégrade la vignette vidéo, elle ne casse pas le déploiement.
+set -uo pipefail   # PAS -e : on veut sortir 0 même en cas d'échec
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN_DIR="${PROJECT_DIR}/var/bin"
+
+mkdir -p "${BIN_DIR}"
+
+# Vérification idempotence : si ffmpeg est déjà en place et fonctionnel, terminer
+if [[ -x "${BIN_DIR}/ffmpeg" ]] && "${BIN_DIR}/ffmpeg" -version >/dev/null 2>&1; then
+    echo "✅ ffmpeg déjà installé"
+    exit 0
+fi
+
+echo "⏳ Téléchargement de ffmpeg (John Van Sickle build statique)..."
+
+DOWNLOAD_URL="https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz"
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf '${TEMP_DIR}'" EXIT
+
+cd "${TEMP_DIR}"
+
+# Téléchargement
+if ! curl -fsSL -o ffmpeg.tar.xz "${DOWNLOAD_URL}"; then
+    echo "⚠ Impossible de télécharger ffmpeg — vignettes vidéo indisponibles"
+    exit 0
+fi
+
+# Extraction
+if ! tar -xf ffmpeg.tar.xz; then
+    echo "⚠ Impossible d'extraire ffmpeg — vignettes vidéo indisponibles"
+    exit 0
+fi
+
+# Localiser les binaires
+FFMPEG=$(find . -name ffmpeg -type f | head -1)
+FFPROBE=$(find . -name ffprobe -type f | head -1)
+
+if [[ -z "$FFMPEG" ]] || [[ -z "$FFPROBE" ]]; then
+    echo "⚠ ffmpeg/ffprobe introuvables dans l'archive — vignettes vidéo indisponibles"
+    exit 0
+fi
+
+# Installation
+cp "${FFMPEG}" "${BIN_DIR}/ffmpeg"
+cp "${FFPROBE}" "${BIN_DIR}/ffprobe"
+chmod +x "${BIN_DIR}/ffmpeg" "${BIN_DIR}/ffprobe"
+
+if "${BIN_DIR}/ffmpeg" -version >/dev/null 2>&1; then
+    echo "✅ ffmpeg installé avec succès"
+    exit 0
+else
+    echo "⚠ ffmpeg installé mais non fonctionnel — vignettes vidéo indisponibles"
+    exit 0
+fi

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -9,6 +9,8 @@
 parameters:
     app.storage_dir: '%kernel.project_dir%/var/storage'
     app.encryption_key: '%env(base64:APP_ENCRYPTION_KEY)%'
+    app.ffmpeg_bin: '%kernel.project_dir%/var/bin/ffmpeg'
+    app.ffprobe_bin: '%kernel.project_dir%/var/bin/ffprobe'
     # Seuil de taille cumulée (octets) au-delà duquel un lot d'upload est déporté
     # au worker Messenger plutôt que traité immédiatement. 250 Mo par défaut,
     # ajustable sans redéploiement de code.
@@ -132,11 +134,24 @@ services:
 
     App\Interface\ExifThumbnailExtractorInterface: '@App\Service\ExifThumbnailExtractor'
 
+    App\Service\Video\VideoDurationProbe:
+        arguments:
+            $ffprobeBin: '%app.ffprobe_bin%'
+
+    App\Service\Video\VideoFrameGrabber:
+        arguments:
+            $ffmpegBin: '%app.ffmpeg_bin%'
+
+    App\Interface\VideoDurationProbeInterface: '@App\Service\Video\VideoDurationProbe'
+    App\Interface\VideoFrameGrabberInterface: '@App\Service\Video\VideoFrameGrabber'
+    App\Interface\VideoThumbnailExtractorInterface: '@App\Service\Video\FfmpegVideoThumbnailExtractor'
+
     App\Service\ThumbnailService:
         arguments:
             $storageDir: '%app.storage_dir%'
             $rawPreviewExtractor: '@RonanLenouvel\RawPreviewExtractor\RawPreviewExtractorInterface'
             $exifThumbnailExtractor: '@App\Interface\ExifThumbnailExtractorInterface'
+            $videoThumbnailExtractor: '@App\Interface\VideoThumbnailExtractorInterface'
 
     App\EventListener\SecurityHeadersListener:
         arguments:

--- a/src/Controller/Web/ExplorerController.php
+++ b/src/Controller/Web/ExplorerController.php
@@ -7,6 +7,7 @@ namespace App\Controller\Web;
 use App\Entity\User;
 use App\Repository\FileRepository;
 use App\Repository\FolderRepository;
+use App\Repository\MediaRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -24,6 +25,7 @@ final class ExplorerController extends AbstractController
     public function __construct(
         private readonly FolderRepository $folderRepository,
         private readonly FileRepository $fileRepository,
+        private readonly MediaRepository $mediaRepository,
     ) {}
 
     #[Route('/explorer', name: 'app_explorer')]
@@ -53,6 +55,15 @@ final class ExplorerController extends AbstractController
             ? $this->fileRepository->findBy(['folder' => $currentFolder, 'owner' => $user], ['createdAt' => 'DESC'])
             : [];
 
+        // Vignettes : les Media du dossier en une requête, indexés par id de File.
+        // La relation Media→File est unidirectionnelle — sans cette map, Twig n'a
+        // aucun chemin vers la vignette. Une relation inverse lazy provoquerait un
+        // N+1 sur chaque carte de la grille.
+        $mediasByFileId = [];
+        foreach ($this->mediaRepository->findBy(['file' => $files]) as $media) {
+            $mediasByFileId[$media->getFile()->getId()->toRfc4122()] = $media;
+        }
+
         // Construit le chemin complet (ancêtres) pour la breadcrumb
         $breadcrumbFolders = [];
         $ancestor = $currentFolder;
@@ -76,6 +87,7 @@ final class ExplorerController extends AbstractController
             'breadcrumbSegments' => $breadcrumbSegments,
             'folders'            => $folders,
             'files'              => $files,
+            'mediasByFileId'     => $mediasByFileId,
             'folderCount'        => count($folders),
             'fileCount'          => count($files),
             'sidebarTree'        => $this->folderRepository->findAllAsTree($user, $currentFolder),

--- a/src/Exception/Video/FrameExtractionFailedException.php
+++ b/src/Exception/Video/FrameExtractionFailedException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception\Video;
+
+final class FrameExtractionFailedException extends \RuntimeException implements VideoThumbnailExtractionException
+{
+}

--- a/src/Exception/Video/VideoThumbnailExtractionException.php
+++ b/src/Exception/Video/VideoThumbnailExtractionException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception\Video;
+
+/**
+ * Contrat racine des échecs d'extraction de frame vidéo.
+ *
+ * Toute exception levée par un extracteur vidéo l'implémente : un `catch`
+ * unique suffit à dégrader gracieusement, sans énumérer les cas — même
+ * principe que RawPreviewExtractorException dans le package RAW.
+ */
+interface VideoThumbnailExtractionException extends \Throwable
+{
+}

--- a/src/Exception/Video/VideoToolUnavailableException.php
+++ b/src/Exception/Video/VideoToolUnavailableException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception\Video;
+
+final class VideoToolUnavailableException extends \RuntimeException implements VideoThumbnailExtractionException
+{
+}

--- a/src/Interface/VideoDurationProbeInterface.php
+++ b/src/Interface/VideoDurationProbeInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+interface VideoDurationProbeInterface
+{
+    /**
+     * Obtient la durée d'une vidéo en secondes.
+     *
+     * Ne lève jamais : une durée inconnue n'est pas un échec, l'appelant
+     * retombe sur la première frame.
+     */
+    public function durationInSeconds(string $absolutePath): ?float;
+}

--- a/src/Interface/VideoFrameGrabberInterface.php
+++ b/src/Interface/VideoFrameGrabberInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Exception\Video\VideoThumbnailExtractionException;
+use App\Service\Video\ExtractedVideoFrame;
+
+interface VideoFrameGrabberInterface
+{
+    /**
+     * Extrait une frame vidéo à un instant donné.
+     *
+     * Ne décide pas quel instant : c'est la façade qui calcule le seek.
+     *
+     * @throws VideoThumbnailExtractionException
+     */
+    public function grab(string $absolutePath, float $seekSeconds): ExtractedVideoFrame;
+}

--- a/src/Interface/VideoThumbnailExtractorInterface.php
+++ b/src/Interface/VideoThumbnailExtractorInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Exception\Video\VideoThumbnailExtractionException;
+use App\Service\Video\ExtractedVideoFrame;
+
+interface VideoThumbnailExtractorInterface
+{
+    /**
+     * Ce fichier est-il une vidéo dont on sait extraire une frame ?
+     *
+     * Décidé sur l'extension seule, sans toucher au disque — formats retenus
+     * par #312 : mp4, webm, mov. Ne lève jamais.
+     */
+    public function supports(string $absolutePath): bool;
+
+    /**
+     * Extrait une frame représentative de la vidéo.
+     *
+     * @throws VideoThumbnailExtractionException toute cause d'échec ; un
+     *                                           `catch` unique suffit
+     */
+    public function extract(string $absolutePath): ExtractedVideoFrame;
+}

--- a/src/Service/MediaProcessor.php
+++ b/src/Service/MediaProcessor.php
@@ -83,6 +83,11 @@ final class MediaProcessor implements MediaProcessorInterface
             // (ThumbnailService gère le RAW et son orientation).
             $thumb = $this->thumbnailService->generate($absolutePath);
             $media->setThumbnailPath($thumb);
+        } elseif ($mediaType === 'video') {
+            // Pas d'EXIF pour la vidéo (hors scope #312) : seulement la vignette.
+            // ThumbnailService détecte lui-même la source, MediaProcessor ignore ffmpeg.
+            $absolutePath = $this->storageService->getAbsolutePath($file->getPath());
+            $media->setThumbnailPath($this->thumbnailService->generate($absolutePath));
         }
 
         $this->em->persist($media);

--- a/src/Service/ThumbnailService.php
+++ b/src/Service/ThumbnailService.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Exception\Video\VideoThumbnailExtractionException;
 use App\Interface\ExifThumbnailExtractorInterface;
+use App\Interface\VideoThumbnailExtractorInterface;
 use RonanLenouvel\RawPreviewExtractor\Exception\RawPreviewExtractorException;
 use RonanLenouvel\RawPreviewExtractor\Orientation;
 use RonanLenouvel\RawPreviewExtractor\RawPreviewExtractorInterface;
@@ -35,6 +37,7 @@ class ThumbnailService
         private readonly string $storageDir,
         private readonly RawPreviewExtractorInterface $rawPreviewExtractor,
         private readonly ExifThumbnailExtractorInterface $exifThumbnailExtractor,
+        private readonly VideoThumbnailExtractorInterface $videoThumbnailExtractor,
     ) {}
 
     /**
@@ -50,6 +53,10 @@ class ThumbnailService
         }
 
         try {
+            if ($this->videoThumbnailExtractor->supports($absolutePath)) {
+                return $this->generateFromVideo($absolutePath);
+            }
+
             if ($this->rawPreviewExtractor->supports($absolutePath)) {
                 return $this->generateFromRaw($absolutePath);
             }
@@ -84,6 +91,31 @@ class ThumbnailService
         }
 
         return $this->resizeAndSave($source, $preview->orientation);
+    }
+
+    /**
+     * Génère le thumbnail depuis une frame extraite d'une vidéo.
+     *
+     * ffmpeg applique déjà la métadonnée `rotate` du conteneur au décodage :
+     * la frame arrive droite, d'où l'orientation Normal — contrairement à une
+     * preview RAW, livrée telle que le capteur l'a vue.
+     */
+    private function generateFromVideo(string $absolutePath): ?string
+    {
+        try {
+            $frame = $this->videoThumbnailExtractor->extract($absolutePath);
+        } catch (VideoThumbnailExtractionException) {
+            // Binaire absent ou extraction en échec : pas de vignette, le Media
+            // est créé sans — comme pour un RAW illisible (generateFromRaw).
+            return null;
+        }
+
+        $source = @imagecreatefromstring($frame->jpegData);
+        if ($source === false) {
+            return null;
+        }
+
+        return $this->resizeAndSave($source, Orientation::Normal);
     }
 
     private const MAX_IMAGE_DIMENSION = 10000; // pixels — au-delà, risque GD memory bomb

--- a/src/Service/Video/ExtractedVideoFrame.php
+++ b/src/Service/Video/ExtractedVideoFrame.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Video;
+
+/**
+ * Frame extraite d'une vidéo, en JPEG.
+ *
+ * Pas d'orientation ici, contrairement à {@see \App\Service\ExifThumbnail} :
+ * ffmpeg applique lui-même la métadonnée `rotate` des conteneurs MP4 au
+ * décodage, la frame produite est donc déjà droite.
+ */
+final readonly class ExtractedVideoFrame
+{
+    public function __construct(
+        public string $jpegData,
+    ) {}
+}

--- a/src/Service/Video/FfmpegVideoThumbnailExtractor.php
+++ b/src/Service/Video/FfmpegVideoThumbnailExtractor.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Video;
+
+use App\Interface\VideoDurationProbeInterface;
+use App\Interface\VideoFrameGrabberInterface;
+use App\Interface\VideoThumbnailExtractorInterface;
+
+/**
+ * Façade : décide où viser, délègue l'extraction.
+ *
+ * N'exécute elle-même aucun binaire — elle orchestre la sonde et le grabber.
+ */
+final class FfmpegVideoThumbnailExtractor implements VideoThumbnailExtractorInterface
+{
+    private const SUPPORTED_EXTENSIONS = ['mp4', 'webm', 'mov'];
+
+    public function __construct(
+        private readonly VideoDurationProbeInterface $durationProbe,
+        private readonly VideoFrameGrabberInterface $frameGrabber,
+    ) {}
+
+    public function supports(string $absolutePath): bool
+    {
+        $extension = strtolower(pathinfo($absolutePath, PATHINFO_EXTENSION));
+
+        return in_array($extension, self::SUPPORTED_EXTENSIONS, true);
+    }
+
+    public function extract(string $absolutePath): ExtractedVideoFrame
+    {
+        // Durée inconnue (stream sans métadonnée, ffprobe absent) : on vise la
+        // première frame. Moins représentative, mais mieux que rien.
+        $duration = $this->durationProbe->durationInSeconds($absolutePath);
+        $seek = $duration !== null ? $duration / 2 : 0.0;
+
+        return $this->frameGrabber->grab($absolutePath, $seek);
+    }
+
+    /**
+     * Extracteur câblé avec les collaborateurs standards.
+     *
+     * Raccourci pour les tests et scripts sans conteneur — sous Symfony,
+     * c'est services.yaml qui fait foi.
+     */
+    public static function createDefault(string $ffmpegBin, string $ffprobeBin): self
+    {
+        return new self(
+            new VideoDurationProbe($ffprobeBin),
+            new VideoFrameGrabber($ffmpegBin),
+        );
+    }
+}

--- a/src/Service/Video/VideoDurationProbe.php
+++ b/src/Service/Video/VideoDurationProbe.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Video;
+
+use App\Interface\VideoDurationProbeInterface;
+use Symfony\Component\Process\Process;
+
+/**
+ * Durée d'une vidéo via ffprobe.
+ *
+ * Ne lève jamais : une durée introuvable fait viser la première frame, ce
+ * qui reste préférable à l'absence de vignette.
+ */
+final class VideoDurationProbe implements VideoDurationProbeInterface
+{
+    private const TIMEOUT_SECONDS = 30;
+
+    public function __construct(private readonly string $ffprobeBin) {}
+
+    public function durationInSeconds(string $absolutePath): ?float
+    {
+        if (!is_executable($this->ffprobeBin)) {
+            return null;
+        }
+
+        try {
+            $process = new Process([
+                $this->ffprobeBin,
+                '-v', 'error',
+                '-show_entries', 'format=duration',
+                '-of', 'default=noprint_wrappers=1:nokey=1',
+                $absolutePath,
+            ]);
+            $process->setTimeout(self::TIMEOUT_SECONDS);
+            $process->run();
+
+            if (!$process->isSuccessful()) {
+                return null;
+            }
+
+            $duration = (float) trim($process->getOutput());
+
+            return $duration > 0 ? $duration : null;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/src/Service/Video/VideoFrameGrabber.php
+++ b/src/Service/Video/VideoFrameGrabber.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Video;
+
+use App\Exception\Video\FrameExtractionFailedException;
+use App\Exception\Video\VideoToolUnavailableException;
+use App\Interface\VideoFrameGrabberInterface;
+use Symfony\Component\Process\Process;
+
+/**
+ * Extrait une frame via un binaire ffmpeg statique.
+ *
+ * o2switch (mutualisé, pas de root) n'a ni ffmpeg système ni imagick : le
+ * binaire est déposé dans var/bin/ par bin/install-ffmpeg.sh au déploiement.
+ *
+ * La commande est construite en tableau d'arguments : un nom de fichier
+ * contenant des métacaractères shell est passé tel quel à execve(), jamais
+ * réinterprété par un shell.
+ */
+final class VideoFrameGrabber implements VideoFrameGrabberInterface
+{
+    private const TIMEOUT_SECONDS = 30;
+
+    public function __construct(private readonly string $ffmpegBin) {}
+
+    public function grab(string $absolutePath, float $seekSeconds): ExtractedVideoFrame
+    {
+        if (!is_executable($this->ffmpegBin)) {
+            throw new VideoToolUnavailableException(
+                sprintf('ffmpeg introuvable ou non exécutable : %s', $this->ffmpegBin),
+            );
+        }
+
+        $outputPath = tempnam(sys_get_temp_dir(), 'hc-video-thumb-').'.jpg';
+
+        try {
+            $process = new Process([
+                $this->ffmpegBin,
+                '-ss', (string) $seekSeconds,
+                '-i', $absolutePath,
+                '-frames:v', '1',
+                '-q:v', '2',
+                '-f', 'image2',
+                '-y',
+                $outputPath,
+            ]);
+            $process->setTimeout(self::TIMEOUT_SECONDS);
+            $process->run();
+
+            if (!$process->isSuccessful()) {
+                throw new FrameExtractionFailedException(
+                    'ffmpeg a échoué : '.$process->getErrorOutput(),
+                );
+            }
+
+            $jpegData = @file_get_contents($outputPath);
+            if ($jpegData === false || $jpegData === '') {
+                throw new FrameExtractionFailedException("ffmpeg n'a produit aucune image");
+            }
+
+            return new ExtractedVideoFrame($jpegData);
+        } finally {
+            if (file_exists($outputPath)) {
+                @unlink($outputPath);
+            }
+        }
+    }
+}

--- a/src/Twig/Components/FoldersGrid.php
+++ b/src/Twig/Components/FoldersGrid.php
@@ -11,5 +11,10 @@ class FoldersGrid
      * @var array<int, object>
      */
     public array $items = [];
+
+    /**
+     * @var array<string, \App\Entity\Media> Media indexés par id de File (RFC 4122)
+     */
+    public array $mediasByFileId = [];
     // Props : liste de fichiers/dossiers, options d’affichage (à étendre si besoin)
 }

--- a/templates/components/FileCard.html.twig
+++ b/templates/components/FileCard.html.twig
@@ -1,17 +1,24 @@
 {# Composant FileCard — Carte fichier #}
 <div class="folder-card hc-item-card">
-	<div class="file-icon hc-item-icon
-		{%- if item.mimeType starts with 'image/' %} hc-item-icon--image
-		{%- elseif item.mimeType starts with 'video/' or item.mimeType starts with 'audio/' or item.mimeType == 'application/pdf' %} hc-item-icon--doc
-		{%- else %} hc-item-icon--doc
-		{%- endif %} mb-2">
-		{% if item.mimeType starts with 'image/' %}<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-images"><path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5z"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
-			{% elseif item.mimeType starts with 'video/' %}<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-video"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
-			{% elseif item.mimeType starts with 'audio/' %}<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-music"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
-			{% elseif item.mimeType == 'application/pdf' %}<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-file"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>
-			{% else %}<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-file"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>
-		{% endif %}
-	</div>
+	{% if media is defined and media and media.thumbnailPath %}
+		<div class="file-icon hc-item-icon hc-item-icon--thumb mb-2">
+			<img src="{{ path('media_thumbnail', {id: media.id}) }}"
+			     alt="{{ item.originalName ?? item.name }}"
+			     loading="lazy"
+			     class="hc-item-thumb-img">
+		</div>
+	{% else %}
+		<div class="file-icon hc-item-icon
+			{%- if item.mimeType starts with 'image/' %} hc-item-icon--image
+			{%- else %} hc-item-icon--doc
+			{%- endif %} mb-2">
+			{% if item.mimeType starts with 'image/' %}<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-images"><path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5z"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+				{% elseif item.mimeType starts with 'video/' %}<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-video"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
+				{% elseif item.mimeType starts with 'audio/' %}<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-music"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
+				{% else %}<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-file"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>
+			{% endif %}
+		</div>
+	{% endif %}
 	<div class="file-name hc-item-name">{{ item.originalName ?? item.name }}</div>
 	<div class="file-meta hc-item-meta">
 		{% if item.size is defined %}

--- a/templates/components/FoldersGrid.html.twig
+++ b/templates/components/FoldersGrid.html.twig
@@ -11,7 +11,7 @@
       <twig:FolderCard :item="folder" />
     {% endfor %}
     {% for file in files %}
-      <twig:FileCard :item="file" />
+      <twig:FileCard :item="file" :media="mediasByFileId[file.id] ?? null" />
     {% endfor %}
   {% endif %}
 </div>

--- a/templates/web/explorer.html.twig
+++ b/templates/web/explorer.html.twig
@@ -34,7 +34,7 @@
       <div class="flex-1" data-testid="file-list">
           {# === FoldersGrid component === #}
           {# Fusionne dossiers et fichiers pour affichage unifié #}
-          <twig:FoldersGrid :folders="folders" :files="files" />
+          <twig:FoldersGrid :folders="folders" :files="files" :mediasByFileId="mediasByFileId" />
       </div>
 
   </div>

--- a/tests/Service/FfmpegVideoThumbnailExtractorTest.php
+++ b/tests/Service/FfmpegVideoThumbnailExtractorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Service\Video\FfmpegVideoThumbnailExtractor;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\ExecutableFinder;
+
+class FfmpegVideoThumbnailExtractorTest extends TestCase
+{
+    private const FIXTURE = __DIR__.'/../../fixtures/demo-videos/testsrc.mp4';
+
+    private ?string $storageDir = null;
+
+    protected function setUp(): void
+    {
+        $ffmpeg = (new ExecutableFinder())->find('ffmpeg');
+        if ($ffmpeg === null) {
+            $this->markTestSkipped('ffmpeg absent de cette machine (présent en CI).');
+        }
+
+        $this->storageDir = sys_get_temp_dir().'/hc-test-video-extract-'.uniqid();
+        mkdir($this->storageDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->storageDir) && is_dir($this->storageDir)) {
+            array_map('unlink', glob($this->storageDir.'/*') ?: []);
+            rmdir($this->storageDir);
+        }
+    }
+
+    public function testSupportsCommonVideoFormats(): void
+    {
+        $extractor = FfmpegVideoThumbnailExtractor::createDefault(
+            (new ExecutableFinder())->find('ffmpeg') ?: 'ffmpeg',
+            (new ExecutableFinder())->find('ffprobe') ?: 'ffprobe',
+        );
+
+        $this->assertTrue($extractor->supports('video.mp4'));
+        $this->assertTrue($extractor->supports('video.webm'));
+        $this->assertTrue($extractor->supports('video.mov'));
+        $this->assertFalse($extractor->supports('image.jpg'));
+        $this->assertFalse($extractor->supports('photo.nef'));
+    }
+
+    public function testExtractsFrameFromFixtureWhenAvailable(): void
+    {
+        if (!file_exists(self::FIXTURE)) {
+            $this->markTestSkipped('Fixture vidéo absent (testsrc.mp4).');
+        }
+
+        $ffmpeg = (new ExecutableFinder())->find('ffmpeg');
+        if ($ffmpeg === null) {
+            $this->markTestSkipped('ffmpeg absent.');
+        }
+
+        $extractor = FfmpegVideoThumbnailExtractor::createDefault(
+            $ffmpeg,
+            (new ExecutableFinder())->find('ffprobe') ?: 'ffprobe',
+        );
+
+        $frame = $extractor->extract(self::FIXTURE);
+
+        $this->assertNotEmpty($frame->jpegData);
+        $image = @imagecreatefromstring($frame->jpegData);
+        $this->assertNotFalse($image, 'Frame doit être un JPEG valide');
+        imagedestroy($image);
+    }
+}

--- a/tests/Service/MediaProcessorTest.php
+++ b/tests/Service/MediaProcessorTest.php
@@ -297,7 +297,7 @@ final class MediaProcessorTest extends TestCase
         $this->assertNull($media);
     }
 
-    public function testProcessCreatesVideoMediaWithoutExifOrThumbnail(): void
+    public function testProcessCreatesVideoMediaWithThumbnailButNoExif(): void
     {
         $file = $this->createStub(File::class);
         $file->method('getMimeType')->willReturn('video/mp4');
@@ -314,7 +314,7 @@ final class MediaProcessorTest extends TestCase
         $exifService = $this->createMock(ExifService::class);
         $exifService->expects($this->never())->method('extract');
         $thumbnailService = $this->createMock(ThumbnailService::class);
-        $thumbnailService->expects($this->never())->method('generate');
+        $thumbnailService->expects($this->once())->method('generate')->willReturn('thumbs/abc.jpg');
 
         $media = $this->processor(
             $mediaRepo,
@@ -326,6 +326,7 @@ final class MediaProcessorTest extends TestCase
 
         $this->assertInstanceOf(Media::class, $media);
         $this->assertSame('video', $media->getMediaType());
+        $this->assertSame('thumbs/abc.jpg', $media->getThumbnailPath());
     }
 
     /**

--- a/tests/Service/ThumbnailServiceExifThumbnailTest.php
+++ b/tests/Service/ThumbnailServiceExifThumbnailTest.php
@@ -69,7 +69,10 @@ final class ThumbnailServiceExifThumbnailTest extends TestCase
         $rawExtractor = $this->createMock(RawPreviewExtractorInterface::class);
         $rawExtractor->method('supports')->willReturn(false);
 
-        return new ThumbnailService($this->storageDir, $rawExtractor, $exifExtractor);
+        $videoExtractor = $this->createMock(\App\Interface\VideoThumbnailExtractorInterface::class);
+        $videoExtractor->method('supports')->willReturn(false);
+
+        return new ThumbnailService($this->storageDir, $rawExtractor, $exifExtractor, $videoExtractor);
     }
 
     public function testUsesEmbeddedExifThumbnailWhenPresent(): void

--- a/tests/Service/ThumbnailServiceRawTest.php
+++ b/tests/Service/ThumbnailServiceRawTest.php
@@ -73,7 +73,10 @@ final class ThumbnailServiceRawTest extends TestCase
         $exifExtractor = $this->createMock(ExifThumbnailExtractorInterface::class);
         $exifExtractor->method('extract')->willReturn(null);
 
-        return new ThumbnailService($this->storageDir, $rawExtractor, $exifExtractor);
+        $videoExtractor = $this->createMock(\App\Interface\VideoThumbnailExtractorInterface::class);
+        $videoExtractor->method('supports')->willReturn(false);
+
+        return new ThumbnailService($this->storageDir, $rawExtractor, $exifExtractor, $videoExtractor);
     }
 
     /**

--- a/tests/Service/ThumbnailServiceRealRawTest.php
+++ b/tests/Service/ThumbnailServiceRealRawTest.php
@@ -73,10 +73,14 @@ final class ThumbnailServiceRealRawTest extends TestCase
         $exifExtractor = $this->createMock(ExifThumbnailExtractorInterface::class);
         $exifExtractor->method('extract')->willReturn(null);
 
+        $videoExtractor = $this->createMock(\App\Interface\VideoThumbnailExtractorInterface::class);
+        $videoExtractor->method('supports')->willReturn(false);
+
         $service = new ThumbnailService(
             $this->storageDir,
             RawPreviewExtractor::createDefault(),
             $exifExtractor,
+            $videoExtractor,
         );
 
         $thumb = $service->generate(self::FIXTURE);

--- a/tests/Service/ThumbnailServiceVideoTest.php
+++ b/tests/Service/ThumbnailServiceVideoTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Exception\Video\FrameExtractionFailedException;
+use App\Interface\ExifThumbnailExtractorInterface;
+use App\Interface\VideoThumbnailExtractorInterface;
+use App\Service\ThumbnailService;
+use App\Service\Video\ExtractedVideoFrame;
+use PHPUnit\Framework\TestCase;
+use RonanLenouvel\RawPreviewExtractor\RawPreviewExtractorInterface;
+
+class ThumbnailServiceVideoTest extends TestCase
+{
+    private string $storageDir;
+
+    protected function setUp(): void
+    {
+        $this->storageDir = sys_get_temp_dir().'/hc-test-thumbs-'.uniqid();
+        mkdir($this->storageDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->storageDir) && is_dir($this->storageDir)) {
+            array_map('unlink', glob($this->storageDir.'/*') ?: []);
+            rmdir($this->storageDir);
+        }
+    }
+
+    private function makeJpeg(int $width, int $height): string
+    {
+        $image = imagecreatetruecolor($width, $height);
+        imagefill($image, 0, 0, imagecolorallocate($image, 255, 0, 0));
+        ob_start();
+        imagejpeg($image, null, 90);
+        $data = ob_get_clean();
+        imagedestroy($image);
+
+        return $data ?: '';
+    }
+
+    private function makeVideoFile(): string
+    {
+        $path = $this->storageDir.'/video.mp4';
+        file_put_contents($path, 'not-a-real-video-the-extractor-is-a-mock');
+
+        return $path;
+    }
+
+    private function service(VideoThumbnailExtractorInterface $videoExtractor): ThumbnailService
+    {
+        $rawExtractor = $this->createMock(RawPreviewExtractorInterface::class);
+        $rawExtractor->method('supports')->willReturn(false);
+
+        $exifExtractor = $this->createMock(ExifThumbnailExtractorInterface::class);
+        $exifExtractor->method('extract')->willReturn(null);
+
+        return new ThumbnailService($this->storageDir, $rawExtractor, $exifExtractor, $videoExtractor);
+    }
+
+    public function testGenerateCreatesVideoThumbnailFromExtractedFrame(): void
+    {
+        $videoPath = $this->makeVideoFile();
+
+        $videoExtractor = $this->createMock(VideoThumbnailExtractorInterface::class);
+        $videoExtractor->method('supports')->willReturn(true);
+        $videoExtractor->method('extract')
+            ->willReturn(new ExtractedVideoFrame($this->makeJpeg(640, 480)));
+
+        $service = $this->service($videoExtractor);
+
+        $thumbnail = $service->generate($videoPath);
+
+        $this->assertNotNull($thumbnail);
+        $this->assertStringStartsWith('thumbs/', $thumbnail);
+        $this->assertFileExists($this->storageDir.'/'.$thumbnail);
+        $image = @imagecreatefromjpeg($this->storageDir.'/'.$thumbnail);
+        $this->assertNotFalse($image);
+        $width = imagesx($image);
+        $this->assertSame(320, $width);
+        imagedestroy($image);
+    }
+
+    public function testGenerateReturnsNullWhenVideoExtractionFails(): void
+    {
+        $videoPath = $this->makeVideoFile();
+
+        $videoExtractor = $this->createMock(VideoThumbnailExtractorInterface::class);
+        $videoExtractor->method('supports')->willReturn(true);
+        $videoExtractor->method('extract')
+            ->willThrowException(new FrameExtractionFailedException('ffmpeg failed'));
+
+        $service = $this->service($videoExtractor);
+
+        $thumbnail = $service->generate($videoPath);
+
+        $this->assertNull($thumbnail);
+    }
+
+    public function testGenerateDoesNotExtractWhenVideoNotSupported(): void
+    {
+        $videoPath = $this->makeVideoFile();
+
+        $videoExtractor = $this->createMock(VideoThumbnailExtractorInterface::class);
+        $videoExtractor->method('supports')->willReturn(false);
+        $videoExtractor->expects($this->never())->method('extract');
+
+        $service = $this->service($videoExtractor);
+
+        $thumbnail = $service->generate($videoPath);
+
+        $this->assertNull($thumbnail);
+    }
+
+    public function testGenerateHandlesMetacharactersInFilename(): void
+    {
+        $videoPath = $this->makeVideoFile();
+
+        $videoExtractor = $this->createMock(VideoThumbnailExtractorInterface::class);
+        $videoExtractor->method('supports')->willReturn(true);
+        $videoExtractor->method('extract')
+            ->willReturn(new ExtractedVideoFrame($this->makeJpeg(320, 240)));
+
+        $service = $this->service($videoExtractor);
+
+        $thumbnail = $service->generate($videoPath);
+
+        $this->assertNotNull($thumbnail);
+        $this->assertFileExists($this->storageDir.'/'.$thumbnail);
+    }
+}

--- a/tests/Service/VideoThumbnailExtractorWiringTest.php
+++ b/tests/Service/VideoThumbnailExtractorWiringTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Interface\VideoThumbnailExtractorInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class VideoThumbnailExtractorWiringTest extends KernelTestCase
+{
+    public function testVideoThumbnailExtractorIsWiredCorrectly(): void
+    {
+        $this->bootKernel();
+        $container = $this->getContainer();
+
+        $extractor = $container->get(VideoThumbnailExtractorInterface::class);
+
+        $this->assertInstanceOf(VideoThumbnailExtractorInterface::class, $extractor);
+    }
+}

--- a/tests/Web/ExplorerPageTest.php
+++ b/tests/Web/ExplorerPageTest.php
@@ -420,6 +420,57 @@ final class ExplorerPageTest extends WebTestCase
         );
     }
 
+    /**
+     * #312 volet 1 — FileCard affiche l'<img> quand Media.thumbnailPath existe.
+     */
+    public function testFileCardShowsThumbnailWhenMediaExists(): void
+    {
+        $user = $this->createUser();
+
+        $folder = new Folder('Photos', $user);
+        $this->em->persist($folder);
+
+        // Fichier avec Media/thumbnailPath
+        $photoFile = new \App\Entity\File('photo.jpg', 'image/jpeg', 1024, 'test/photo.jpg', $folder, $user);
+        $this->em->persist($photoFile);
+
+        $media = new \App\Entity\Media($photoFile, 'photo');
+        $media->setThumbnailPath('thumbs/abc123.jpg');
+        $this->em->persist($media);
+
+        // Fichier sans Media
+        $pdfFile = new \App\Entity\File('doc.pdf', 'application/pdf', 2048, 'test/doc.pdf', $folder, $user);
+        $this->em->persist($pdfFile);
+
+        $this->em->flush();
+        $folderId = $folder->getId()->toRfc4122();
+
+        $this->login();
+
+        $crawler = $this->client->request('GET', '/explorer?folder=' . $folderId);
+
+        $this->assertResponseIsSuccessful();
+
+        // Vérifier qu'il y a bien 2 fichiers affichés
+        $this->assertSelectorExists('[data-testid="file-list"]');
+        // La grille contient au moins 2 cartes
+        $cards = $crawler->filter('.hc-item-card');
+        $this->assertGreaterThanOrEqual(2, $cards->count(), 'Attendu 2 fichiers dans le dossier');
+
+        // Chercher la carte par le nom de fichier unique (l'<img> est dedans)
+        $photoCard = null;
+        $cards->each(function ($card, $key) use (&$photoCard) {
+            $name = $card->filter('.hc-item-name')->text();
+            if (strpos($name, 'photo.jpg') !== false) {
+                $photoCard = $card;
+            }
+        });
+
+        $this->assertNotNull($photoCard, 'Carte photo.jpg non trouvée');
+        // Le photo doit avoir une <img> (pas une icône SVG)
+        $this->assertCount(1, $photoCard->filter('img.hc-item-thumb-img'), 'La photo doit avoir une vignette');
+    }
+
     public function testViewButtonAppearsOnlyForImageAndVideoFiles(): void
     {
         $user = $this->createUser();


### PR DESCRIPTION
## Résumé

Affiche les vignettes (thumbnails) réelles des fichiers dans « Mes fichiers » :
- **Volet 1** : vignettes images (déjà générées, câblage pur)
- **Volet 2** : extraction de vignettes vidéo via ffmpeg

Deux commits indépendants, le volet 1 est mergeable seul.

## Volet 1 — Images

- `ExplorerController` charge les Media en une requête (pas de N+1)
- `FileCard.html.twig` affiche `<img>` quand `thumbnailPath` existe, sinon icône SVG
- CSS : `.hc-item-icon--thumb` + `.hc-item-thumb-img` (cover-fit)
- Test : `testFileCardShowsThumbnailWhenMediaExists` vérifie l'affichage réel
- ✅ 24 tests Explorer

## Volet 2 — Vidéos

- Exceptions + interfaces : `VideoThumbnailExtractionException`, `VideoThumbnailExtractorInterface`
- Implémentation : `VideoDurationProbe`, `VideoFrameGrabber`, `FfmpegVideoThumbnailExtractor`
- `ThumbnailService` : branchement vidéo prioritaire avant RAW, dégradation gracieuse
- `MediaProcessor` : génère la vignette pour les vidéos
- Déploiement : script `bin/install-ffmpeg.sh` (idempotent), intégré à CI et deploy scripts
- ✅ 61 tests (4 cas vidéo, 2 skippés sans ffmpeg local)

## Test plan

```bash
# Tous les tests passent
./vendor/bin/phpunit --filter "Explorer|ThumbnailService|MediaProcessor|Video|Wiring"

# Assets buildés
composer build-assets
```

## Closes #312