### PR TITLE
🔥 chore(css): supprimer la référence SVG cassée dans upload.css

### DIFF
--- a/assets/styles/upload.css
+++ b/assets/styles/upload.css
@@ -38,7 +38,6 @@
     inset: 0;
     background: rgba(255, 255, 255, 0.08);
     backdrop-filter: blur(24px) saturate(200%);
-    filter: url(#lg); /* SVG turbulence displacement (defined in layout.html.twig) */
     pointer-events: none;
     border-radius: 1.6rem;
 }


### PR DESCRIPTION
## Résumé

Étape 3/9 du chantier #341.

- Suppression de `filter: url(#lg)` dans `assets/styles/upload.css:41` : référençait un `<filter id="lg">` censé être défini dans `layout.html.twig` — confirmé inexistant dans tout le repo (`templates/web/layout.html.twig` inclus). No-op silencieux déjà cassé.

**Note** : le ticket #341 mentionnait aussi des commentaires morts dans `templates/components/NewMenu.html.twig` et `assets/controllers/new_menu_controller.js`. Vérification faite : ces deux fichiers ne contiennent aucune référence au SVG/glassmorphism (uniquement des icônes `<svg>` normales sans rapport). Rien à nettoyer là — étape limitée à la correction réellement confirmée.

Réf #341 (chantier en plusieurs PRs, ticket pas encore fermé).

## Test plan

- [x] `composer dev-check` : build assets OK, 899 tests PHPUnit OK
- [x] Grep confirmé : `<filter id="lg">` inexistant dans tout le repo
- [ ] Vérifier visuellement que la modale d'upload ne régresse pas (le filtre était déjà un no-op)