### PR TITLE
🔥 chore(css): retirer les backdrop-filter résiduels (app-shell, settings, main)

### DIFF
--- a/assets/styles/app-shell.css
+++ b/assets/styles/app-shell.css
@@ -135,8 +135,6 @@
 	padding: 12px 24px;
 	border-bottom: 1px solid var(--hc-border);
 	background: var(--hc-surface-2);
-	backdrop-filter: blur(20px) saturate(180%);
-	-webkit-backdrop-filter: blur(20px) saturate(180%);
 	flex-shrink: 0;
 }
 
@@ -209,7 +207,6 @@
 	position: fixed;
 	inset: 0;
 	background: rgba(0, 0, 0, 0.25);
-	backdrop-filter: blur(4px);
 	z-index: 40;
 	display: none;
 }
@@ -223,8 +220,6 @@
 	right: 0;
 	height: 64px;
 	background: var(--hc-surface-strong);
-	backdrop-filter: blur(24px) saturate(180%);
-	-webkit-backdrop-filter: blur(24px) saturate(180%);
 	border-top: 1px solid var(--hc-border);
 	display: grid;
 	grid-template-columns: repeat(4, 1fr);

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -1,25 +1,4 @@
 
-/* Barre de recherche Material/Liquid Glass */
-.search-glass {
-   background: rgba(255,255,255,0.13);
-   border: 1.2px solid rgba(165,180,252,0.22);
-   border-radius: 1.1rem;
-   box-shadow: 0 2px 12px 0 rgba(31,38,135,0.10);
-   color: #e0e7ef;
-   font-size: 1.08rem;
-   padding: 0.65rem 1.1rem;
-   backdrop-filter: blur(18px) saturate(180%);
-   transition: border-color 0.18s, box-shadow 0.18s;
-}
-.search-glass:focus {
-   border-color: #a5b4fc;
-   box-shadow: 0 0 0 2px #a5b4fc33, 0 2px 12px 0 rgba(31,38,135,0.10);
-   outline: none;
-}
-.search-glass::placeholder {
-   color: #a5b4fc;
-   opacity: 0.7;
-}
 /* Import-card form (structure) */
 .import-card-form {
    display: flex;

--- a/assets/styles/settings.css
+++ b/assets/styles/settings.css
@@ -2,7 +2,6 @@
 
 .settings-card {
     background: var(--hc-surface);
-    backdrop-filter: blur(24px) saturate(180%);
     border: 1px solid var(--hc-border);
     border-radius: 1rem;
     padding: 1.5rem;


### PR DESCRIPTION
## Résumé

Étape 5/9 du chantier #341.

- `assets/styles/app-shell.css` : retrait des `backdrop-filter`/`-webkit-backdrop-filter` sur `.hc-topbar`, `.drawer-overlay`, `.tab-bar` — ces éléments reposaient déjà sur `var(--hc-surface-2)`/`var(--hc-surface-strong)` pour le fond, seul le flou décoratif est retiré.
- `assets/styles/settings.css` : idem sur `.settings-card`.
- `assets/styles/main.css` : suppression de `.search-glass` (zéro usage confirmé — grep sur templates et JS).

Réf #341 (chantier en plusieurs PRs, ticket pas encore fermé).

## Test plan

- [x] `composer build-assets` + 899 tests PHPUnit OK
- [x] `npm test` : 133 tests Jest OK
- [x] Grep confirmé : `.search-glass` non utilisée nulle part
- [ ] Vérification visuelle manuelle : topbar, drawer mobile, tab-bar mobile, page paramètres (light/dark)