### PR TITLE
🔥 chore(upload): migrer la modale d'upload du glassmorphism vers theme.css

### DIFF
--- a/assets/js/upload-modal.js
+++ b/assets/js/upload-modal.js
@@ -188,7 +188,7 @@ function createModalOverlay(files, currentFolderId, folders, isAlbumMode) {
     overlay.className = 'upload-modal-overlay';
     overlay.id = 'hc-upload-modal-overlay';
     // Force critical layout styles inline — CSS class may load after injection
-    overlay.style.cssText = 'position:fixed;inset:0;z-index:9999;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.45);backdrop-filter:blur(4px)';
+    overlay.style.cssText = 'position:fixed;inset:0;z-index:9999;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.45)';
 
     const card = document.createElement('div');
     card.className = 'upload-modal-card';
@@ -199,20 +199,19 @@ function createModalOverlay(files, currentFolderId, folders, isAlbumMode) {
         'margin:1rem',
         'border-radius:1.6rem',
         'overflow:hidden',
-        'background:rgba(255,255,255,0.08)',
-        'backdrop-filter:blur(24px) saturate(180%)',
-        'border:1px solid rgba(255,255,255,0.15)',
-        'box-shadow:0 8px 32px rgba(0,0,0,0.4)',
+        'background:var(--hc-surface)',
+        'border:1px solid var(--hc-border)',
+        'box-shadow:var(--hc-shadow-lg)',
     ].join(';');
 
     const content = document.createElement('div');
     content.className = 'upload-modal-content';
-    content.style.cssText = 'position:relative;z-index:10;padding:1.5rem;color:rgba(255,255,255,0.9);font-family:inherit';
+    content.style.cssText = 'position:relative;z-index:10;padding:1.5rem;color:var(--hc-text);font-family:inherit';
 
     // Title
     const title = document.createElement('div');
     title.className = 'upload-modal-title';
-    title.style.cssText = 'font-size:1.25rem;font-weight:600;color:rgba(255,255,255,0.95);margin-bottom:1.25rem;display:flex;align-items:center;gap:0.5rem';
+    title.style.cssText = 'font-size:1.25rem;font-weight:600;color:var(--hc-text);margin-bottom:1.25rem;display:flex;align-items:center;gap:0.5rem';
     title.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="flex-shrink:0"><polyline points="16 16 12 12 8 16"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/></svg>'
         + `<span>Importer ${files.length} fichier${files.length > 1 ? 's' : ''}</span>`;
 
@@ -226,7 +225,7 @@ function createModalOverlay(files, currentFolderId, folders, isAlbumMode) {
 
         const destLabel = document.createElement('label');
         destLabel.className = 'upload-destination-label';
-        destLabel.style.cssText = 'font-size:0.75rem;font-weight:600;color:rgba(255,255,255,0.5);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;display:block';
+        destLabel.style.cssText = 'font-size:0.75rem;font-weight:600;color:var(--hc-text-2);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;display:block';
         destLabel.textContent = 'Destination';
 
         const folderListEl = document.createElement('hc-folder-list');
@@ -249,19 +248,19 @@ function createModalOverlay(files, currentFolderId, folders, isAlbumMode) {
     // Actions
     const actions = document.createElement('div');
     actions.className = 'upload-actions';
-    actions.style.cssText = 'display:flex;justify-content:flex-end;gap:0.75rem;margin-top:1.25rem;padding-top:1rem;border-top:1px solid rgba(255,255,255,0.08)';
+    actions.style.cssText = 'display:flex;justify-content:flex-end;gap:0.75rem;margin-top:1.25rem;padding-top:1rem;border-top:1px solid var(--hc-border)';
 
     const cancelBtn = document.createElement('button');
     cancelBtn.type = 'button';
     cancelBtn.className = 'upload-btn upload-btn--cancel';
-    cancelBtn.style.cssText = 'padding:0.6rem 1.25rem;border-radius:0.75rem;border:none;background:rgba(255,255,255,0.08);color:rgba(255,255,255,0.7);font-size:0.9rem;cursor:pointer';
+    cancelBtn.style.cssText = 'padding:0.6rem 1.25rem;border-radius:0.75rem;border:none;background:var(--hc-surface-2);color:var(--hc-text-2);font-size:0.9rem;cursor:pointer';
     cancelBtn.textContent = 'Annuler';
     cancelBtn.id = 'hc-upload-cancel-btn';
 
     const submitBtn = document.createElement('button');
     submitBtn.type = 'button';
     submitBtn.className = 'upload-btn upload-btn--submit';
-    submitBtn.style.cssText = 'padding:0.6rem 1.25rem;border-radius:0.75rem;border:none;background:rgba(59,130,246,0.8);color:#fff;font-size:0.9rem;font-weight:600;cursor:pointer';
+    submitBtn.style.cssText = 'padding:0.6rem 1.25rem;border-radius:0.75rem;border:none;background:var(--hc-accent);color:#fff;font-size:0.9rem;font-weight:600;cursor:pointer';
     submitBtn.textContent = 'Uploader';
     submitBtn.id = 'hc-upload-submit-btn';
 
@@ -289,7 +288,7 @@ function createUploadItem(file) {
     const item = document.createElement('div');
     item.className = 'upload-item upload-item--pending';
     item.setAttribute('data-file-name', file.name);
-    item.style.cssText = 'padding:0.6rem 0;border-bottom:1px solid rgba(255,255,255,0.06)';
+    item.style.cssText = 'padding:0.6rem 0;border-bottom:1px solid var(--hc-border)';
 
     const header = document.createElement('div');
     header.className = 'upload-item__header';
@@ -297,21 +296,21 @@ function createUploadItem(file) {
 
     const icon = document.createElement('span');
     icon.className = 'upload-item__icon';
-    icon.innerHTML = '<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" style="color:rgba(255,255,255,0.85)"><path d="M13.828 10.172a4 4 0 0 0-5.656 0l-4 4a4 4 0 1 0 5.656 5.656l1.102-1.101m-.758-4.899a4 4 0 0 0 5.658 0l4-4a4 4 0 0 0-5.656-5.656l-1.1 1.1"/></svg>';
+    icon.innerHTML = '<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" style="color:var(--hc-text-2)"><path d="M13.828 10.172a4 4 0 0 0-5.656 0l-4 4a4 4 0 1 0 5.656 5.656l1.102-1.101m-.758-4.899a4 4 0 0 0 5.658 0l4-4a4 4 0 0 0-5.656-5.656l-1.1 1.1"/></svg>';
 
     const name = document.createElement('span');
     name.className = 'upload-item__name';
-    name.style.cssText = 'flex:1;color:rgba(255,255,255,0.85);overflow:hidden;text-overflow:ellipsis;white-space:nowrap';
+    name.style.cssText = 'flex:1;color:var(--hc-text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap';
     name.textContent = file.name;
 
     const size = document.createElement('span');
     size.className = 'upload-item__size';
-    size.style.cssText = 'color:rgba(255,255,255,0.4);font-size:0.75rem;white-space:nowrap';
+    size.style.cssText = 'color:var(--hc-text-3);font-size:0.75rem;white-space:nowrap';
     size.textContent = formatFileSize(file.size);
 
     const status = document.createElement('span');
     status.className = 'upload-item__status upload-item__status--pending';
-    status.style.cssText = 'color:rgba(255,255,255,0.4);font-size:0.75rem;white-space:nowrap';
+    status.style.cssText = 'color:var(--hc-text-3);font-size:0.75rem;white-space:nowrap';
     status.textContent = 'En attente';
 
     header.appendChild(icon);
@@ -321,7 +320,7 @@ function createUploadItem(file) {
 
     const progress = document.createElement('div');
     progress.className = 'upload-item__progress';
-    progress.style.cssText = 'height:2px;background:rgba(255,255,255,0.08);border-radius:1px;margin-top:0.35rem;overflow:hidden';
+    progress.style.cssText = 'height:2px;background:var(--hc-border);border-radius:1px;margin-top:0.35rem;overflow:hidden';
 
     const bar = document.createElement('div');
     bar.className = 'upload-item__bar';

--- a/assets/styles/upload.css
+++ b/assets/styles/upload.css
@@ -1,5 +1,5 @@
 /* ========================================
-   HomeCloud Upload Module — Liquid Glass Design
+   HomeCloud Upload Module
    ======================================== */
 
 /* === Modal overlay (backdrop) === */
@@ -11,7 +11,6 @@
     align-items: center;
     justify-content: center;
     background: rgba(0, 0, 0, 0.45);
-    backdrop-filter: blur(4px);
     animation: fadeIn 0.2s ease;
 }
 
@@ -20,7 +19,6 @@
     to { opacity: 1; }
 }
 
-/* === Liquid Glass Card === */
 .upload-modal-card {
     position: relative;
     width: 100%;
@@ -28,29 +26,7 @@
     margin: 1rem;
     border-radius: 1.6rem;
     overflow: hidden;
-    box-shadow: 0 8px 32px rgba(31, 38, 135, 0.22);
-}
-
-/* LG Layer 1: Blurred backdrop */
-.upload-modal-card::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: rgba(255, 255, 255, 0.08);
-    backdrop-filter: blur(24px) saturate(200%);
-    filter: url(#lg); /* SVG turbulence displacement (defined in layout.html.twig) */
-    pointer-events: none;
-    border-radius: 1.6rem;
-}
-
-/* LG Layer 2: Tint overlay */
-.upload-modal-card::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: rgba(255, 255, 255, 0.06);
-    pointer-events: none;
-    border-radius: 1.6rem;
+    box-shadow: var(--hc-shadow-lg);
 }
 
 /* === Modal content (positioned above layers) === */
@@ -64,7 +40,7 @@
 .upload-modal-title {
     font-size: 1.25rem;
     font-weight: 600;
-    color: rgba(255, 255, 255, 0.95);
+    color: var(--hc-text);
     margin-bottom: 1.25rem;
     display: flex;
     align-items: center;
@@ -79,7 +55,7 @@
 .upload-destination-label {
     font-size: 0.75rem;
     font-weight: 600;
-    color: rgba(255, 255, 255, 0.5);
+    color: var(--hc-text-2);
     text-transform: uppercase;
     letter-spacing: 0.05em;
     margin-bottom: 0.5rem;
@@ -99,23 +75,23 @@
     gap: 0.5rem;
     padding: 0.6rem 0.75rem;
     border-radius: 0.75rem;
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    color: rgba(255, 255, 255, 0.75);
+    background: var(--hc-surface-2);
+    border: 1px solid var(--hc-border);
+    color: var(--hc-text-2);
     font-size: 0.85rem;
     cursor: pointer;
     transition: all 0.2s ease;
 }
 
 .upload-folder-option:hover {
-    background: rgba(255, 255, 255, 0.08);
-    border-color: rgba(255, 255, 255, 0.15);
+    background: var(--hc-input);
+    border-color: var(--hc-border-strong);
 }
 
 .upload-folder-option.active {
-    background: rgba(59, 130, 246, 0.15);
-    border-color: rgba(59, 130, 246, 0.3);
-    color: rgba(255, 255, 255, 0.95);
+    background: var(--hc-accent-soft);
+    border-color: var(--hc-accent);
+    color: var(--hc-text);
 }
 
 .upload-folder-option::before {
@@ -133,22 +109,22 @@
     width: 100%;
     padding: 0.6rem 0.75rem;
     border-radius: 0.75rem;
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    color: rgba(255, 255, 255, 0.9);
+    background: var(--hc-input);
+    border: 1px solid var(--hc-border);
+    color: var(--hc-text);
     font-size: 0.85rem;
     transition: all 0.2s ease;
 }
 
 .upload-new-folder-input::placeholder {
-    color: rgba(255, 255, 255, 0.35);
+    color: var(--hc-text-3);
 }
 
 .upload-new-folder-input:focus {
     outline: none;
-    background: rgba(255, 255, 255, 0.06);
-    border-color: rgba(59, 130, 246, 0.4);
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+    background: var(--hc-surface-2);
+    border-color: var(--hc-accent);
+    box-shadow: 0 0 0 2px var(--hc-accent-soft);
 }
 
 /* === File list === */
@@ -168,17 +144,17 @@
 }
 
 .upload-file-list::-webkit-scrollbar-track {
-    background: rgba(255, 255, 255, 0.04);
+    background: var(--hc-surface-2);
     border-radius: 4px;
 }
 
 .upload-file-list::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.12);
+    background: var(--hc-border-strong);
     border-radius: 4px;
 }
 
 .upload-file-list::-webkit-scrollbar-thumb:hover {
-    background: rgba(255, 255, 255, 0.18);
+    background: var(--hc-text-3);
 }
 
 /* === Upload item === */
@@ -188,14 +164,14 @@
     gap: 0.35rem;
     padding: 0.6rem 0.75rem;
     border-radius: 0.85rem;
-    background: rgba(255, 255, 255, 0.06);
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: var(--hc-surface-2);
+    border: 1px solid var(--hc-border);
     transition: all 0.2s ease;
 }
 
 .upload-item:hover {
-    background: rgba(255, 255, 255, 0.08);
-    border-color: rgba(255, 255, 255, 0.12);
+    background: var(--hc-input);
+    border-color: var(--hc-border-strong);
 }
 
 /* Item header (name + size + status) */
@@ -214,7 +190,7 @@
 .upload-item__name {
     font-size: 0.8rem;
     font-weight: 500;
-    color: rgba(255, 255, 255, 0.9);
+    color: var(--hc-text);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -223,7 +199,7 @@
 
 .upload-item__size {
     font-size: 0.72rem;
-    color: rgba(255, 255, 255, 0.45);
+    color: var(--hc-text-3);
     flex-shrink: 0;
 }
 
@@ -236,7 +212,7 @@
 }
 
 .upload-item__status--pending {
-    color: rgba(255, 255, 255, 0.4);
+    color: var(--hc-text-3);
 }
 
 .upload-item__status--uploading {
@@ -244,17 +220,17 @@
 }
 
 .upload-item__status--done {
-    color: #34d399;
+    color: var(--hc-ok);
 }
 
 .upload-item__status--error {
-    color: #f87171;
+    color: var(--hc-err);
 }
 
 /* === Progress bar === */
 .upload-item__progress {
     height: 3px;
-    background: rgba(255, 255, 255, 0.08);
+    background: var(--hc-border);
     border-radius: 2px;
     overflow: hidden;
 }
@@ -264,22 +240,19 @@
     background: var(--hc-accent);
     border-radius: 2px;
     transition: width 0.3s ease;
-    box-shadow: 0 0 6px rgba(59, 130, 246, 0.4);
 }
 
 .upload-item__meta {
     font-size: 0.72rem;
-    color: rgba(255, 255, 255, 0.4);
+    color: var(--hc-text-3);
 }
 
 .upload-item--done .upload-item__bar {
-    background: linear-gradient(90deg, #10b981, #34d399);
-    box-shadow: 0 0 6px rgba(16, 185, 129, 0.4);
+    background: var(--hc-ok);
 }
 
 .upload-item--error .upload-item__bar {
-    background: linear-gradient(90deg, #ef4444, #f87171);
-    box-shadow: 0 0 6px rgba(239, 68, 68, 0.4);
+    background: var(--hc-err);
 }
 
 /* === Buttons row === */
@@ -303,35 +276,33 @@
 }
 
 .upload-btn--cancel {
-    background: rgba(255, 255, 255, 0.08);
-    color: rgba(255, 255, 255, 0.7);
-    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: var(--hc-surface-2);
+    color: var(--hc-text-2);
+    border: 1px solid var(--hc-border);
 }
 
 .upload-btn--cancel:hover {
-    background: rgba(255, 255, 255, 0.12);
-    color: rgba(255, 255, 255, 0.9);
+    background: var(--hc-input);
+    color: var(--hc-text);
 }
 
 .upload-btn--cancel:active {
-    background: rgba(255, 255, 255, 0.15);
+    background: var(--hc-border-strong);
 }
 
 .upload-btn--submit {
-    background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(99, 102, 241, 0.2));
-    color: #60a5fa;
-    border: 1px solid rgba(59, 130, 246, 0.3);
+    background: var(--hc-accent);
+    color: #fff;
+    border: none;
     font-weight: 600;
 }
 
 .upload-btn--submit:hover {
-    background: linear-gradient(135deg, rgba(59, 130, 246, 0.3), rgba(99, 102, 241, 0.3));
-    border-color: rgba(59, 130, 246, 0.5);
-    box-shadow: 0 0 12px rgba(59, 130, 246, 0.25);
+    background: var(--hc-accent-2);
 }
 
 .upload-btn--submit:active {
-    background: linear-gradient(135deg, rgba(59, 130, 246, 0.4), rgba(99, 102, 241, 0.4));
+    background: var(--hc-accent-2);
 }
 
 .upload-btn--submit:disabled {
@@ -343,7 +314,7 @@
 .upload-item__cancel {
     background: none;
     border: none;
-    color: rgba(255, 255, 255, 0.3);
+    color: var(--hc-text-3);
     cursor: pointer;
     font-size: 0.75rem;
     padding: 0.15rem 0.35rem;
@@ -352,15 +323,15 @@
 }
 
 .upload-item__cancel:hover {
-    color: #f87171;
-    background: rgba(248, 113, 113, 0.12);
+    color: var(--hc-err);
+    background: rgba(239, 68, 68, 0.12);
 }
 
 /* === Empty state === */
 .upload-empty {
     text-align: center;
     padding: 2rem 1rem;
-    color: rgba(255, 255, 255, 0.5);
+    color: var(--hc-text-2);
     font-size: 0.85rem;
 }
 


### PR DESCRIPTION
## Résumé

Étape 8/9 du chantier #341 — le plus gros morceau.

- `assets/js/upload-modal.js` : les styles inline (`style.cssText`) de l'overlay, de la carte, du titre et des items de fichiers passent de `rgba(255,255,255,x)`/`backdrop-filter` à `var(--hc-*)`. **Le garde-fou anti-FOUC est préservé** : les styles critiques restent injectés inline au moment de la création du DOM (le commentaire "Force critical layout styles inline" et son comportement ne changent pas) — seules les valeurs changent, les variables `--hc-*` étant déjà résolues via `theme.css` chargé avant tout JS.
- `assets/styles/upload.css` : suppression des deux couches `::before`/`::after` de distorsion Liquid Glass (dont le `filter: url(#lg)` déjà cassé, cf. #345), migration des `rgba(255,255,255,x)` restants vers `--hc-*`. Les couleurs de statut sémantiques (bleu "en cours", `--hc-ok` "terminé", `--hc-err` "erreur") sont conservées, ce ne sont pas du glassmorphism décoratif.

Réf #341 (chantier en plusieurs PRs, ticket pas encore fermé).

## Test plan

- [x] `composer build-assets` + 899 tests PHPUnit OK
- [x] `npm test` : 133 tests Jest OK, y compris tous les tests `upload-modal-*` (album, ETA, progress, relative-path) et `open-upload-modal.test.js` — aucun changement de comportement
- [ ] **Vérification visuelle manuelle requise** : ouvrir la modale d'upload (multi-fichiers), tester progress bar, erreurs, mode album (#339), en light et dark