### PR TITLE
📝 docs(frontend): remplacer la doc Liquid Glass par le design system theme.css

### DIFF
--- a/.claude/frontend.md
+++ b/.claude/frontend.md
@@ -1,21 +1,27 @@
 # Design Frontend
 
-## Style : Material Design + Liquid Glass
+## Style : design system `theme.css` (variables `--hc-*`)
 
-Glassmorphism avec distorsion SVG (`feTurbulence` / `feDisplacementMap`).
+Le design system actif repose sur `assets/styles/theme.css` : variables CSS custom, palette light/dark, ombres nettes (pas de glassmorphism, pas de `backdrop-filter` décoratif).
 
-## Palette Tailwind v4
+## Variables principales (`--hc-*`)
 
-| Rôle         | Valeur                                              |
-|--------------|-----------------------------------------------------|
-| Fond page    | `from-slate-900 via-blue-950 to-indigo-900`         |
-| Surface      | `bg-white/10 backdrop-blur-2xl` + SVG filter        |
-| Accent       | `bg-blue-500` / `text-blue-400`                     |
-| Arrondi      | `rounded-2xl` ou `rounded-3xl` (toujours)           |
-| Transitions  | `transition-all` sur tous les éléments interactifs  |
+| Rôle                 | Variable(s)                                                        |
+|----------------------|---------------------------------------------------------------------|
+| Accent               | `--hc-accent`, `--hc-accent-2`, `--hc-accent-soft`                 |
+| Accents secondaires  | `--hc-indigo`, `--hc-indigo-soft`, `--hc-green`, `--hc-green-soft` |
+| Fond                 | `--hc-bg`, `--hc-bg-2`                                             |
+| Surface              | `--hc-surface`, `--hc-surface-2`, `--hc-surface-strong`, `--hc-input` |
+| Bordure              | `--hc-border`, `--hc-border-row`, `--hc-border-strong`             |
+| Texte                | `--hc-text`, `--hc-text-2`, `--hc-text-3`                          |
+| Ombre                | `--hc-shadow`, `--hc-shadow-lg`, `--hc-shadow-crisp`               |
+| Statuts              | `--hc-ok`, `--hc-warn`, `--hc-err`                                 |
+
+Dark mode : `[data-theme="dark"]` (toggle JS) ou `@media (prefers-color-scheme: dark)` en fallback OS. Toute nouvelle valeur de couleur doit passer par ces variables plutôt que des couleurs Tailwind en dur, pour rester cohérente entre light et dark.
 
 ## Règles
 
 - Jamais de coins droits (`rounded-none`) sur les cards ou boutons
-- Toujours `transition-all` sur les éléments cliquables/survolables
-- Le SVG filter de distorsion s'applique sur les surfaces flottantes (modals, cards)
+- Toujours `transition-all` (ou `transition-colors`) sur les éléments cliquables/survolables
+- Toute surface (modal, card, toolbar) doit utiliser `var(--hc-surface)` / `var(--hc-border)` / `var(--hc-shadow-lg)` — pas de `bg-white/x`, `backdrop-blur`, ou couleurs Tailwind en dur
+- Pas de `backdrop-filter` décoratif : les seuls flous tolérés sont des overlays de lisibilité texte/icône sur média (galerie, albums), à valider au cas par cas


### PR DESCRIPTION
## Résumé

Étape 1/9 du chantier #341 : réécriture de `.claude/frontend.md`.

Le style glassmorphism documenté (distorsion SVG `feTurbulence`/`feDisplacementMap`) est un reliquat de POC abandonné qui n'existe nulle part dans le repo (vérifié, y compris dans `templates/web/layout.html.twig`) — trompeur pour les futurs agents/devs. Le design system réellement actif est `theme.css` (variables `--hc-*`, palette light/dark, ombres nettes).

Réf #341 (chantier en plusieurs PRs, ticket pas encore fermé).

## Test plan

- [x] Doc pure, zéro risque technique — pas de code touché
- [ ] Relecture du contenu par @ronan-develop