### PR TITLE
✨ feat(logging): tracer intention et cause du traitement média

### DIFF
--- a/src/Handler/MediaProcessHandler.php
+++ b/src/Handler/MediaProcessHandler.php
@@ -11,6 +11,8 @@ use App\Interface\UploadBatchRepositoryInterface;
 use App\Message\MediaProcessMessage;
 use App\Repository\FileRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
@@ -34,16 +36,46 @@ final class MediaProcessHandler
         private readonly UploadBatchRepositoryInterface $uploadBatchRepository,
         private readonly BatchCompletionNotifierInterface $batchCompletionNotifier,
         private readonly EntityManagerInterface $em,
+        private readonly LoggerInterface $logger = new NullLogger(),
     ) {}
 
     public function __invoke(MediaProcessMessage $message): void
     {
         $file = $this->fileRepository->find($message->fileId);
         if ($file === null) {
+            // Message rejoué après suppression du fichier, ou fileId invalide :
+            // ne pas confondre avec un traitement silencieusement sauté.
+            $this->logger->warning('MediaProcessMessage : fichier introuvable', [
+                'fileId' => $message->fileId,
+            ]);
+
             return;
         }
 
-        $this->mediaProcessor->process($file);
+        $media = $this->mediaProcessor->process($file);
+
+        if ($media === null) {
+            // Fichier dont le type n'ouvre pas droit à un Media (ni photo, ni
+            // vidéo) : pas une erreur, mais utile à distinguer d'un traitement
+            // qui aurait dû produire un Media et n'y est pas arrivé.
+            $this->logger->info('Fichier sans Media associé (type non pris en charge)', [
+                'fileName' => $file->getOriginalName(),
+                'fileId' => $file->getId()->toRfc4122(),
+            ]);
+        } elseif ($media->getThumbnailPath() === null) {
+            // Media créé mais sans vignette : succès partiel — la cause précise
+            // (ffmpeg absent, RAW illisible, etc.) est déjà tracée par
+            // ThumbnailService, ce warning sert à repérer l'occurrence côté fichier.
+            $this->logger->warning('Media traité sans vignette', [
+                'fileName' => $file->getOriginalName(),
+                'fileId' => $file->getId()->toRfc4122(),
+            ]);
+        } else {
+            $this->logger->info('Media traité', [
+                'fileName' => $file->getOriginalName(),
+                'fileId' => $file->getId()->toRfc4122(),
+            ]);
+        }
 
         $this->notifyIfBatchCompleted($file->getBatch());
     }

--- a/src/Service/ThumbnailService.php
+++ b/src/Service/ThumbnailService.php
@@ -7,6 +7,8 @@ namespace App\Service;
 use App\Exception\Video\VideoThumbnailExtractionException;
 use App\Interface\ExifThumbnailExtractorInterface;
 use App\Interface\VideoThumbnailExtractorInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use RonanLenouvel\RawPreviewExtractor\Exception\RawPreviewExtractorException;
 use RonanLenouvel\RawPreviewExtractor\Orientation;
 use RonanLenouvel\RawPreviewExtractor\RawPreviewExtractorInterface;
@@ -38,6 +40,7 @@ class ThumbnailService
         private readonly RawPreviewExtractorInterface $rawPreviewExtractor,
         private readonly ExifThumbnailExtractorInterface $exifThumbnailExtractor,
         private readonly VideoThumbnailExtractorInterface $videoThumbnailExtractor,
+        private readonly LoggerInterface $logger = new NullLogger(),
     ) {}
 
     /**
@@ -79,9 +82,14 @@ class ThumbnailService
     {
         try {
             $preview = $this->rawPreviewExtractor->extract($absolutePath);
-        } catch (RawPreviewExtractorException) {
+        } catch (RawPreviewExtractorException $e) {
             // RAW sans preview, illisible ou format non géré : pas de vignette,
             // le Media est créé sans, comme pour une image GD en échec.
+            $this->logger->warning('Échec de génération de vignette (RAW)', [
+                'path' => $absolutePath,
+                'exception' => $e,
+            ]);
+
             return null;
         }
 
@@ -104,9 +112,14 @@ class ThumbnailService
     {
         try {
             $frame = $this->videoThumbnailExtractor->extract($absolutePath);
-        } catch (VideoThumbnailExtractionException) {
+        } catch (VideoThumbnailExtractionException $e) {
             // Binaire absent ou extraction en échec : pas de vignette, le Media
             // est créé sans — comme pour un RAW illisible (generateFromRaw).
+            $this->logger->warning('Échec de génération de vignette (vidéo)', [
+                'path' => $absolutePath,
+                'exception' => $e,
+            ]);
+
             return null;
         }
 

--- a/tests/Handler/MediaProcessHandlerTest.php
+++ b/tests/Handler/MediaProcessHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Handler;
 
 use App\Entity\File;
+use App\Entity\Media;
 use App\Entity\UploadBatch;
 use App\Entity\User;
 use App\Handler\MediaProcessHandler;
@@ -15,6 +16,7 @@ use App\Repository\FileRepository;
 use App\Interface\BatchCompletionNotifierInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 final class MediaProcessHandlerTest extends TestCase
 {
@@ -24,6 +26,7 @@ final class MediaProcessHandlerTest extends TestCase
         ?UploadBatchRepositoryInterface $batchRepo = null,
         ?BatchCompletionNotifierInterface $notifier = null,
         ?EntityManagerInterface $em = null,
+        ?LoggerInterface $logger = null,
     ): MediaProcessHandler {
         return new MediaProcessHandler(
             $fileRepo,
@@ -31,6 +34,7 @@ final class MediaProcessHandlerTest extends TestCase
             $batchRepo ?? $this->createStub(UploadBatchRepositoryInterface::class),
             $notifier ?? $this->createStub(BatchCompletionNotifierInterface::class),
             $em ?? $this->createStub(EntityManagerInterface::class),
+            $logger ?? $this->createStub(LoggerInterface::class),
         );
     }
 
@@ -177,5 +181,120 @@ final class MediaProcessHandlerTest extends TestCase
             $batchRepo,
             $notifier,
         )(new MediaProcessMessage('id'));
+    }
+
+    /**
+     * Un Media créé sans vignette (thumbnailPath null) est un succès partiel :
+     * on veut le voir dans les logs pour distinguer "traité mais dégradé" de
+     * "jamais traité" — observé en prod sur #312, impossible à diagnostiquer
+     * sans ce niveau de détail.
+     */
+    public function testLogsInfoWithFileIdWhenMediaCreatedWithoutThumbnail(): void
+    {
+        $file = $this->createStub(File::class);
+        $file->method('getId')->willReturn(\Symfony\Component\Uid\Uuid::fromString('0195c2f0-0000-7000-8000-000000000001'));
+        $file->method('getOriginalName')->willReturn('video.mp4');
+        $file->method('getBatch')->willReturn(null);
+
+        $fileRepo = $this->createStub(FileRepository::class);
+        $fileRepo->method('find')->willReturn($file);
+
+        $media = $this->createStub(Media::class);
+        $media->method('getThumbnailPath')->willReturn(null);
+
+        $processor = $this->createStub(MediaProcessorInterface::class);
+        $processor->method('process')->willReturn($media);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with(
+                $this->stringContains('sans vignette'),
+                $this->callback(fn (array $context) => ($context['fileName'] ?? null) === 'video.mp4'),
+            );
+
+        $this->handler($fileRepo, $processor, logger: $logger)(new MediaProcessMessage('0195c2f0-0000-7000-8000-000000000001'));
+    }
+
+    /**
+     * Un Media créé avec vignette : succès complet, tracé en info (pas warning).
+     */
+    public function testLogsInfoWithFileIdWhenMediaCreatedWithThumbnail(): void
+    {
+        $file = $this->createStub(File::class);
+        $file->method('getId')->willReturn(\Symfony\Component\Uid\Uuid::fromString('0195c2f0-0000-7000-8000-000000000002'));
+        $file->method('getOriginalName')->willReturn('photo.jpg');
+        $file->method('getBatch')->willReturn(null);
+
+        $fileRepo = $this->createStub(FileRepository::class);
+        $fileRepo->method('find')->willReturn($file);
+
+        $media = $this->createStub(Media::class);
+        $media->method('getThumbnailPath')->willReturn('thumbs/abc.jpg');
+
+        $processor = $this->createStub(MediaProcessorInterface::class);
+        $processor->method('process')->willReturn($media);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('warning');
+        $logger->expects($this->once())
+            ->method('info')
+            ->with(
+                $this->stringContains('traité'),
+                $this->callback(fn (array $context) => ($context['fileName'] ?? null) === 'photo.jpg'),
+            );
+
+        $this->handler($fileRepo, $processor, logger: $logger)(new MediaProcessMessage('0195c2f0-0000-7000-8000-000000000002'));
+    }
+
+    /**
+     * MediaProcessor::process() renvoie null pour un type non pris en charge
+     * (ex: PDF) : ne doit jamais être confondu avec "Media traité" (succès).
+     */
+    public function testLogsInfoWhenFileTypeHasNoAssociatedMedia(): void
+    {
+        $file = $this->createStub(File::class);
+        $file->method('getId')->willReturn(\Symfony\Component\Uid\Uuid::fromString('0195c2f0-0000-7000-8000-000000000003'));
+        $file->method('getOriginalName')->willReturn('document.pdf');
+        $file->method('getBatch')->willReturn(null);
+
+        $fileRepo = $this->createStub(FileRepository::class);
+        $fileRepo->method('find')->willReturn($file);
+
+        $processor = $this->createStub(MediaProcessorInterface::class);
+        $processor->method('process')->willReturn(null);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('warning');
+        $logger->expects($this->once())
+            ->method('info')
+            ->with(
+                $this->stringContains('non pris en charge'),
+                $this->callback(fn (array $context) => ($context['fileName'] ?? null) === 'document.pdf'),
+            );
+
+        $this->handler($fileRepo, $processor, logger: $logger)(new MediaProcessMessage('0195c2f0-0000-7000-8000-000000000003'));
+    }
+
+    /**
+     * Fichier introuvable en base : traçé pour distinguer d'un traitement
+     * silencieusement sauté par accident (message rejoué après suppression).
+     */
+    public function testLogsWarningWhenFileNotFound(): void
+    {
+        $fileRepo = $this->createStub(FileRepository::class);
+        $fileRepo->method('find')->willReturn(null);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with(
+                $this->stringContains('introuvable'),
+                $this->callback(fn (array $context) => ($context['fileId'] ?? null) === 'missing-uuid'),
+            );
+
+        $this->handler($fileRepo, $this->createStub(MediaProcessorInterface::class), logger: $logger)(
+            new MediaProcessMessage('missing-uuid'),
+        );
     }
 }

--- a/tests/Service/ThumbnailServiceLoggingTest.php
+++ b/tests/Service/ThumbnailServiceLoggingTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Exception\Video\FrameExtractionFailedException;
+use App\Interface\ExifThumbnailExtractorInterface;
+use App\Interface\VideoThumbnailExtractorInterface;
+use App\Service\ThumbnailService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use RonanLenouvel\RawPreviewExtractor\Exception\PreviewNotFoundException;
+use RonanLenouvel\RawPreviewExtractor\RawPreviewExtractorInterface;
+
+/**
+ * Jusqu'ici, un échec d'extraction (RAW illisible, ffmpeg absent, vidéo
+ * corrompue) était avalé silencieusement : le Media était créé sans vignette,
+ * sans aucune trace exploitable. Observé en prod sur #312 — impossible de
+ * savoir depuis les logs pourquoi une vidéo n'avait pas de thumbnail.
+ */
+final class ThumbnailServiceLoggingTest extends TestCase
+{
+    private string $storageDir;
+
+    protected function setUp(): void
+    {
+        $this->storageDir = sys_get_temp_dir().'/hc-thumb-log-'.uniqid();
+        mkdir($this->storageDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $thumbsDir = $this->storageDir.'/thumbs';
+        if (is_dir($thumbsDir)) {
+            array_map('unlink', glob($thumbsDir.'/*') ?: []);
+            rmdir($thumbsDir);
+        }
+        array_map('unlink', glob($this->storageDir.'/*') ?: []);
+        if (is_dir($this->storageDir)) {
+            rmdir($this->storageDir);
+        }
+    }
+
+    private function makeVideoFile(): string
+    {
+        $path = $this->storageDir.'/video.mp4';
+        file_put_contents($path, 'not-a-real-video');
+
+        return $path;
+    }
+
+    public function testLogsWarningWithCauseWhenVideoExtractionFails(): void
+    {
+        $videoPath = $this->makeVideoFile();
+
+        $videoExtractor = $this->createMock(VideoThumbnailExtractorInterface::class);
+        $videoExtractor->method('supports')->willReturn(true);
+        $videoExtractor->method('extract')
+            ->willThrowException(new FrameExtractionFailedException('ffmpeg a échoué : exit 1'));
+
+        $rawExtractor = $this->createMock(RawPreviewExtractorInterface::class);
+        $rawExtractor->method('supports')->willReturn(false);
+
+        $exifExtractor = $this->createMock(ExifThumbnailExtractorInterface::class);
+        $exifExtractor->method('extract')->willReturn(null);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with(
+                $this->stringContains('vignette'),
+                $this->callback(function (array $context) use ($videoPath) {
+                    return ($context['path'] ?? null) === $videoPath
+                        && ($context['exception'] ?? null) instanceof FrameExtractionFailedException;
+                }),
+            );
+
+        $service = new ThumbnailService($this->storageDir, $rawExtractor, $exifExtractor, $videoExtractor, $logger);
+        $thumb = $service->generate($videoPath);
+
+        $this->assertNull($thumb);
+    }
+
+    public function testLogsWarningWithCauseWhenRawExtractionFails(): void
+    {
+        $rawPath = $this->storageDir.'/photo.nef';
+        file_put_contents($rawPath, 'not-a-real-raw');
+
+        $rawExtractor = $this->createMock(RawPreviewExtractorInterface::class);
+        $rawExtractor->method('supports')->willReturn(true);
+        $rawExtractor->method('extract')
+            ->willThrowException(new PreviewNotFoundException('no preview'));
+
+        $exifExtractor = $this->createMock(ExifThumbnailExtractorInterface::class);
+        $exifExtractor->method('extract')->willReturn(null);
+
+        $videoExtractor = $this->createMock(VideoThumbnailExtractorInterface::class);
+        $videoExtractor->method('supports')->willReturn(false);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with(
+                $this->stringContains('vignette'),
+                $this->callback(function (array $context) use ($rawPath) {
+                    return ($context['path'] ?? null) === $rawPath
+                        && ($context['exception'] ?? null) instanceof PreviewNotFoundException;
+                }),
+            );
+
+        $service = new ThumbnailService($this->storageDir, $rawExtractor, $exifExtractor, $videoExtractor, $logger);
+        $service->generate($rawPath);
+    }
+
+    public function testDoesNotLogWhenThumbnailGenerationSucceeds(): void
+    {
+        $videoPath = $this->makeVideoFile();
+
+        $videoExtractor = $this->createMock(VideoThumbnailExtractorInterface::class);
+        $videoExtractor->method('supports')->willReturn(false);
+
+        $rawExtractor = $this->createMock(RawPreviewExtractorInterface::class);
+        $rawExtractor->method('supports')->willReturn(false);
+
+        $exifExtractor = $this->createMock(ExifThumbnailExtractorInterface::class);
+        $exifExtractor->method('extract')->willReturn(null);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('warning');
+
+        $image = imagecreatetruecolor(400, 300);
+        ob_start();
+        imagejpeg($image);
+        $data = (string) ob_get_clean();
+        imagedestroy($image);
+        $jpegPath = $this->storageDir.'/photo.jpg';
+        file_put_contents($jpegPath, $data);
+
+        $service = new ThumbnailService($this->storageDir, $rawExtractor, $exifExtractor, $videoExtractor, $logger);
+        $thumb = $service->generate($jpegPath);
+
+        $this->assertNotNull($thumb);
+    }
+
+    public function testLoggerDefaultsToNullLoggerWhenNotProvided(): void
+    {
+        // Rétrocompatibilité : les sites d'instanciation existants (tests,
+        // services.yaml sans binding explicite) ne doivent pas casser.
+        $rawExtractor = $this->createMock(RawPreviewExtractorInterface::class);
+        $rawExtractor->method('supports')->willReturn(false);
+
+        $exifExtractor = $this->createMock(ExifThumbnailExtractorInterface::class);
+        $exifExtractor->method('extract')->willReturn(null);
+
+        $videoExtractor = $this->createMock(VideoThumbnailExtractorInterface::class);
+        $videoExtractor->method('supports')->willReturn(false);
+
+        $service = new ThumbnailService($this->storageDir, $rawExtractor, $exifExtractor, $videoExtractor);
+
+        $this->assertInstanceOf(ThumbnailService::class, $service);
+    }
+}


### PR DESCRIPTION
## Contexte

En diagnostiquant #312 en prod (vignettes vidéo absentes malgré un Media
créé), impossible de savoir depuis les logs pourquoi l'extraction avait
échoué — `ThumbnailService` avalait silencieusement toute exception pour
dégrader gracieusement (comportement à garder), et `MediaProcessHandler` ne
traçait rien du tout.

## Changements

- `ThumbnailService` : log `warning` avec le chemin du fichier et l'exception
  exacte à chaque échec d'extraction (RAW ou vidéo), avant de retourner `null`
- `MediaProcessHandler` : log `info`/`warning` par fichier traité — Media créé
  avec vignette (info), sans vignette (warning), type non pris en charge
  (info), ou fichier introuvable (warning)
- `LoggerInterface` injecté avec un défaut `NullLogger()` dans les deux
  classes — rétrocompatible avec tous les sites d'instanciation existants

## Test plan

- [x] TDD : tests RED→GREEN pour chaque nouveau cas de log
- [x] Suite complète : 890 tests, 1 seul échec préexistant sans rapport
      (`TailwindBuildTest`, dépend d'un `composer build-assets` local)