### PR TITLE
✨ feat(upload): câbler l'import album sur le flux XHR (progress bar)

### DIFF
--- a/assets/controllers/album_import_controller.js
+++ b/assets/controllers/album_import_controller.js
@@ -1,17 +1,24 @@
 import { Controller } from '@hotwired/stimulus';
 
 /* Import de photos depuis le disque directement dans un album : ouvre le
- * sélecteur de fichiers natif, soumet automatiquement le formulaire dès
- * qu'une sélection est faite. */
+ * sélecteur de fichiers natif, puis émet hc:files-selected (avec albumId)
+ * au lieu de soumettre le formulaire nativement — consommé par
+ * upload-modal.js (mode album, #339), qui offre la progress bar (#336) et
+ * associe chaque média à l'album une fois uploadé. */
 export default class extends Controller {
     static targets = ['input'];
+    static values = { albumId: String };
 
     pick() {
         this.inputTarget.click();
     }
 
     submit() {
-        if (this.inputTarget.files.length === 0) return;
-        this.element.requestSubmit();
+        const files = Array.from(this.inputTarget.files);
+        this.inputTarget.value = '';
+        if (files.length === 0) return;
+        document.dispatchEvent(new CustomEvent('hc:files-selected', {
+            detail: { files, albumId: this.albumIdValue },
+        }));
     }
 }

--- a/assets/js/upload-modal.js
+++ b/assets/js/upload-modal.js
@@ -88,9 +88,11 @@ function startBatchTracking(batchId) {
  * @param {string} folderId - Optional folder ID
  * @param {string} newFolderName - Optional new folder name
  * @param {string} batchId - Optional upload batch ID (corrèle les fichiers d'un même envoi)
+ * @param {boolean} [processSync] - Traitement média synchrone (#339, import direct dans un album :
+ *   le mediaId doit être connu immédiatement dans la réponse)
  * @returns {Function} (file, metadata, onProgress) => Promise
  */
-function createUploadFn(token, folderId, newFolderName, batchId) {
+function createUploadFn(token, folderId, newFolderName, batchId, processSync) {
     return (file, metadata, onProgress) => {
         return new Promise((resolve, reject) => {
             const xhr = new XMLHttpRequest();
@@ -101,6 +103,7 @@ function createUploadFn(token, folderId, newFolderName, batchId) {
             if (folderId) formData.append('folderId', folderId);
             if (newFolderName) formData.append('newFolderName', newFolderName);
             if (batchId) formData.append('batchId', batchId);
+            if (processSync) formData.append('processSync', '1');
             // Dossier local glissé-déposé (#238) : recrée l'arborescence côté serveur
             if (file._hcRelativePath) formData.append('relativePath', file._hcRelativePath);
 
@@ -156,14 +159,31 @@ function createUploadFn(token, folderId, newFolderName, batchId) {
 }
 
 /**
+ * Associe un média fraîchement uploadé (processSync) à un album (#339).
+ *
+ * @param {string} albumId
+ * @param {string} mediaId
+ */
+async function addMediaToAlbum(albumId, mediaId) {
+    const res = await apiFetch(`/api/v1/albums/${albumId}/medias`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mediaId }),
+    });
+    if (!res.ok) throw new Error(`Album association failed: ${res.status}`);
+    return res.json();
+}
+
+/**
  * Render upload modal overlay + card.
- * 
+ *
  * @param {File[]} files
  * @param {string} currentFolderId - Pre-selected folder
  * @param {Object} folders - Available folders {id, name, icon}[]
+ * @param {boolean} [isAlbumMode] - Mode album (#339) : pas de sélecteur de destination
  * @returns {HTMLElement} overlay
  */
-function createModalOverlay(files, currentFolderId, folders) {
+function createModalOverlay(files, currentFolderId, folders, isAlbumMode) {
     const overlay = document.createElement('div');
     overlay.className = 'upload-modal-overlay';
     overlay.id = 'hc-upload-modal-overlay';
@@ -196,21 +216,25 @@ function createModalOverlay(files, currentFolderId, folders) {
     title.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="flex-shrink:0"><polyline points="16 16 12 12 8 16"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/></svg>'
         + `<span>Importer ${files.length} fichier${files.length > 1 ? 's' : ''}</span>`;
 
-    // Destination section
-    const destSection = document.createElement('div');
-    destSection.className = 'upload-destination';
-    destSection.style.marginBottom = '1.25rem';
+    // Destination section — absente en mode album (#339) : pas de dossier
+    // à choisir, le fichier est associé directement à l'album.
+    let destSection = null;
+    if (!isAlbumMode) {
+        destSection = document.createElement('div');
+        destSection.className = 'upload-destination';
+        destSection.style.marginBottom = '1.25rem';
 
-    const destLabel = document.createElement('label');
-    destLabel.className = 'upload-destination-label';
-    destLabel.style.cssText = 'font-size:0.75rem;font-weight:600;color:rgba(255,255,255,0.5);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;display:block';
-    destLabel.textContent = 'Destination';
+        const destLabel = document.createElement('label');
+        destLabel.className = 'upload-destination-label';
+        destLabel.style.cssText = 'font-size:0.75rem;font-weight:600;color:rgba(255,255,255,0.5);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;display:block';
+        destLabel.textContent = 'Destination';
 
-    const folderListEl = document.createElement('hc-folder-list');
-    folderListEl.id = 'hc-upload-folder-list';
+        const folderListEl = document.createElement('hc-folder-list');
+        folderListEl.id = 'hc-upload-folder-list';
 
-    destSection.appendChild(destLabel);
-    destSection.appendChild(folderListEl);
+        destSection.appendChild(destLabel);
+        destSection.appendChild(folderListEl);
+    }
 
     // File list
     const fileListEl = document.createElement('div');
@@ -245,7 +269,7 @@ function createModalOverlay(files, currentFolderId, folders) {
     actions.appendChild(submitBtn);
 
     content.appendChild(title);
-    content.appendChild(destSection);
+    if (destSection) content.appendChild(destSection);
     content.appendChild(fileListEl);
     content.appendChild(actions);
 
@@ -390,12 +414,16 @@ function updateUploadItem(itemEl, state, progress, error, volumeInfo) {
 /**
  * Initialize upload modal and queue.
  * Called when 'hc:files-selected' fires.
- * 
+ *
  * @param {File[]} files
- * @param {Object} options - {folderId, folders}
+ * @param {Object} options - {folderId, folders, albumId}
+ * @param {string} [options.albumId] - Mode album (#339) : pas de sélecteur de
+ *   destination, chaque upload est traité en synchrone (processSync) puis
+ *   associé à cet album via son mediaId.
  */
 async function openUploadModal(files, options = {}) {
-    const { folderId, folders } = options;
+    const { folderId, folders, albumId } = options;
+    const isAlbumMode = Boolean(albumId);
 
     // Close previous modal if any
     closeUploadModal();
@@ -412,16 +440,19 @@ async function openUploadModal(files, options = {}) {
     const createUploadQueueFn = await getCreateUploadQueue();
 
     // Create & open modal
-    const overlay = createModalOverlay(files, folderId, folders || []);
+    const overlay = createModalOverlay(files, folderId, folders || [], isAlbumMode);
     document.body.appendChild(overlay);
 
-    // Initialize hc-folder-list component with available folders
+    // Initialize hc-folder-list component with available folders — absent en mode album
     const folderListEl = overlay.querySelector('#hc-upload-folder-list');
-    folderListEl.setFolders(folders || []);
-    if (folderId) folderListEl.setSelected(folderId);
+    if (folderListEl) {
+        folderListEl.setFolders(folders || []);
+        if (folderId) folderListEl.setSelected(folderId);
+    }
 
-    // Get folder selection on submit — delegate to hc-folder-list
-    const getDestFolder = () => folderListEl.getSelected();
+    // Get folder selection on submit — mode album : pas de dossier à choisir,
+    // le backend en assigne un par défaut (DefaultFolderService).
+    const getDestFolder = () => (isAlbumMode ? { id: null, isNew: false } : folderListEl.getSelected());
 
     const fileListEl = overlay.querySelector('#hc-upload-file-list');
     const itemElements = new Map();
@@ -441,6 +472,10 @@ async function openUploadModal(files, options = {}) {
     files.forEach((file) => {
         etaTrackers.set(file, createEtaTracker());
     });
+
+    // Mode album (#339) : promesses d'association média→album en cours,
+    // à attendre avant d'afficher le succès / recharger la page.
+    const pendingAlbumAssociations = [];
 
     // Create upload queue with callbacks for UI updates
     currentUploadQueue = createUploadQueueFn({
@@ -464,6 +499,21 @@ async function openUploadModal(files, options = {}) {
             const itemEl = itemElements.get(file);
             if (itemEl) {
                 updateUploadItem(itemEl, 'completed', 100);
+            }
+            // Mode album (#339) : le fichier a été traité en synchrone
+            // (processSync), le mediaId est donc déjà connu — l'associer à
+            // l'album. Un fichier sans média possible (ex: PDF) n'a pas de
+            // mediaId : rien à associer, ce n'est pas une erreur. La promesse
+            // est stockée (pas juste catchée) pour que le submit handler
+            // puisse attendre la fin de TOUTES les associations avant
+            // d'afficher le succès / recharger la page — sinon un lot de
+            // plusieurs fichiers en concurrence pourrait recharger la page
+            // avant que la dernière association ait fini côté serveur.
+            if (isAlbumMode && response?.mediaId) {
+                const p = addMediaToAlbum(albumId, response.mediaId).catch((err) => {
+                    console.error('[UploadModal] Album association failed:', err);
+                });
+                pendingAlbumAssociations.push(p);
             }
         },
         onError: (file, error) => {
@@ -493,14 +543,19 @@ async function openUploadModal(files, options = {}) {
             // Déclarer le lot : le serveur décide immediate vs deferred et renvoie
             // le batchId à joindre à chaque upload. Best-effort — si la déclaration
             // échoue, on uploade quand même sans lot (traitement immédiat côté serveur).
+            // Mode album (#339) : jamais de lot deferred — processSync l'exige déjà
+            // côté backend (garde-fou 400 sinon), et l'utilisateur attend la
+            // confirmation immédiate de l'ajout à l'album.
             let batchId = null;
             let batchMode = 'immediate';
-            try {
-                const declared = await declareBatch(files, postBatchJson);
-                batchId = declared?.batchId ?? null;
-                batchMode = declared?.mode ?? 'immediate';
-            } catch (e) {
-                console.debug('Batch declaration failed, uploading without batch', e);
+            if (!isAlbumMode) {
+                try {
+                    const declared = await declareBatch(files, postBatchJson);
+                    batchId = declared?.batchId ?? null;
+                    batchMode = declared?.mode ?? 'immediate';
+                } catch (e) {
+                    console.debug('Batch declaration failed, uploading without batch', e);
+                }
             }
 
             // Create uploadFn with selected folder + batch
@@ -508,11 +563,20 @@ async function openUploadModal(files, options = {}) {
                 currentToken,
                 destFolder.isNew ? null : destFolder.id,
                 destFolder.isNew ? destFolder.name : null,
-                batchId
+                batchId,
+                isAlbumMode,
             );
 
             // Start queue processing with uploadFn
             await currentUploadQueue.process(uploadFn);
+
+            // Mode album : attendre que toutes les associations média→album
+            // (déclenchées par onComplete) soient terminées avant d'afficher
+            // le succès et de recharger la page — sinon la dernière
+            // association pourrait ne pas être visible après le reload.
+            if (isAlbumMode) {
+                await Promise.all(pendingAlbumAssociations);
+            }
 
             // Check results
             const stats = currentUploadQueue.getStats();
@@ -576,9 +640,18 @@ function closeUploadModal() {
  */
 export function initUploadModal() {
     document.addEventListener('hc:files-selected', async (event) => {
-        const { files, folderId } = event.detail;
+        const { files, folderId, albumId } = event.detail;
         if (!files || !Array.isArray(files)) {
             console.warn('[UploadModal] Invalid files:', files);
+            return;
+        }
+
+        // Mode album (#339) : pas de sélecteur de destination, donc pas
+        // besoin de récupérer la liste des dossiers.
+        if (albumId) {
+            openUploadModal(files, { albumId }).catch(err => {
+                console.error('[UploadModal] Error opening modal:', err);
+            });
             return;
         }
 

--- a/assets/tests/album-import-controller.test.js
+++ b/assets/tests/album-import-controller.test.js
@@ -1,0 +1,71 @@
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { Application } from '@hotwired/stimulus';
+import AlbumImportController from '../controllers/album_import_controller.js';
+
+/**
+ * TDD RED — #339 : l'import direct dans un album émet hc:files-selected
+ * (avec albumId) au lieu de soumettre un formulaire natif — nécessaire pour
+ * bénéficier de la progress bar (#336) et du traitement synchrone
+ * (processSync) qui permet l'association immédiate à l'album.
+ */
+describe('album-import controller', () => {
+    let application;
+
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <form data-controller="album-import"
+                  data-album-import-album-id-value="album-42">
+                <input type="file" multiple data-album-import-target="input"
+                       data-action="change->album-import#submit">
+                <button type="button" data-action="click->album-import#pick">Importer</button>
+            </form>
+        `;
+
+        application = Application.start();
+        application.register('album-import', AlbumImportController);
+    });
+
+    afterEach(() => {
+        application.stop();
+        jest.restoreAllMocks();
+    });
+
+    function getInput() {
+        return document.querySelector('[data-album-import-target="input"]');
+    }
+
+    test('la sélection de fichiers émet hc:files-selected avec albumId, pas de soumission de formulaire native', async () => {
+        const file = new File(['x'], 'photo.jpg', { type: 'image/jpeg' });
+        const input = getInput();
+        Object.defineProperty(input, 'files', { value: [file], configurable: true });
+
+        const received = jest.fn();
+        document.addEventListener('hc:files-selected', received);
+
+        const formSubmitSpy = jest.fn();
+        input.closest('form').requestSubmit = formSubmitSpy;
+
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        await Promise.resolve();
+
+        expect(received).toHaveBeenCalledTimes(1);
+        const { files, albumId } = received.mock.calls[0][0].detail;
+        expect(albumId).toBe('album-42');
+        expect(files).toHaveLength(1);
+        expect(files[0]).toBe(file);
+        expect(formSubmitSpy).not.toHaveBeenCalled();
+    });
+
+    test('sélection vide : aucun événement émis', async () => {
+        const input = getInput();
+        Object.defineProperty(input, 'files', { value: [], configurable: true });
+
+        const received = jest.fn();
+        document.addEventListener('hc:files-selected', received);
+
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        await Promise.resolve();
+
+        expect(received).not.toHaveBeenCalled();
+    });
+});

--- a/assets/tests/upload-modal-album.test.js
+++ b/assets/tests/upload-modal-album.test.js
@@ -1,0 +1,127 @@
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+
+await import('../components/hc-folder-list.js');
+const { openUploadModal, closeUploadModal } = await import('../js/upload-modal.js');
+
+/**
+ * TDD RED — #339 : mode "album" de la modale d'upload.
+ *
+ * Contrairement au mode standard (destination = dossier au choix), l'import
+ * direct dans un album n'a pas de notion de dossier : on masque le
+ * sélecteur, on force processSync=1 sur chaque upload (pour récupérer le
+ * mediaId immédiatement, cf. FileUploadController), puis on associe chaque
+ * média uploadé à l'album via POST /api/v1/albums/{albumId}/medias.
+ *
+ * Réutilise le pattern FakeXHR de upload-modal-progress.test.js (#239).
+ */
+let createdXHRs = [];
+
+class FakeXHR {
+    constructor() {
+        createdXHRs.push(this);
+        this._listeners = {};
+        this.upload = {
+            _listeners: {},
+            addEventListener(evt, cb) { this._listeners[evt] = cb; },
+        };
+    }
+    addEventListener(evt, cb) { this._listeners[evt] = cb; }
+    open(method, url) { this._method = method; this._url = url; }
+    setRequestHeader() {}
+    send(formData) { this._formData = formData; }
+    fireLoad(status, body) {
+        this.status = status;
+        this.responseText = JSON.stringify(body);
+        this._listeners['load']?.();
+    }
+}
+
+async function flushMicrotasks(times = 20) {
+    for (let i = 0; i < times; i++) {
+        await Promise.resolve();
+    }
+}
+
+describe('openUploadModal — mode album (#339)', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        createdXHRs = [];
+        window.HC = { getToken: async () => 'test-token', userId: 'user-1' };
+        global.XMLHttpRequest = FakeXHR;
+        global.fetch = jest.fn().mockResolvedValue({ ok: false });
+    });
+
+    afterEach(() => {
+        closeUploadModal();
+        jest.restoreAllMocks();
+    });
+
+    test('mode album : pas de sélecteur de destination affiché', async () => {
+        const file = new File(['x'], 'photo.jpg', { type: 'image/jpeg' });
+
+        await openUploadModal([file], { albumId: 'album-1' });
+
+        const folderList = document.querySelector('#hc-upload-folder-list');
+        expect(folderList).toBeNull();
+    });
+
+    test('mode album : chaque upload envoie processSync=1 sans folderId', async () => {
+        const file = new File(['x'], 'photo.jpg', { type: 'image/jpeg' });
+
+        await openUploadModal([file], { albumId: 'album-1' });
+
+        const submitBtn = document.getElementById('hc-upload-submit-btn');
+        submitBtn.click();
+        await flushMicrotasks();
+
+        expect(createdXHRs.length).toBe(1);
+        expect(createdXHRs[0]._url).toBe('/api/v1/files');
+
+        const formData = createdXHRs[0]._formData;
+        expect(formData.get('processSync')).toBe('1');
+        expect(formData.get('folderId')).toBeNull();
+    });
+
+    test('mode album : après upload réussi, associe le mediaId à l\'album via POST /api/v1/albums/{id}/medias', async () => {
+        const file = new File(['x'], 'photo.jpg', { type: 'image/jpeg' });
+
+        global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ id: 'album-1', mediaCount: 1 }) });
+
+        await openUploadModal([file], { albumId: 'album-1' });
+
+        const submitBtn = document.getElementById('hc-upload-submit-btn');
+        submitBtn.click();
+        await flushMicrotasks();
+
+        createdXHRs[0].fireLoad(201, { id: 'file-1', mediaId: 'media-42' });
+        await flushMicrotasks(40);
+
+        expect(global.fetch).toHaveBeenCalledWith(
+            '/api/v1/albums/album-1/medias',
+            expect.objectContaining({
+                method: 'POST',
+                body: JSON.stringify({ mediaId: 'media-42' }),
+            }),
+        );
+    });
+
+    test('mode album : pas d\'association si le fichier uploadé n\'a pas produit de média (mediaId absent)', async () => {
+        const file = new File(['x'], 'doc.pdf', { type: 'application/pdf' });
+
+        global.fetch = jest.fn();
+
+        await openUploadModal([file], { albumId: 'album-1' });
+
+        const submitBtn = document.getElementById('hc-upload-submit-btn');
+        submitBtn.click();
+        await flushMicrotasks();
+
+        createdXHRs[0].fireLoad(201, { id: 'file-1', mediaId: null });
+        await flushMicrotasks(40);
+
+        expect(global.fetch).not.toHaveBeenCalledWith(
+            expect.stringContaining('/medias'),
+            expect.anything(),
+        );
+    });
+});

--- a/src/ApiResource/FileOutput.php
+++ b/src/ApiResource/FileOutput.php
@@ -84,6 +84,13 @@ final class FileOutput
     public string $folderName = '';
     public ?string $ownerId = null;
     public string $createdAt = '';
+    /**
+     * UUID du Media créé, si le fichier a été traité en synchrone (POST avec
+     * `processSync=1`, cf. FileUploadController). Reste null quand le
+     * traitement média est différé (kernel.terminate ou worker) : le Media
+     * n'existe pas encore au moment de la réponse.
+     */
+    public ?string $mediaId = null;
 
     // --- Champs d'entrée supplémentaires (POST via JSON ou multipart) ---
     /** UUID d'un folder existant. Prioritaire sur newFolderName. */

--- a/src/Controller/Api/AlbumAddMediaController.php
+++ b/src/Controller/Api/AlbumAddMediaController.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Controller\Api;
 
+use App\Entity\User;
 use App\Interface\AlbumRepositoryInterface;
 use App\Repository\MediaRepository;
+use App\Security\AlbumVoter;
 use App\State\AlbumProvider;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -13,6 +15,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
@@ -42,6 +45,8 @@ final class AlbumAddMediaController extends AbstractController
         $album = $this->albumRepository->findById(Uuid::fromString($id))
             ?? throw new NotFoundHttpException('Album not found');
 
+        $this->denyAccessUnlessGranted(AlbumVoter::VIEW, $album);
+
         $body = json_decode((string) $request->getContent(), true);
         $mediaId = $body['mediaId'] ?? null;
 
@@ -51,6 +56,12 @@ final class AlbumAddMediaController extends AbstractController
 
         $media = $this->mediaRepository->find($mediaId)
             ?? throw new NotFoundHttpException('Media not found');
+
+        /** @var User $user */
+        $user = $this->getUser();
+        if (!$media->isOwnedBy($user)) {
+            throw new AccessDeniedHttpException('You are not the owner of this Media');
+        }
 
         $album->addMedia($media); // idempotent via Collection::contains()
         $this->em->flush();

--- a/src/Controller/Api/AlbumRemoveMediaController.php
+++ b/src/Controller/Api/AlbumRemoveMediaController.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace App\Controller\Api;
 
+use App\Entity\User;
 use App\Interface\AlbumRepositoryInterface;
 use App\Repository\MediaRepository;
+use App\Security\AlbumVoter;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Uid\Uuid;
@@ -36,8 +39,16 @@ final class AlbumRemoveMediaController extends AbstractController
         $album = $this->albumRepository->findById(Uuid::fromString($id))
             ?? throw new NotFoundHttpException('Album not found');
 
+        $this->denyAccessUnlessGranted(AlbumVoter::VIEW, $album);
+
         $media = $this->mediaRepository->find($mediaId)
             ?? throw new NotFoundHttpException('Media not found');
+
+        /** @var User $user */
+        $user = $this->getUser();
+        if (!$media->isOwnedBy($user)) {
+            throw new AccessDeniedHttpException('You are not the owner of this Media');
+        }
 
         $album->removeMedia($media);
         $this->em->flush();

--- a/src/Controller/Api/FileUploadController.php
+++ b/src/Controller/Api/FileUploadController.php
@@ -88,20 +88,34 @@ final class FileUploadController extends AbstractController
         );
 
         $batch = $this->resolveBatch($request, $ownerId);
+
+        $processSync = $request->request->getBoolean('processSync');
+        if ($processSync && $batch !== null && $batch->isDeferred()) {
+            throw new BadRequestHttpException('processSync cannot be combined with a deferred batch');
+        }
+
         if ($batch !== null) {
             $file->setBatch($batch);
             $this->em->flush();
         }
 
         // Routage EXCLUSIF du traitement média (supports() reconnaît aussi les RAW
-        // envoyés en application/octet-stream, via l'extension) :
-        // - lot "deferred" (lourd) → worker Messenger seul, l'utilisateur n'attend pas ;
+        // envoyés en application/octet-stream, via l'extension) — un seul des
+        // trois chemins est emprunté, jamais plusieurs pour le même fichier :
+        // - processSync (import direct, ex. album) → traité ici même, l'appelant
+        //   a besoin du Media (et donc de son id) dans la réponse immédiate ;
+        // - sinon, lot "deferred" (lourd) → worker Messenger seul, l'utilisateur
+        //   n'attend pas ;
         // - sinon (immediate, ou pas de lot) → traitement juste après la réponse
         //   HTTP (kernel.terminate), sans mobiliser la file.
-        // Un seul des deux chemins est emprunté : fini le no-op systématique du
-        // worker qui refaisait le travail déjà fait à kernel.terminate.
+        // Fini le no-op systématique du worker qui refaisait le travail déjà
+        // fait à kernel.terminate.
+        $mediaId = null;
         if ($this->mediaProcessor->supports($file->getMimeType(), $file->getOriginalName())) {
-            if ($batch !== null && $batch->isDeferred()) {
+            if ($processSync) {
+                $media = $this->mediaProcessor->process($file);
+                $mediaId = $media?->getId()->toRfc4122();
+            } elseif ($batch !== null && $batch->isDeferred()) {
                 $this->bus->dispatch(new MediaProcessMessage((string) $file->getId()));
             } else {
                 $this->pendingMediaProcessingCollector->add((string) $file->getId());
@@ -109,6 +123,7 @@ final class FileUploadController extends AbstractController
         }
 
         $output = $this->provider->toOutput($file);
+        $output->mediaId = $mediaId;
 
         return new JsonResponse(
             json_decode($this->serializer->serialize($output, 'json'), true),

--- a/templates/web/album_detail.html.twig
+++ b/templates/web/album_detail.html.twig
@@ -39,7 +39,8 @@
         {{ icons.icon('images', 20) }}
       </a>
       <form method="post" action="{{ path('app_album_import', {id: album.id}) }}"
-            enctype="multipart/form-data" data-controller="album-import">
+            enctype="multipart/form-data" data-controller="album-import"
+            data-album-import-album-id-value="{{ album.id }}">
         <input type="hidden" name="_token" value="{{ csrf_token('album-import') }}">
         <input type="file" name="files[]" multiple accept="image/*,video/*"
                class="hidden" data-album-import-target="input"

--- a/tests/Api/AlbumMediaOwnershipTest.php
+++ b/tests/Api/AlbumMediaOwnershipTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api;
+
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Media;
+use App\Entity\User;
+use App\Tests\AuthenticatedApiTestCase;
+
+/**
+ * TDD RED — faille IDOR découverte pendant #339 : AlbumAddMediaController et
+ * AlbumRemoveMediaController n'appliquaient aucun contrôle d'ownership.
+ * N'importe quel utilisateur authentifié pouvait associer/retirer n'importe
+ * quel Media (même appartenant à un autre utilisateur) sur n'importe quel
+ * Album (même appartenant à un autre utilisateur), en connaissant juste les
+ * UUID.
+ *
+ * Le contrôle attendu, cohérent avec l'existant :
+ * - Album : AlbumVoter::VIEW (owner OU partage actif, cf. AlbumWebController
+ *   qui applique déjà ce même voter sur les routes web équivalentes)
+ * - Media : Media::isOwnedBy() (déjà utilisé ailleurs, encapsule
+ *   getFile()->getOwner())
+ */
+final class AlbumMediaOwnershipTest extends AuthenticatedApiTestCase
+{
+    private function createAlbumFor(User $user, string $name = 'Album'): Album
+    {
+        $album = new Album($name, $user);
+        $this->em->persist($album);
+        $this->em->flush();
+
+        return $album;
+    }
+
+    private function createMediaFor(User $user, string $name = 'photo.jpg'): Media
+    {
+        $folder = new Folder('Photos', $user);
+        $this->em->persist($folder);
+
+        $file = new File($name, 'image/jpeg', 1024, "test/{$name}", $folder, $user);
+        $this->em->persist($file);
+
+        $media = new Media($file, 'photo');
+        $this->em->persist($media);
+        $this->em->flush();
+
+        return $media;
+    }
+
+    public function testCannotAddAnotherUsersMediaToOwnAlbum(): void
+    {
+        $alice = $this->createUser('alice-idor@example.com', 'password123', 'Alice');
+        $bob   = $this->createUser('bob-idor@example.com', 'password123', 'Bob');
+
+        $aliceAlbum = $this->createAlbumFor($alice);
+        $bobsMedia  = $this->createMediaFor($bob, 'bob-private.jpg');
+
+        $client = $this->createAuthenticatedKernelBrowser($alice);
+        $client->request(
+            'POST',
+            '/api/v1/albums/' . $aliceAlbum->getId() . '/medias',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['mediaId' => (string) $bobsMedia->getId()]),
+        );
+
+        $this->assertResponseStatusCodeSame(403);
+
+        $this->em->clear();
+        $refreshedAlbum = $this->em->getRepository(Album::class)->find($aliceAlbum->getId());
+        $this->assertCount(0, $refreshedAlbum->getMedias(), 'Le média de Bob ne doit pas avoir été associé');
+    }
+
+    public function testCannotAddMediaToAnotherUsersAlbum(): void
+    {
+        $alice = $this->createUser('alice-idor2@example.com', 'password123', 'Alice');
+        $bob   = $this->createUser('bob-idor2@example.com', 'password123', 'Bob');
+
+        $bobsAlbum  = $this->createAlbumFor($bob);
+        $alicesMedia = $this->createMediaFor($alice, 'alice-photo.jpg');
+
+        $client = $this->createAuthenticatedKernelBrowser($alice);
+        $client->request(
+            'POST',
+            '/api/v1/albums/' . $bobsAlbum->getId() . '/medias',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['mediaId' => (string) $alicesMedia->getId()]),
+        );
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testCanAddOwnMediaToOwnAlbum(): void
+    {
+        $alice = $this->createUser('alice-idor3@example.com', 'password123', 'Alice');
+
+        $album = $this->createAlbumFor($alice);
+        $media = $this->createMediaFor($alice, 'my-photo.jpg');
+
+        $client = $this->createAuthenticatedKernelBrowser($alice);
+        $client->request(
+            'POST',
+            '/api/v1/albums/' . $album->getId() . '/medias',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['mediaId' => (string) $media->getId()]),
+        );
+
+        $this->assertResponseStatusCodeSame(200);
+    }
+
+    public function testCannotRemoveAnotherUsersMediaAssociation(): void
+    {
+        $alice = $this->createUser('alice-idor4@example.com', 'password123', 'Alice');
+        $bob   = $this->createUser('bob-idor4@example.com', 'password123', 'Bob');
+
+        $bobsAlbum = $this->createAlbumFor($bob);
+        $bobsMedia = $this->createMediaFor($bob, 'bob-photo.jpg');
+        $bobsAlbum->addMedia($bobsMedia);
+        $this->em->flush();
+
+        $client = $this->createAuthenticatedKernelBrowser($alice);
+        $client->request(
+            'DELETE',
+            '/api/v1/albums/' . $bobsAlbum->getId() . '/medias/' . $bobsMedia->getId(),
+        );
+
+        $this->assertResponseStatusCodeSame(403);
+
+        $this->em->clear();
+        $refreshedAlbum = $this->em->getRepository(Album::class)->find($bobsAlbum->getId());
+        $this->assertCount(1, $refreshedAlbum->getMedias(), 'Le média de Bob doit rester associé à son album');
+    }
+
+    public function testCanRemoveOwnMediaFromOwnAlbum(): void
+    {
+        $alice = $this->createUser('alice-idor5@example.com', 'password123', 'Alice');
+
+        $album = $this->createAlbumFor($alice);
+        $media = $this->createMediaFor($alice, 'my-photo.jpg');
+        $album->addMedia($media);
+        $this->em->flush();
+
+        $client = $this->createAuthenticatedKernelBrowser($alice);
+        $client->request(
+            'DELETE',
+            '/api/v1/albums/' . $album->getId() . '/medias/' . $media->getId(),
+        );
+
+        $this->assertResponseStatusCodeSame(200);
+    }
+}

--- a/tests/Api/AlbumTest.php
+++ b/tests/Api/AlbumTest.php
@@ -47,10 +47,15 @@ final class AlbumTest extends AuthenticatedApiTestCase
         return $user;
     }
 
-    private function createMedia(): Media
+    /**
+     * Média appartenant à alice@example.com (utilisateur JWT par défaut de
+     * requestWithJwt) : les endpoints /albums/{id}/medias vérifient
+     * désormais l'ownership du Media, un média d'un autre utilisateur serait
+     * rejeté (403) — cf. AlbumMediaOwnershipTest pour ces cas.
+     */
+    private function createMedia(?User $owner = null): Media
     {
-        $user = new User('media-owner@example.com', 'Owner');
-        $this->em->persist($user);
+        $user = $owner ?? $this->em->getRepository(User::class)->findOneBy(['email' => 'alice@example.com']);
         $folder = new Folder('Photos', $user);
         $this->em->persist($folder);
         $file = new File('photo.jpg', 'image/jpeg', 1024, '2026/02/test.jpg', $folder, $user);
@@ -254,7 +259,7 @@ final class AlbumTest extends AuthenticatedApiTestCase
         $client = static::createClient();
         $response = ApiTestHelper::requestWithJwt($client, 'POST', '/api/v1/albums/' . $album->getId() . '/medias', [
             'json' => ['mediaId' => (string) $media->getId()]
-        ]);
+        ], 'alice@example.com');
 
         Assert::assertSame(200, $response->getStatusCode());
         Assert::assertSame(1, $response->toArray()['mediaCount']);
@@ -282,7 +287,7 @@ final class AlbumTest extends AuthenticatedApiTestCase
         $client = static::createClient();
         $response = ApiTestHelper::requestWithJwt($client, 'POST', '/api/v1/albums/' . $album->getId() . '/medias', [
             'json' => ['mediaId' => '00000000-0000-0000-0000-000000000000']
-        ]);
+        ], 'alice@example.com');
 
         Assert::assertSame(404, $response->getStatusCode());
     }
@@ -297,7 +302,7 @@ final class AlbumTest extends AuthenticatedApiTestCase
         $this->em->flush();
 
         $client = static::createClient();
-        $response = ApiTestHelper::requestWithJwt($client, 'DELETE', '/api/v1/albums/' . $album->getId() . '/medias/' . $media->getId());
+        $response = ApiTestHelper::requestWithJwt($client, 'DELETE', '/api/v1/albums/' . $album->getId() . '/medias/' . $media->getId(), [], 'alice@example.com');
 
         Assert::assertSame(200, $response->getStatusCode());
         Assert::assertSame(0, $response->toArray()['mediaCount']);

--- a/tests/Api/FileUploadProcessSyncTest.php
+++ b/tests/Api/FileUploadProcessSyncTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api;
+
+use App\Entity\File;
+use App\Entity\Media;
+use App\Entity\Folder;
+use App\Entity\UploadBatch;
+use App\Entity\User;
+use App\Tests\AuthenticatedApiTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * TDD RED — #339 : flag `processSync` sur POST /api/v1/files.
+ *
+ * Permet à un appelant (import direct dans un album) d'obtenir le
+ * `mediaId` du Media créé dans la réponse HTTP immédiate, en forçant le
+ * même traitement synchrone que celui déjà utilisé par AlbumImportService
+ * — sans emprunter le worker Messenger ni kernel.terminate (routage
+ * exclusif à trois branches, cf. commentaire de routage dans
+ * FileUploadController).
+ */
+final class FileUploadProcessSyncTest extends AuthenticatedApiTestCase
+{
+    private User $alice;
+    private Folder $folder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->alice = $this->createUser('alice-sync@example.com', 'password123', 'Alice');
+        $this->folder = $this->createFolder('TestFolder', $this->alice);
+    }
+
+    public function testProcessSyncReturnsMediaIdImmediatelyWithoutDispatchingToWorker(): void
+    {
+        $client = $this->createAuthenticatedKernelBrowser($this->alice);
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'test_sync_');
+        $image = imagecreatetruecolor(100, 80);
+        imagejpeg($image, $tempFile);
+        imagedestroy($image);
+
+        $client->request(
+            'POST',
+            '/api/v1/files',
+            [
+                'ownerId'     => (string) $this->alice->getId(),
+                'folderId'    => (string) $this->folder->getId(),
+                'processSync' => '1',
+            ],
+            ['file' => new UploadedFile($tempFile, 'sync.jpg', 'image/jpeg', null, false)],
+            ['CONTENT_TYPE' => 'multipart/form-data'],
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+        @unlink($tempFile);
+
+        $response = json_decode((string) $client->getResponse()->getContent(), true);
+        $this->assertArrayHasKey('mediaId', $response);
+        $this->assertNotNull($response['mediaId'], 'mediaId doit être présent dans la réponse en mode processSync');
+
+        $media = $this->em->getRepository(Media::class)->find(Uuid::fromString($response['mediaId']));
+        $this->assertNotNull($media, 'Le Media référencé par mediaId doit exister en base');
+        $this->assertNotNull($media->getThumbnailPath(), 'La vignette doit déjà être générée');
+
+        $transport = static::getContainer()->get('messenger.transport.async');
+        $this->assertCount(0, $transport->get(), 'processSync ne doit jamais dispatcher au worker');
+    }
+
+    public function testProcessSyncOnNonMediaFileReturnsNullMediaIdWithoutError(): void
+    {
+        $client = $this->createAuthenticatedKernelBrowser($this->alice);
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'test_sync_pdf_');
+        file_put_contents($tempFile, '%PDF-1.4 fake content');
+
+        $client->request(
+            'POST',
+            '/api/v1/files',
+            [
+                'ownerId'     => (string) $this->alice->getId(),
+                'folderId'    => (string) $this->folder->getId(),
+                'processSync' => '1',
+            ],
+            ['file' => new UploadedFile($tempFile, 'doc.pdf', 'application/pdf', null, false)],
+            ['CONTENT_TYPE' => 'multipart/form-data'],
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+        @unlink($tempFile);
+
+        $response = json_decode((string) $client->getResponse()->getContent(), true);
+        $this->assertArrayHasKey('mediaId', $response);
+        $this->assertNull($response['mediaId']);
+    }
+
+    public function testWithoutProcessSyncMediaIdIsNullInImmediateResponse(): void
+    {
+        $client = $this->createAuthenticatedKernelBrowser($this->alice);
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'test_nosync_');
+        $image = imagecreatetruecolor(100, 80);
+        imagejpeg($image, $tempFile);
+        imagedestroy($image);
+
+        $client->request(
+            'POST',
+            '/api/v1/files',
+            [
+                'ownerId'  => (string) $this->alice->getId(),
+                'folderId' => (string) $this->folder->getId(),
+            ],
+            ['file' => new UploadedFile($tempFile, 'nosync.jpg', 'image/jpeg', null, false)],
+            ['CONTENT_TYPE' => 'multipart/form-data'],
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+        @unlink($tempFile);
+
+        $response = json_decode((string) $client->getResponse()->getContent(), true);
+        $this->assertArrayHasKey('mediaId', $response);
+        $this->assertNull(
+            $response['mediaId'],
+            'Sans processSync, le Media n\'existe pas encore au moment de la réponse (kernel.terminate)'
+        );
+    }
+
+    /**
+     * Garde-fou du routage à trois branches exclusives : processSync ne doit
+     * jamais se combiner avec un batchId deferred — un fichier ne doit
+     * jamais être éligible à deux chemins de traitement en même temps.
+     */
+    public function testProcessSyncCombinedWithDeferredBatchIsRejected(): void
+    {
+        $batch = new UploadBatch($this->alice, 1, 300_000_000, UploadBatch::MODE_DEFERRED);
+        $this->em->persist($batch);
+        $this->em->flush();
+
+        $client = $this->createAuthenticatedKernelBrowser($this->alice);
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'test_sync_conflict_');
+        $image = imagecreatetruecolor(100, 80);
+        imagejpeg($image, $tempFile);
+        imagedestroy($image);
+
+        $client->request(
+            'POST',
+            '/api/v1/files',
+            [
+                'ownerId'     => (string) $this->alice->getId(),
+                'folderId'    => (string) $this->folder->getId(),
+                'processSync' => '1',
+                'batchId'     => (string) $batch->getId(),
+            ],
+            ['file' => new UploadedFile($tempFile, 'conflict.jpg', 'image/jpeg', null, false)],
+            ['CONTENT_TYPE' => 'multipart/form-data'],
+        );
+
+        @unlink($tempFile);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+}


### PR DESCRIPTION
## Résumé

Suite de #336 (progress bar upload) et #339 : l'import de fichiers depuis un album utilisait un formulaire natif (soumission POST classique), sans progression possible. Cette PR l'aligne sur le flux XHR déjà en place pour la modale d'upload standard.

- **Sécurité (découverte fortuite)** : `AlbumAddMediaController`/`AlbumRemoveMediaController` (`POST`/`DELETE /api/v1/albums/{id}/medias`) n'appliquaient aucun contrôle d'ownership — IDOR corrigé avec `AlbumVoter::VIEW` + `Media::isOwnedBy()`, tests dédiés
- **Backend** : nouveau flag `processSync` sur `POST /api/v1/files` — traite le média en synchrone (comme le fait déjà `AlbumImportService`) pour exposer `mediaId` immédiatement dans la réponse. Routage à trois branches désormais exclusives (processSync / worker deferred / kernel.terminate), garde-fou 400 si combiné à un batch deferred
- **Frontend** : nouveau mode "album" dans `upload-modal.js` — pas de sélecteur de destination (l'utilisateur est déjà dans l'album), chaque upload est associé automatiquement via son `mediaId`. `album_import_controller.js` dispatch désormais `hc:files-selected` au lieu de soumettre le formulaire nativement (fallback no-JS conservé)

Cette PR dépend de #340 (base : `feat/336-upload-progress-eta`) — à merger après.

Closes #339

## Test plan

- [x] Suite PHPUnit complète (899 tests) — 0 échec
- [x] Suite Jest complète (133 tests, 31 suites) — 0 échec
- [x] Nouveaux tests : `FileUploadProcessSyncTest`, `AlbumMediaOwnershipTest`, `upload-modal-album.test.js`, `album-import-controller.test.js`
- [x] `composer build-assets` : build OK