### PR TITLE
✨ feat(upload): afficher volume, vitesse et temps restant estimé pendant l'upload

### DIFF
--- a/assets/js/explorer-drop.js
+++ b/assets/js/explorer-drop.js
@@ -1,10 +1,14 @@
 import { readDroppedEntries } from './directory-entry-reader.js';
 
 /**
- * Active le drag & drop de fichiers/dossiers sur la zone d'import
- * (`#main-import-card`), en réutilisant la structure du dossier local déposé
- * (#238) : chaque fichier annoté de son relativePath, consommé par
- * upload-modal.js pour recréer l'arborescence côté serveur.
+ * Active l'import de fichiers/dossiers sur la zone `#main-import-card`,
+ * par drag & drop ou via le sélecteur natif (bouton "Parcourir") : les deux
+ * chemins convergent vers le même événement `hc:files-selected`, consommé
+ * par upload-modal.js (progress bar, #336) — jamais de soumission de
+ * formulaire native, qui ne permettrait aucune progression.
+ *
+ * La structure du dossier local déposé (#238) est préservée : chaque fichier
+ * est annoté de son relativePath.
  *
  * Auparavant dupliqué à l'identique dans explorer.html.twig et home.html.twig.
  */
@@ -12,7 +16,16 @@ export function initExplorerDrop() {
     const importCard = document.getElementById('main-import-card');
     if (!importCard) return { destroy() {} };
 
+    const fileInput = importCard.querySelector('#import-file-input');
+
     let dragCounter = 0;
+
+    const dispatchFilesSelected = (files) => {
+        if (files.length === 0) return;
+        const folderIdInput = importCard.querySelector('input[name="folder_id"]');
+        const folderId = folderIdInput ? folderIdInput.value : '';
+        document.dispatchEvent(new CustomEvent('hc:files-selected', { detail: { files, folderId } }));
+    };
 
     const onDragEnter = (e) => {
         e.preventDefault();
@@ -43,17 +56,18 @@ export function initExplorerDrop() {
                 return file;
             });
 
-        if (files.length === 0) return;
-
-        const folderIdInput = importCard.querySelector('input[name="folder_id"]');
-        const folderId = folderIdInput ? folderIdInput.value : '';
-        document.dispatchEvent(new CustomEvent('hc:files-selected', { detail: { files, folderId } }));
+        dispatchFilesSelected(files);
+    };
+    const onFileInputChange = () => {
+        dispatchFilesSelected(Array.from(fileInput.files));
+        fileInput.value = '';
     };
 
     document.addEventListener('dragenter', onDragEnter);
     document.addEventListener('dragover', onDragOver);
     document.addEventListener('dragleave', onDragLeave);
     document.addEventListener('drop', onDrop);
+    fileInput?.addEventListener('change', onFileInputChange);
 
     return {
         destroy() {
@@ -61,6 +75,7 @@ export function initExplorerDrop() {
             document.removeEventListener('dragover', onDragOver);
             document.removeEventListener('dragleave', onDragLeave);
             document.removeEventListener('drop', onDrop);
+            fileInput?.removeEventListener('change', onFileInputChange);
         },
     };
 }

--- a/assets/js/upload-eta.js
+++ b/assets/js/upload-eta.js
@@ -1,0 +1,77 @@
+/**
+ * HomeCloud — Vitesse d'upload et temps restant estimé (#336).
+ *
+ * Module pur (aucune dépendance au DOM) : calcule une vitesse moyenne
+ * glissante à partir d'échantillons {loaded, timestamp} successifs, puis
+ * en déduit un ETA. `nowFn` injectable pour des tests déterministes
+ * (cohérent avec le pattern de upload-batch.js).
+ */
+
+const MAX_SAMPLES = 5;
+
+/**
+ * Crée un tracker de vitesse pour un upload donné.
+ *
+ * @param {Object} [options]
+ * @param {() => number} [options.nowFn=Date.now]
+ * @returns {{ sample: (loaded: number) => { speedBytesPerSec: number, etaSeconds: number|null } }}
+ */
+export function createEtaTracker({ nowFn = () => Date.now() } = {}) {
+    const samples = [];
+
+    return {
+        /**
+         * Enregistre un nouvel échantillon de progression et retourne la
+         * vitesse moyenne glissante + l'ETA courants.
+         *
+         * @param {number} loaded - octets transférés cumulés
+         * @param {number} total - taille totale en octets
+         * @returns {{ speedBytesPerSec: number, etaSeconds: number|null }}
+         */
+        sample(loaded, total) {
+            const timestamp = nowFn();
+            samples.push({ loaded, timestamp });
+            if (samples.length > MAX_SAMPLES) samples.shift();
+
+            const first = samples[0];
+            const last = samples[samples.length - 1];
+            const elapsedSec = (last.timestamp - first.timestamp) / 1000;
+            const deltaBytes = last.loaded - first.loaded;
+
+            const speedBytesPerSec = elapsedSec > 0 ? deltaBytes / elapsedSec : 0;
+            const remainingBytes = total - loaded;
+            const etaSeconds = speedBytesPerSec > 0 ? remainingBytes / speedBytesPerSec : null;
+
+            return { speedBytesPerSec, etaSeconds };
+        },
+    };
+}
+
+/**
+ * Formatte une vitesse en Mo/s.
+ *
+ * @param {number} bytesPerSec
+ * @returns {string}
+ */
+export function formatSpeed(bytesPerSec) {
+    const mbPerSec = bytesPerSec / (1024 * 1024);
+    return `${mbPerSec.toFixed(1)} Mo/s`;
+}
+
+/**
+ * Formatte un temps restant estimé en secondes ou minutes.
+ *
+ * @param {number|null} etaSeconds
+ * @returns {string}
+ */
+export function formatEta(etaSeconds) {
+    if (etaSeconds === null || !Number.isFinite(etaSeconds) || etaSeconds < 0) {
+        return 'temps restant inconnu';
+    }
+    if (etaSeconds < 60) {
+        return `${Math.ceil(etaSeconds)}s restantes`;
+    }
+    const minutes = Math.floor(etaSeconds / 60);
+    const seconds = Math.round(etaSeconds % 60);
+    return `${minutes}min ${seconds}s restantes`;
+}

--- a/assets/js/upload-modal.js
+++ b/assets/js/upload-modal.js
@@ -13,6 +13,7 @@
 import '../components/hc-folder-list.js';
 import { apiFetch } from './api.js';
 import { declareBatch, createBatchPoller } from './upload-batch.js';
+import { createEtaTracker, formatSpeed, formatEta } from './upload-eta.js';
 
 const UPLOAD_API_ROUTE = '/api/v1/files';
 const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024; // 5 GB
@@ -300,12 +301,17 @@ function createUploadItem(file) {
 
     const bar = document.createElement('div');
     bar.className = 'upload-item__bar';
-    bar.style.cssText = 'height:100%;background:rgba(59,130,246,0.7);border-radius:1px;transition:width 0.3s ease;width:0%';
+    bar.style.cssText = 'height:100%;border-radius:1px;transition:width 0.3s ease;width:0%';
 
     progress.appendChild(bar);
 
+    const meta = document.createElement('div');
+    meta.className = 'upload-item__meta';
+    meta.style.cssText = 'margin-top:0.25rem';
+
     item.appendChild(header);
     item.appendChild(progress);
+    item.appendChild(meta);
 
     return item;
 }
@@ -317,9 +323,9 @@ function createUploadItem(file) {
  * @returns {string}
  */
 function formatFileSize(bytes) {
-    if (bytes === 0) return '0 B';
+    if (bytes === 0) return '0 o';
     const k = 1024;
-    const sizes = ['B', 'KB', 'MB', 'GB'];
+    const sizes = ['o', 'Ko', 'Mo', 'Go'];
     const i = Math.floor(Math.log(bytes) / Math.log(k));
     return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
 }
@@ -331,8 +337,9 @@ function formatFileSize(bytes) {
  * @param {string} state
  * @param {number} progress
  * @param {string} error
+ * @param {{loaded: number, total: number, speedBytesPerSec: number, etaSeconds: number|null}} [volumeInfo]
  */
-function updateUploadItem(itemEl, state, progress, error) {
+function updateUploadItem(itemEl, state, progress, error, volumeInfo) {
     // Update state class
     const stateClass = state.toLowerCase();
     itemEl.className = `upload-item upload-item--${stateClass}`;
@@ -353,6 +360,17 @@ function updateUploadItem(itemEl, state, progress, error) {
     // Update progress bar
     const barEl = itemEl.querySelector('.upload-item__bar');
     barEl.style.width = `${progress || 0}%`;
+
+    // Update volume/speed/ETA line
+    const metaEl = itemEl.querySelector('.upload-item__meta');
+    if (metaEl) {
+        if (state === 'uploading' && volumeInfo) {
+            const { loaded, total, speedBytesPerSec, etaSeconds } = volumeInfo;
+            metaEl.textContent = `${formatFileSize(loaded)} / ${formatFileSize(total)} — ${formatSpeed(speedBytesPerSec)} — ${formatEta(etaSeconds)}`;
+        } else {
+            metaEl.textContent = '';
+        }
+    }
 
     // Show error message if needed
     if (state === 'error' && error) {
@@ -418,13 +436,28 @@ async function openUploadModal(files, options = {}) {
         itemElements.set(file, itemEl);
     });
 
+    // Tracker de vitesse/ETA par fichier, indexé comme itemElements (#336)
+    const etaTrackers = new Map();
+    files.forEach((file) => {
+        etaTrackers.set(file, createEtaTracker());
+    });
+
     // Create upload queue with callbacks for UI updates
     currentUploadQueue = createUploadQueueFn({
         maxConcurrent: 3,
         onProgress: (file, progress) => {
             const itemEl = itemElements.get(file);
             if (itemEl) {
-                updateUploadItem(itemEl, 'uploading', progress.progress || 0);
+                const loaded = progress.loaded || 0;
+                const total = progress.total || file.size;
+                const tracker = etaTrackers.get(file);
+                const { speedBytesPerSec, etaSeconds } = tracker.sample(loaded, total);
+                updateUploadItem(itemEl, 'uploading', progress.progress || 0, null, {
+                    loaded,
+                    total,
+                    speedBytesPerSec,
+                    etaSeconds,
+                });
             }
         },
         onComplete: (file, response) => {

--- a/assets/styles/upload.css
+++ b/assets/styles/upload.css
@@ -261,10 +261,15 @@
 
 .upload-item__bar {
     height: 100%;
-    background: linear-gradient(90deg, #3b82f6, #60a5fa);
+    background: var(--hc-accent);
     border-radius: 2px;
     transition: width 0.3s ease;
     box-shadow: 0 0 6px rgba(59, 130, 246, 0.4);
+}
+
+.upload-item__meta {
+    font-size: 0.72rem;
+    color: rgba(255, 255, 255, 0.4);
 }
 
 .upload-item--done .upload-item__bar {

--- a/assets/tests/explorer-drop.test.js
+++ b/assets/tests/explorer-drop.test.js
@@ -42,6 +42,7 @@ describe('initExplorerDrop', () => {
         document.body.innerHTML = `
             <div id="main-import-card">
                 <input type="hidden" name="folder_id" value="folder-42">
+                <input type="file" id="import-file-input" multiple>
             </div>
         `;
         handle = initExplorerDrop();
@@ -49,6 +50,37 @@ describe('initExplorerDrop', () => {
 
     afterEach(() => {
         handle.destroy();
+    });
+
+    test("sélection via le bouton Parcourir (#import-file-input) → hc:files-selected, pas de soumission de formulaire native (#336)", async () => {
+        const fileInput = document.getElementById('import-file-input');
+        const file = new File(['x'], 'photo.jpg', { type: 'image/jpeg' });
+        Object.defineProperty(fileInput, 'files', { value: [file], configurable: true });
+
+        const received = jest.fn();
+        document.addEventListener('hc:files-selected', received);
+
+        fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+        await flushMicrotasks();
+
+        expect(received).toHaveBeenCalledTimes(1);
+        const { files, folderId } = received.mock.calls[0][0].detail;
+        expect(folderId).toBe('folder-42');
+        expect(files).toHaveLength(1);
+        expect(files[0]).toBe(file);
+    });
+
+    test('sélection vide (annulation du sélecteur natif) : aucun événement émis', async () => {
+        const fileInput = document.getElementById('import-file-input');
+        Object.defineProperty(fileInput, 'files', { value: [], configurable: true });
+
+        const received = jest.fn();
+        document.addEventListener('hc:files-selected', received);
+
+        fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+        await flushMicrotasks();
+
+        expect(received).not.toHaveBeenCalled();
     });
 
     test("dépose d'un dossier local → hc:files-selected avec relativePath annoté sur chaque File", async () => {

--- a/assets/tests/upload-eta.test.js
+++ b/assets/tests/upload-eta.test.js
@@ -1,0 +1,62 @@
+import { describe, test, expect } from '@jest/globals';
+import { createEtaTracker, formatSpeed, formatEta } from '../js/upload-eta.js';
+
+describe('createEtaTracker', () => {
+    test('un seul échantillon : vitesse nulle, ETA inconnu (pas encore de delta temporel)', () => {
+        let now = 0;
+        const tracker = createEtaTracker({ nowFn: () => now });
+
+        const { speedBytesPerSec, etaSeconds } = tracker.sample(100, 1000);
+        expect(speedBytesPerSec).toBe(0);
+        expect(etaSeconds).toBeNull();
+    });
+
+    test('deux échantillons espacés d\'1s : vitesse moyenne et ETA cohérents', () => {
+        let now = 0;
+        const tracker = createEtaTracker({ nowFn: () => now });
+
+        tracker.sample(0, 1000);
+        now = 1000;
+        const { speedBytesPerSec, etaSeconds } = tracker.sample(100, 1000);
+
+        expect(speedBytesPerSec).toBe(100);
+        expect(etaSeconds).toBeCloseTo(9, 5); // (1000-100)/100
+    });
+
+    test('moyenne glissante : ne garde que les derniers échantillons (fenêtre bornée)', () => {
+        let now = 0;
+        const tracker = createEtaTracker({ nowFn: () => now });
+
+        // 11 échantillons à vitesse constante de 50 octets/s (1 par seconde)
+        let last;
+        for (let i = 0; i <= 10; i++) {
+            now = i * 1000;
+            last = tracker.sample(i * 50, 10000);
+        }
+
+        expect(last.speedBytesPerSec).toBeCloseTo(50, 5);
+    });
+});
+
+describe('formatSpeed', () => {
+    test('formate en Mo/s avec une décimale', () => {
+        expect(formatSpeed(1024 * 1024)).toBe('1.0 Mo/s');
+        expect(formatSpeed(2.5 * 1024 * 1024)).toBe('2.5 Mo/s');
+    });
+});
+
+describe('formatEta', () => {
+    test('moins de 60s : affiche en secondes', () => {
+        expect(formatEta(42)).toBe('42s restantes');
+    });
+
+    test('60s ou plus : affiche en minutes + secondes', () => {
+        expect(formatEta(125)).toBe('2min 5s restantes');
+    });
+
+    test('ETA null ou invalide : message générique', () => {
+        expect(formatEta(null)).toBe('temps restant inconnu');
+        expect(formatEta(-5)).toBe('temps restant inconnu');
+        expect(formatEta(NaN)).toBe('temps restant inconnu');
+    });
+});

--- a/assets/tests/upload-modal-eta.test.js
+++ b/assets/tests/upload-modal-eta.test.js
@@ -1,0 +1,114 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+await import('../components/hc-folder-list.js');
+const { openUploadModal, closeUploadModal } = await import('../js/upload-modal.js');
+
+/**
+ * TDD RED — #336 : volume transféré + vitesse + temps restant estimé
+ * pendant l'upload.
+ *
+ * Réutilise le pattern FakeXHR de upload-modal-progress.test.js (#239)
+ * pour reproduire le chemin réel emprunté en production, avec une horloge
+ * injectée pour rendre le calcul de vitesse déterministe.
+ */
+let createdXHRs = [];
+
+class FakeXHR {
+    constructor() {
+        createdXHRs.push(this);
+        this._listeners = {};
+        this.upload = {
+            _listeners: {},
+            addEventListener(evt, cb) { this._listeners[evt] = cb; },
+        };
+    }
+    addEventListener(evt, cb) { this._listeners[evt] = cb; }
+    open() {}
+    setRequestHeader() {}
+    send() {}
+    fireUploadProgress(loaded, total) {
+        this.upload._listeners['progress']?.({ lengthComputable: true, loaded, total });
+    }
+    fireLoad(status, body) {
+        this.status = status;
+        this.responseText = JSON.stringify(body);
+        this._listeners['load']?.();
+    }
+}
+
+async function flushMicrotasks(times = 20) {
+    for (let i = 0; i < times; i++) {
+        await Promise.resolve();
+    }
+}
+
+describe('openUploadModal — volume, vitesse, ETA (#336)', () => {
+    let now;
+
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        createdXHRs = [];
+        window.HC = { getToken: async () => 'test-token', userId: 'user-1' };
+        global.XMLHttpRequest = FakeXHR;
+        global.fetch = jest.fn().mockResolvedValue({ ok: false });
+
+        now = 1_000_000;
+        jest.spyOn(Date, 'now').mockImplementation(() => now);
+    });
+
+    afterEach(() => {
+        closeUploadModal();
+        jest.restoreAllMocks();
+    });
+
+    test('affiche le volume transféré (X Mo / Y Go), la vitesse et le temps restant estimé', async () => {
+        // 2 Go au total, upload à vitesse constante pour un calcul d'ETA simple
+        const totalSize = 2 * 1024 * 1024 * 1024;
+        const file = new File([''], 'video.mp4', { type: 'video/mp4' });
+        Object.defineProperty(file, 'size', { value: totalSize });
+
+        await openUploadModal([file], {
+            folderId: 'folder-1',
+            folders: [{ id: 'folder-1', name: 'Root' }],
+        });
+
+        document.getElementById('hc-upload-submit-btn').click();
+        await flushMicrotasks();
+        expect(createdXHRs.length).toBe(1);
+
+        // 1er échantillon : 100 Mo transférés à t0
+        const loaded1 = 100 * 1024 * 1024;
+        createdXHRs[0].fireUploadProgress(loaded1, totalSize);
+        await flushMicrotasks();
+
+        // 2e échantillon 1s plus tard : 200 Mo transférés → 100 Mo/s
+        now += 1000;
+        const loaded2 = 200 * 1024 * 1024;
+        createdXHRs[0].fireUploadProgress(loaded2, totalSize);
+        await flushMicrotasks();
+
+        const meta = document.querySelector('.upload-item__meta');
+        expect(meta).not.toBeNull();
+        expect(meta.textContent).toContain('Mo');
+        expect(meta.textContent).toContain('Go');
+        expect(meta.textContent).toMatch(/Mo\/s/);
+        // (2048 Mo - 200 Mo) / 100 Mo/s ≈ 18s restantes
+        expect(meta.textContent).toMatch(/restant/);
+
+        createdXHRs[0].fireLoad(201, { id: 'f1' });
+        await flushMicrotasks();
+    });
+
+    test('la barre de progression ne fige plus de couleur en inline (couleur pilotée par CSS .upload-item__bar → var(--hc-accent))', async () => {
+        const file = new File(['x'.repeat(1000)], 'photo.jpg', { type: 'image/jpeg' });
+
+        await openUploadModal([file], {
+            folderId: 'folder-1',
+            folders: [{ id: 'folder-1', name: 'Root' }],
+        });
+
+        const bar = document.querySelector('.upload-item__bar');
+        expect(bar.classList.contains('upload-item__bar')).toBe(true);
+        expect(bar.getAttribute('style')).not.toMatch(/background/);
+    });
+});

--- a/templates/components/ImportCard.html.twig
+++ b/templates/components/ImportCard.html.twig
@@ -10,7 +10,7 @@
       Cliquez pour importer un fichier<br>ou glissez-déposez ici
     </div>
     <input type="hidden" name="folder_id" value="{{ currentFolder ? currentFolder.id : '' }}">
-    <input type="file" name="file" id="import-file-input" class="hidden" onchange="this.form.submit()">
+    <input type="file" name="file" id="import-file-input" class="hidden" multiple>
     <button type="button" class="import-btn hc-btn-soft font-semibold text-sm px-4 py-2 rounded-md cursor-pointer"
             style="border:none; background: var(--hc-accent-soft); color: var(--hc-accent);"
             onclick="document.getElementById('import-file-input').click();">


### PR DESCRIPTION
## Résumé

- Ajoute une ligne de progression volume/vitesse/ETA sous chaque fichier en cours d'upload dans la modale d'upload (`X Mo / Y Go — Z Mo/s — Ns restantes`)
- Nouveau module pur `assets/js/upload-eta.js` : calcule vitesse moyenne glissante + ETA à partir des échantillons de progression XHR (`nowFn` injectable, testé isolément)
- La barre de progression utilise désormais `var(--hc-accent)` (couleur primary du thème) au lieu du bleu codé en dur
- `formatFileSize` francisé (Ko/Mo/Go au lieu de KB/MB/GB)

Scope volontairement limité à la modale d'upload (dashboard/explorer, `upload-modal.js`). L'import de fichiers depuis un album utilise un flux de formulaire natif séparé, sans progression possible dans son état actuel — voir #339 pour ce chantier distinct.

Closes #336

## Test plan

- [x] Suite Jest complète (125 tests, 29 suites) — aucune régression, y compris tests #239 existants
- [x] Nouveau test `upload-eta.test.js` (module pur : vitesse, ETA, formatters)
- [x] Nouveau test `upload-modal-eta.test.js` (intégration DOM : affichage `.upload-item__meta`, couleur barre pilotée par CSS)