### PR TITLE
feat(settings): exposer le curseur de concurrence d'envoi

### DIFF
--- a/assets/js/upload-modal.js
+++ b/assets/js/upload-modal.js
@@ -14,6 +14,7 @@ import '../components/hc-folder-list.js';
 import { apiFetch } from './api.js';
 import { declareBatch, createBatchPoller } from './upload-batch.js';
 import { createEtaTracker, formatSpeed, formatEta } from './upload-eta.js';
+import { getMaxConcurrent } from './upload-preferences.js';
 
 const UPLOAD_API_ROUTE = '/api/v1/files';
 const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024; // 5 GB
@@ -478,7 +479,7 @@ async function openUploadModal(files, options = {}) {
 
     // Create upload queue with callbacks for UI updates
     currentUploadQueue = createUploadQueueFn({
-        maxConcurrent: 3,
+        maxConcurrent: getMaxConcurrent(),
         onProgress: (file, progress) => {
             const itemEl = itemElements.get(file);
             if (itemEl) {

--- a/assets/js/upload-preferences.js
+++ b/assets/js/upload-preferences.js
@@ -1,0 +1,21 @@
+const STORAGE_KEY = 'hc.upload.maxConcurrent';
+
+export const MAX_CONCURRENT_MIN = 1;
+export const MAX_CONCURRENT_MAX = 6;
+export const MAX_CONCURRENT_DEFAULT = 3;
+
+export function getMaxConcurrent() {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    const parsed = Number(stored);
+
+    if (stored === null || !Number.isFinite(parsed) || parsed < MAX_CONCURRENT_MIN || parsed > MAX_CONCURRENT_MAX) {
+        return MAX_CONCURRENT_DEFAULT;
+    }
+
+    return Math.round(parsed);
+}
+
+export function setMaxConcurrent(value) {
+    const clamped = Math.min(MAX_CONCURRENT_MAX, Math.max(MAX_CONCURRENT_MIN, Math.round(value)));
+    localStorage.setItem(STORAGE_KEY, String(clamped));
+}

--- a/assets/tests/upload-preferences.test.js
+++ b/assets/tests/upload-preferences.test.js
@@ -1,0 +1,57 @@
+import { describe, test, expect, beforeEach } from '@jest/globals';
+import {
+    getMaxConcurrent,
+    setMaxConcurrent,
+    MAX_CONCURRENT_MIN,
+    MAX_CONCURRENT_MAX,
+    MAX_CONCURRENT_DEFAULT,
+} from '../js/upload-preferences.js';
+
+describe('upload-preferences', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    describe('getMaxConcurrent', () => {
+        test('retourne la valeur par défaut si rien n\'est stocké', () => {
+            expect(getMaxConcurrent()).toBe(MAX_CONCURRENT_DEFAULT);
+        });
+
+        test('retourne la valeur stockée si valide', () => {
+            setMaxConcurrent(5);
+            expect(getMaxConcurrent()).toBe(5);
+        });
+
+        test('retombe sur la valeur par défaut si la valeur stockée est corrompue (non numérique)', () => {
+            localStorage.setItem('hc.upload.maxConcurrent', 'not-a-number');
+            expect(getMaxConcurrent()).toBe(MAX_CONCURRENT_DEFAULT);
+        });
+
+        test('retombe sur la valeur par défaut si la valeur stockée est hors bornes', () => {
+            localStorage.setItem('hc.upload.maxConcurrent', '999');
+            expect(getMaxConcurrent()).toBe(MAX_CONCURRENT_DEFAULT);
+        });
+    });
+
+    describe('setMaxConcurrent', () => {
+        test('persiste une valeur valide', () => {
+            setMaxConcurrent(4);
+            expect(localStorage.getItem('hc.upload.maxConcurrent')).toBe('4');
+        });
+
+        test('clampe une valeur trop basse au minimum', () => {
+            setMaxConcurrent(0);
+            expect(getMaxConcurrent()).toBe(MAX_CONCURRENT_MIN);
+        });
+
+        test('clampe une valeur trop haute au maximum', () => {
+            setMaxConcurrent(50);
+            expect(getMaxConcurrent()).toBe(MAX_CONCURRENT_MAX);
+        });
+
+        test('arrondit une valeur décimale', () => {
+            setMaxConcurrent(3.7);
+            expect(getMaxConcurrent()).toBe(4);
+        });
+    });
+});

--- a/templates/web/settings.html.twig
+++ b/templates/web/settings.html.twig
@@ -38,6 +38,29 @@
 
     </div>
 
+    {# ── Card envois ── #}
+    <div class="settings-card">
+
+        <h2 class="settings-card-title">Envois</h2>
+
+        <div class="flex flex-col gap-4">
+
+            <div class="settings-field">
+                <label for="settings-max-concurrent" class="settings-label">
+                    Fichiers envoyés en parallèle : <span id="settings-max-concurrent-value"></span>
+                </label>
+                <input id="settings-max-concurrent" type="range" min="1" max="6" step="1"
+                       class="settings-input">
+                <p class="text-sm" style="color: var(--hc-text-2)">
+                    Réglage propre à cet appareil et à sa connexion — une valeur plus basse
+                    est recommandée sur un réseau lent ou instable.
+                </p>
+            </div>
+
+        </div>
+
+    </div>
+
     {# ── Card mot de passe ── #}
     <div class="settings-card">
 
@@ -74,8 +97,23 @@
 <div id="settings-toast" class="settings-toast"></div>
 
 <script>
-(function () {
+(async function () {
     var userId = '{{ user.id }}';
+
+    var uploadPrefs = await import('{{ asset('js/upload-preferences.js') }}');
+    var rangeEl = document.getElementById('settings-max-concurrent');
+    var valueEl = document.getElementById('settings-max-concurrent-value');
+
+    function renderMaxConcurrent(value) {
+        rangeEl.value = value;
+        valueEl.textContent = value;
+    }
+
+    renderMaxConcurrent(uploadPrefs.getMaxConcurrent());
+    rangeEl.addEventListener('input', function () {
+        uploadPrefs.setMaxConcurrent(Number(rangeEl.value));
+        renderMaxConcurrent(uploadPrefs.getMaxConcurrent());
+    });
 
     function showToast(message, isError) {
         var toast = document.getElementById('settings-toast');


### PR DESCRIPTION
## Résumé

- Nouveau module `upload-preferences.js` : lecture/écriture de `maxConcurrent` (bornes 1-6, fallback 3), persisté en `localStorage`
- Curseur exposé dans une nouvelle card "Envois" sur la page réglages
- `upload-modal.js` lit désormais cette préférence au lieu d'une valeur en dur

Persistance volontairement locale (par machine), pas en base sur `User` : la valeur optimale dépend du réseau/de l'appareil, pas de l'identité du compte.

Closes #245

## Test plan

- [x] 8 tests unitaires sur `upload-preferences.js` (bornes, clamp, fallback, persistance)
- [x] Suite JS complète : 125/125 tests passent, aucune régression
- [x] Suite PHPUnit complète : 899/899 tests passent, aucune régression
- [x] Vérifié manuellement dans le navigateur (curseur fonctionnel, valeur affichée à jour, persistance localStorage confirmée via DevTools)