### PR TITLE
🔥 chore(css): migrer les modales Twig du glassmorphism vers theme.css

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -5,6 +5,7 @@
 @import "./layout.css";
 @import "./app-shell.css";
 @import "./sidebar-folders.css";
+@import "./modals.css";
 @import "./login.css";
 @import "./reset-password.css";
 @import "./error-page.css";

--- a/assets/styles/modals.css
+++ b/assets/styles/modals.css
@@ -1,0 +1,73 @@
+/*
+ * assets/styles/modals.css
+ * Styles communs aux modales simples (Rename, DeleteFolder, Move, MediaViewer,
+ * PdfViewer, MainToolbar/recherche, reset-password) — remplace le pattern
+ * glassmorphism répété (bg-white/10 backdrop-blur-2xl border-white/20).
+ * cf. share-modal.css pour le pattern équivalent de la modale de partage.
+ */
+
+.hc-modal-overlay {
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.hc-modal-card {
+  background: var(--hc-surface);
+  color: var(--hc-text);
+  border: 1px solid var(--hc-border);
+  box-shadow: var(--hc-shadow-crisp);
+}
+
+.hc-modal-title {
+  color: var(--hc-text);
+}
+
+.hc-modal-text {
+  color: var(--hc-text-2);
+}
+
+.hc-modal-input {
+  background: var(--hc-input);
+  border: 1px solid var(--hc-border);
+  color: var(--hc-text);
+}
+
+.hc-modal-input::placeholder {
+  color: var(--hc-text-3);
+}
+
+.hc-modal-btn-cancel {
+  color: var(--hc-text-2);
+}
+
+.hc-modal-btn-cancel:hover {
+  color: var(--hc-text);
+  background: var(--hc-surface-2);
+}
+
+.hc-modal-option {
+  border: 1px solid var(--hc-border);
+}
+
+.hc-modal-option--danger {
+  background: rgba(239, 68, 68, 0.08);
+  border-color: rgba(239, 68, 68, 0.25);
+  color: var(--hc-err);
+}
+
+.hc-modal-option--danger:hover {
+  background: rgba(239, 68, 68, 0.14);
+}
+
+.hc-modal-option--warn {
+  background: rgba(245, 158, 11, 0.08);
+  border-color: rgba(245, 158, 11, 0.25);
+  color: var(--hc-warn);
+}
+
+.hc-modal-option--warn:hover {
+  background: rgba(245, 158, 11, 0.14);
+}
+
+.hc-modal-option-desc {
+  color: var(--hc-text-2);
+}

--- a/templates/components/DeleteFolderModal.html.twig
+++ b/templates/components/DeleteFolderModal.html.twig
@@ -1,18 +1,17 @@
 {# Modale de suppression de dossier avec options #}
 <div id="delete-folder-modal"
-     class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+     class="hc-modal-overlay hidden fixed inset-0 z-50 flex items-center justify-center"
      tabindex="-1"
      aria-modal="true"
      role="dialog">
-  <div class="bg-white/10 backdrop-blur-2xl border border-white/20 rounded-3xl
-              shadow-2xl p-6 w-full max-w-md mx-4">
+  <div class="hc-modal-card rounded-3xl p-6 w-full max-w-md mx-4">
 
-    <h2 class="text-white text-xl font-semibold mb-2">
+    <h2 class="hc-modal-title text-xl font-semibold mb-2">
       Supprimer le dossier
     </h2>
-    <p class="text-white/70 text-sm mb-5">
+    <p class="hc-modal-text text-sm mb-5">
       Que souhaitez-vous faire avec le contenu de
-      <strong id="delete-folder-name" class="text-white">ce dossier</strong> ?
+      <strong id="delete-folder-name" class="hc-modal-title">ce dossier</strong> ?
     </p>
 
     <form id="delete-folder-form" method="POST" action="">
@@ -24,24 +23,24 @@
         <button type="button"
                 data-testid="delete-folder-recursive-btn"
                 onclick="submitDeleteFolder(1)"
-                class="flex items-center gap-3 px-4 py-3 rounded-2xl bg-red-500/20 border border-red-500/30
-                       hover:bg-red-500/30 text-red-200 hover:text-white transition-all text-left">
+                class="hc-modal-option hc-modal-option--danger flex items-center gap-3 px-4 py-3 rounded-2xl
+                       transition-all text-left">
           <span class="text-2xl"><svg width="32" height="32" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-trash"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg></span>
           <div>
             <div class="font-semibold text-sm">Supprimer tout le contenu</div>
-            <div class="text-xs text-white/50 mt-0.5">Le dossier et tous ses fichiers seront supprimés définitivement.</div>
+            <div class="hc-modal-option-desc text-xs mt-0.5">Le dossier et tous ses fichiers seront supprimés définitivement.</div>
           </div>
         </button>
 
         <button type="button"
                 data-testid="delete-folder-keep-files-btn"
                 onclick="submitDeleteFolder(0)"
-                class="flex items-center gap-3 px-4 py-3 rounded-2xl bg-yellow-500/20 border border-yellow-500/30
-                       hover:bg-yellow-500/30 text-yellow-200 hover:text-white transition-all text-left">
+                class="hc-modal-option hc-modal-option--warn flex items-center gap-3 px-4 py-3 rounded-2xl
+                       transition-all text-left">
           <span class="text-2xl"><svg width="32" height="32" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-package"><path d="M16.5 9.4l-9-5.19"/><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg></span>
           <div>
             <div class="font-semibold text-sm">Conserver les fichiers</div>
-            <div class="text-xs text-white/50 mt-0.5">Les fichiers seront déplacés vers le dossier <em>Uploads</em>.</div>
+            <div class="hc-modal-option-desc text-xs mt-0.5">Les fichiers seront déplacés vers le dossier <em>Uploads</em>.</div>
           </div>
         </button>
       </div>
@@ -49,7 +48,7 @@
       <div class="flex justify-end">
         <button type="button"
                 onclick="closeModal('delete-folder-modal')"
-                class="px-4 py-2 rounded-xl text-white/70 hover:text-white hover:bg-white/10 transition-colors">
+                class="hc-modal-btn-cancel px-4 py-2 rounded-xl transition-colors">
           Annuler
         </button>
       </div>

--- a/templates/components/MainToolbar.html.twig
+++ b/templates/components/MainToolbar.html.twig
@@ -1,17 +1,15 @@
 {# Overlay résultats de recherche XHR — branché sur #main-search-input du layout #}
 <div id="search-results-overlay"
-     class="hidden fixed inset-0 z-50 flex items-start justify-center bg-black/45 backdrop-blur-sm pt-20"
+     class="hc-modal-overlay hidden fixed inset-0 z-50 flex items-start justify-center pt-20"
      tabindex="-1"
      aria-modal="true"
      role="dialog">
-  <div class="bg-slate-900 border border-white/20 rounded-2xl
-              shadow-2xl w-full max-w-sm mx-4 overflow-hidden">
-    <div class="flex items-center justify-between px-3 py-2 border-b border-white/10">
-      <span id="search-results-count" class="text-xs text-white/50">Recherche…</span>
+  <div class="hc-modal-card rounded-2xl w-full max-w-sm mx-4 overflow-hidden">
+    <div class="flex items-center justify-between px-3 py-2" style="border-bottom: 1px solid var(--hc-border)">
+      <span id="search-results-count" class="hc-modal-text text-xs">Recherche…</span>
       <button type="button" onclick="closeModal('search-results-overlay')"
               title="Fermer" aria-label="Fermer la recherche"
-              class="flex items-center justify-center w-7 h-7 rounded-full
-                     bg-white/10 hover:bg-white/20 text-white/70 hover:text-white
+              class="hc-modal-btn-cancel flex items-center justify-center w-7 h-7 rounded-full
                      text-base leading-none transition-colors">×</button>
     </div>
     <ul id="search-results-list" class="list-none m-0 py-1 max-h-[40vh] overflow-y-auto"></ul>
@@ -68,7 +66,7 @@
         list.innerHTML = '';
         if (items.length === 0) {
             var empty = document.createElement('li');
-            empty.className = 'px-6 py-6 text-center text-sm text-white/40';
+            empty.className = 'hc-modal-text px-6 py-6 text-center text-sm';
             empty.textContent = 'Aucun fichier ni dossier trouvé';
             list.appendChild(empty);
             return;
@@ -82,11 +80,11 @@
 
             var a = document.createElement('a');
             a.href = url;
-            a.className = 'flex items-center gap-2.5 px-3 py-2 text-slate-100 no-underline hover:bg-white/10 transition-colors';
+            a.className = 'hc-modal-title hc-modal-btn-cancel flex items-center gap-2.5 px-3 py-2 no-underline transition-colors';
             a.addEventListener('click', closeSearch);
 
             var iconSpan = document.createElement('span');
-            iconSpan.className = 'shrink-0 text-white/70 flex items-center justify-center w-6 h-6';
+            iconSpan.className = 'hc-modal-text shrink-0 flex items-center justify-center w-6 h-6';
 
             if (item.thumbnailUrl) {
                 var thumb = document.createElement('img');
@@ -109,7 +107,7 @@
 
             if (!item.isFolder) {
                 var folderDiv = document.createElement('div');
-                folderDiv.className = 'flex items-center gap-1 text-xs text-white/45 mt-0.5';
+                folderDiv.className = 'hc-modal-text flex items-center gap-1 text-xs mt-0.5';
                 folderDiv.innerHTML = ICONS.folder;
                 var folderNameSpan = document.createElement('span');
                 folderNameSpan.textContent = item.folderName;

--- a/templates/components/MediaViewerModal.html.twig
+++ b/templates/components/MediaViewerModal.html.twig
@@ -1,17 +1,16 @@
 {# Modale de visualisation image/vidéo — lecteurs natifs du navigateur #}
 <div id="media-viewer-modal"
-     class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+     class="hc-modal-overlay hidden fixed inset-0 z-50 flex items-center justify-center"
      tabindex="-1"
      aria-modal="true"
      role="dialog">
-  <div class="bg-white/10 backdrop-blur-2xl border border-white/20
-              shadow-2xl p-4 w-screen h-screen flex flex-col">
+  <div class="hc-modal-card p-4 w-screen h-screen flex flex-col">
 
     <div class="flex items-center justify-between mb-3">
-      <h2 class="text-white text-lg font-semibold truncate" id="media-viewer-name">ce fichier</h2>
+      <h2 class="hc-modal-title text-lg font-semibold truncate" id="media-viewer-name">ce fichier</h2>
       <button type="button"
               onclick="closeMediaViewerModal()"
-              class="px-3 py-1.5 rounded-xl text-white/70 hover:text-white hover:bg-white/10 transition-colors">
+              class="hc-modal-btn-cancel px-3 py-1.5 rounded-xl transition-colors">
         Fermer
       </button>
     </div>

--- a/templates/components/MoveModal.html.twig
+++ b/templates/components/MoveModal.html.twig
@@ -1,15 +1,14 @@
 {# Modale unique de déplacement — partagée par tous les boutons ↪️ #}
 <div id="move-modal"
-     class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+     class="hc-modal-overlay hidden fixed inset-0 z-50 flex items-center justify-center"
      tabindex="-1"
      aria-modal="true"
      role="dialog">
-  <div class="bg-white/10 backdrop-blur-2xl border border-white/20 rounded-3xl
-              shadow-2xl p-6 w-full max-w-md mx-4">
+  <div class="hc-modal-card rounded-3xl p-6 w-full max-w-md mx-4">
 
     {# Titre dynamique (rempli par JS) #}
     <h2 id="move-modal-title"
-        class="text-white text-xl font-semibold mb-4">
+        class="hc-modal-title text-xl font-semibold mb-4">
       Déplacer...
     </h2>
 
@@ -17,7 +16,7 @@
     <div id="move-target-list"
          class="max-h-64 overflow-y-auto space-y-2 mb-4">
       {# Chargement initial #}
-      <p class="text-white/50 text-sm text-center py-4">Chargement...</p>
+      <p class="hc-modal-text text-sm text-center py-4">Chargement...</p>
     </div>
 
     {# Champs cachés pour transmettre le contexte au JS #}
@@ -28,7 +27,7 @@
     <div class="flex justify-end gap-3">
       <button type="button"
               onclick="closeModal('move-modal')"
-              class="px-4 py-2 rounded-xl text-white/70 hover:text-white hover:bg-white/10 transition-colors">
+              class="hc-modal-btn-cancel px-4 py-2 rounded-xl transition-colors">
         Annuler
       </button>
       <button type="button"

--- a/templates/components/PdfViewerModal.html.twig
+++ b/templates/components/PdfViewerModal.html.twig
@@ -1,17 +1,16 @@
 {# Modale de visualisation PDF — lecteur natif du navigateur, aucune librairie JS #}
 <div id="pdf-viewer-modal"
-     class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+     class="hc-modal-overlay hidden fixed inset-0 z-50 flex items-center justify-center"
      tabindex="-1"
      aria-modal="true"
      role="dialog">
-  <div class="bg-white/10 backdrop-blur-2xl border border-white/20
-              shadow-2xl p-4 w-screen h-screen flex flex-col">
+  <div class="hc-modal-card p-4 w-screen h-screen flex flex-col">
 
     <div class="flex items-center justify-between mb-3">
-      <h2 class="text-white text-lg font-semibold truncate" id="pdf-viewer-name">ce document</h2>
+      <h2 class="hc-modal-title text-lg font-semibold truncate" id="pdf-viewer-name">ce document</h2>
       <button type="button"
               onclick="closePdfViewerModal()"
-              class="px-3 py-1.5 rounded-xl text-white/70 hover:text-white hover:bg-white/10 transition-colors">
+              class="hc-modal-btn-cancel px-3 py-1.5 rounded-xl transition-colors">
         Fermer
       </button>
     </div>

--- a/templates/components/RenameModal.html.twig
+++ b/templates/components/RenameModal.html.twig
@@ -1,21 +1,20 @@
 {# Modale de renommage — partagée par tous les boutons de renommage #}
 <div id="rename-modal"
-     class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+     class="hc-modal-overlay hidden fixed inset-0 z-50 flex items-center justify-center"
      tabindex="-1"
      aria-modal="true"
      role="dialog">
-  <div class="bg-white/10 backdrop-blur-2xl border border-white/20 rounded-3xl
-              shadow-2xl p-6 w-full max-w-md mx-4">
+  <div class="hc-modal-card rounded-3xl p-6 w-full max-w-md mx-4">
 
     <h2 id="rename-modal-title"
-        class="text-white text-xl font-semibold mb-4">
+        class="hc-modal-title text-xl font-semibold mb-4">
       Renommer...
     </h2>
 
     <input type="text"
            id="rename-input"
-           class="w-full px-4 py-2 rounded-xl bg-white/10 border border-white/20
-                  text-white placeholder-white/40 focus:outline-none focus:ring-2
+           class="hc-modal-input w-full px-4 py-2 rounded-xl
+                  focus:outline-none focus:ring-2
                   focus:ring-green-400/60 mb-2"
            maxlength="255"
            autocomplete="off">
@@ -28,7 +27,7 @@
     <div class="flex justify-end gap-3 mt-4">
       <button type="button"
               onclick="closeModal('rename-modal')"
-              class="px-4 py-2 rounded-xl text-white/70 hover:text-white hover:bg-white/10 transition-colors">
+              class="hc-modal-btn-cancel px-4 py-2 rounded-xl transition-colors">
         Annuler
       </button>
       <button type="button"

--- a/templates/reset_password/request.html.twig
+++ b/templates/reset_password/request.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Réinitialiser mon mot de passe{% endblock %}
 
 {% block body %}
-<div class="max-w-md mx-auto mt-16 p-8 bg-white/10 backdrop-blur-2xl rounded-2xl shadow-lg">
+<div class="hc-modal-card max-w-md mx-auto mt-16 p-8 rounded-2xl">
     <h2 class="text-2xl font-bold mb-4 text-center">Réinitialiser mon mot de passe</h2>
     <form id="reset-password-form" class="flex flex-col gap-4">
         <input type="email" name="email" id="email" required placeholder="Votre email" class="px-4 py-2 rounded-xl border focus:outline-none focus:ring-2 focus:ring-blue-400/50" />


### PR DESCRIPTION
## Résumé

Étape 4/9 du chantier #341.

- `RenameModal`, `DeleteFolderModal`, `MoveModal`, `MediaViewerModal`, `PdfViewerModal`, `MainToolbar` (overlay de recherche) et `reset_password/request` partageaient le pattern `bg-black/50 backdrop-blur-sm` (overlay) + `bg-white/10 backdrop-blur-2xl border-white/20 rounded-3xl` (carte) — remplacé par des classes communes dans `assets/styles/modals.css`, basées sur `--hc-surface`/`--hc-border`/`--hc-shadow-crisp`, sur le modèle de `share-modal.css` déjà migré.
- Le texte associé (`text-white/x`) et les boutons d'option colorés (suppression = rouge, conservation = jaune) sont aussi migrés pour rester lisibles en light mode — le pattern original s'appuyait sur un fond sombre permanent, `--hc-surface` bascule en fond clair en light mode.
- Le HTML généré côté client par le JS inline de recherche (`MainToolbar.html.twig`) est migré aussi (mêmes classes utilitaires).

Réf #341 (chantier en plusieurs PRs, ticket pas encore fermé).

## Test plan

- [x] `composer build-assets` (Tailwind) + 899 tests PHPUnit OK
- [x] `npm test` : 133 tests Jest OK, y compris `delete-folder-modal.test.js`, `media-viewer-modal.test.js`, `pdf-viewer-modal.test.js`
- [x] Vérifié via `curl` que les nouvelles classes sont bien présentes dans le HTML servi et le CSS compilé
- [ ] **Vérification visuelle manuelle requise** (pas d'outil de capture d'écran dans cet environnement) : ouvrir chaque modale en light et dark, contrôler le contraste texte/fond et les boutons d'action (suppression, déplacement, renommage)