### PR TITLE
🔥 chore(js): migrer hc-folder-list.js du glassmorphism vers theme.css

### DIFF
--- a/assets/components/hc-folder-list.js
+++ b/assets/components/hc-folder-list.js
@@ -63,9 +63,9 @@ class HCFolderList extends HTMLElement {
                     gap: 0.5rem;
                     padding: 0.6rem 0.75rem;
                     border-radius: 0.75rem;
-                    background: rgba(255,255,255,0.06);
-                    border: 1px solid rgba(255,255,255,0.1);
-                    color: rgba(255,255,255,0.8);
+                    background: var(--hc-surface-2);
+                    border: 1px solid var(--hc-border);
+                    color: var(--hc-text-2);
                     font-size: 0.85rem;
                     cursor: pointer;
                     width: 100%;
@@ -74,13 +74,13 @@ class HCFolderList extends HTMLElement {
                 }
 
                 .folder-option:hover {
-                    background: rgba(255,255,255,0.1);
+                    background: var(--hc-input);
                 }
 
                 .folder-option.active {
-                    background: rgba(59,130,246,0.25);
-                    border-color: rgba(59,130,246,0.4);
-                    color: #fff;
+                    background: var(--hc-accent-soft);
+                    border-color: var(--hc-accent);
+                    color: var(--hc-text);
                 }
 
                 .folder-icon {
@@ -91,9 +91,9 @@ class HCFolderList extends HTMLElement {
                     width: 100%;
                     padding: 0.6rem 0.75rem;
                     border-radius: 0.75rem;
-                    background: rgba(255,255,255,0.05);
-                    border: 1px solid rgba(255,255,255,0.1);
-                    color: rgba(255,255,255,0.8);
+                    background: var(--hc-input);
+                    border: 1px solid var(--hc-border);
+                    color: var(--hc-text);
                     font-size: 0.85rem;
                     outline: none;
                     box-sizing: border-box;
@@ -101,17 +101,17 @@ class HCFolderList extends HTMLElement {
                 }
 
                 .new-folder-input:focus {
-                    border-color: rgba(59,130,246,0.5);
-                    background: rgba(255,255,255,0.08);
+                    border-color: var(--hc-accent);
+                    background: var(--hc-surface-2);
                 }
 
                 .new-folder-input::placeholder {
-                    color: rgba(255,255,255,0.3);
+                    color: var(--hc-text-3);
                 }
 
                 .folder-list-empty {
                     padding: 0.75rem;
-                    color: rgba(255,255,255,0.4);
+                    color: var(--hc-text-3);
                     font-size: 0.85rem;
                     font-style: italic;
                     text-align: center;


### PR DESCRIPTION
## Résumé

Étape 6/9 du chantier #341.

`assets/components/hc-folder-list.js` : composant Shadow DOM réellement actif en prod (importé par `upload-modal.js`, sélecteur de dossier dans la modale d'upload). Les ~10 `rgba(255,255,255,0.0x)` sont remplacés par les variables `--hc-*` du design system — les custom properties CSS traversent le Shadow DOM normalement, aucune plomberie supplémentaire nécessaire.

Réf #341 (chantier en plusieurs PRs, ticket pas encore fermé).

## Test plan

- [x] `composer build-assets` + 899 tests PHPUnit OK
- [x] `npm test` : 133 tests Jest OK, y compris `hc-folder-list.test.js`
- [ ] Vérification visuelle manuelle : ouvrir la modale d'upload, dérouler la liste de dossiers (état normal, hover, actif, champ "créer un dossier"), light et dark