### PR TITLE
Suppression photo(s) « mes fichiers » : proposer de conserver dans « mes albums »

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -7,6 +7,7 @@ import './js/move-modal.js';
 import './js/folder-children.js';
 import './js/rename.js';
 import './js/delete-folder-modal.js';
+import './js/delete-file-modal.js';
 import './js/pdf-viewer-modal.js';
 import './js/media-viewer-modal.js';
 import { initUploadModal } from './js/upload-modal.js';

--- a/assets/js/delete-file-modal.js
+++ b/assets/js/delete-file-modal.js
@@ -1,0 +1,41 @@
+import { Modal } from './modal.js';
+
+/**
+ * Ouvre la modale de suppression de fichier (#246).
+ *
+ * L'option « conserver dans mes albums » n'est affichée que si le fichier
+ * a un Media rattaché à au moins un album (inAlbum) — sinon confirmation
+ * simple, jamais de confirm() natif.
+ *
+ * @param {string}  fileId   UUID du fichier à supprimer
+ * @param {string}  fileName Nom affiché dans la modale
+ * @param {string}  folderId Dossier courant (pour la redirection post-suppression)
+ * @param {boolean} inAlbum  Le Media associé appartient à au moins un album
+ */
+window.openDeleteFileModal = function (fileId, fileName, folderId, inAlbum) {
+	const form         = document.getElementById('delete-file-form');
+	const nameEl       = document.getElementById('delete-file-name');
+	const folderInput  = document.getElementById('delete-file-folder-input');
+	const albumOption  = document.getElementById('delete-file-album-option');
+	const simpleConfirm = document.getElementById('delete-file-simple-confirm');
+
+	if (!form || !nameEl) return;
+
+	form.action = `/files/${fileId}/delete`;
+	nameEl.textContent = fileName || 'ce fichier';
+	folderInput.value = folderId || '';
+
+	albumOption.classList.toggle('hidden', !inAlbum);
+	simpleConfirm.classList.toggle('hidden', !!inAlbum);
+
+	Modal.open('delete-file-modal');
+};
+
+window.submitDeleteFile = function (keepInAlbums) {
+	const form  = document.getElementById('delete-file-form');
+	const input = document.getElementById('delete-file-keep-in-albums-input');
+	if (!form || !input) return;
+
+	input.value = keepInAlbums ? '1' : '0';
+	form.submit();
+};

--- a/assets/tests/delete-file-modal.test.js
+++ b/assets/tests/delete-file-modal.test.js
@@ -1,0 +1,63 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+jest.unstable_mockModule('../js/modal.js', () => ({
+  Modal: {
+    open: jest.fn(),
+    close: jest.fn(),
+  },
+}));
+
+const { Modal } = await import('../js/modal.js');
+await import('../js/delete-file-modal.js');
+
+describe('delete-file-modal behavior', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    document.body.innerHTML = `
+      <form id="delete-file-form" method="POST" action="">
+        <input type="hidden" name="keep_in_albums" id="delete-file-keep-in-albums-input" value="0">
+        <input type="hidden" name="folder_id" id="delete-file-folder-input" value="">
+        <span id="delete-file-name"></span>
+      </form>
+      <div id="delete-file-album-option" class="hidden"></div>
+      <div id="delete-file-simple-confirm" class="hidden"></div>
+    `;
+
+    const form = document.getElementById('delete-file-form');
+    form.submit = jest.fn();
+  });
+
+  test('opens modal and shows the album option when file is in an album', () => {
+    window.openDeleteFileModal('file-1', 'vacances.jpg', 'folder-1', true);
+
+    expect(Modal.open).toHaveBeenCalledWith('delete-file-modal');
+    expect(document.getElementById('delete-file-album-option').classList.contains('hidden')).toBe(false);
+    expect(document.getElementById('delete-file-simple-confirm').classList.contains('hidden')).toBe(true);
+  });
+
+  test('opens modal with simple confirmation only when file is not in any album', () => {
+    window.openDeleteFileModal('file-2', 'doc.pdf', 'folder-1', false);
+
+    expect(Modal.open).toHaveBeenCalledWith('delete-file-modal');
+    expect(document.getElementById('delete-file-album-option').classList.contains('hidden')).toBe(true);
+    expect(document.getElementById('delete-file-simple-confirm').classList.contains('hidden')).toBe(false);
+  });
+
+  test('submitDeleteFile sets keep_in_albums flag and submits the form', () => {
+    window.openDeleteFileModal('file-1', 'vacances.jpg', 'folder-1', true);
+    window.submitDeleteFile(true);
+
+    const form = document.getElementById('delete-file-form');
+    expect(document.getElementById('delete-file-keep-in-albums-input').value).toBe('1');
+    expect(form.action).toContain('file-1');
+    expect(form.submit).toHaveBeenCalled();
+  });
+
+  test('submitDeleteFile without keep sets keep_in_albums to 0', () => {
+    window.openDeleteFileModal('file-1', 'vacances.jpg', 'folder-1', true);
+    window.submitDeleteFile(false);
+
+    expect(document.getElementById('delete-file-keep-in-albums-input').value).toBe('0');
+  });
+});

--- a/migrations/Version20260723114759.php
+++ b/migrations/Version20260723114759.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260723114759 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '#246 — Media::$file devient nullable (détachement) ; ajout de Media::$owner pour ne plus dépendre de File::$owner comme source d\'autorité.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE medias DROP FOREIGN KEY `FK_12D2AF8193CB796C`');
+        $this->addSql('ALTER TABLE medias ADD owner_id BINARY(16) DEFAULT NULL, CHANGE file_id file_id BINARY(16) DEFAULT NULL');
+        // Backfill : owner_id hérite du propriétaire du File tant qu'il existe encore (aucun Media n'est détaché à ce stade).
+        $this->addSql('UPDATE medias m INNER JOIN files f ON m.file_id = f.id SET m.owner_id = f.owner_id');
+        $this->addSql('ALTER TABLE medias CHANGE owner_id owner_id BINARY(16) NOT NULL');
+        $this->addSql('ALTER TABLE medias ADD CONSTRAINT FK_12D2AF8193CB796C FOREIGN KEY (file_id) REFERENCES files (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE medias ADD CONSTRAINT FK_12D2AF817E3C61F9 FOREIGN KEY (owner_id) REFERENCES users (id)');
+        $this->addSql('CREATE INDEX IDX_12D2AF817E3C61F9 ON medias (owner_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Irréversible pour les Media détachés (file_id NULL) : ils perdent
+        // leur seule ancre vers un File au moment de repasser en NOT NULL.
+        $this->addSql('ALTER TABLE medias DROP FOREIGN KEY FK_12D2AF8193CB796C');
+        $this->addSql('ALTER TABLE medias DROP FOREIGN KEY FK_12D2AF817E3C61F9');
+        $this->addSql('DROP INDEX IDX_12D2AF817E3C61F9 ON medias');
+        $this->addSql('ALTER TABLE medias DROP owner_id, CHANGE file_id file_id BINARY(16) NOT NULL');
+        $this->addSql('ALTER TABLE medias ADD CONSTRAINT `FK_12D2AF8193CB796C` FOREIGN KEY (file_id) REFERENCES files (id) ON DELETE CASCADE');
+    }
+}

--- a/src/ApiResource/MediaOutput.php
+++ b/src/ApiResource/MediaOutput.php
@@ -55,7 +55,8 @@ final class MediaOutput
     public function __construct(
         public readonly string $id,
         public readonly string $mediaType,
-        public readonly string $fileId,
+        /** null si le Media est détaché de son File source (#246) */
+        public readonly ?string $fileId,
         public readonly ?int $width,
         public readonly ?int $height,
         public readonly ?string $takenAt,

--- a/src/Controller/Api/MediaThumbnailController.php
+++ b/src/Controller/Api/MediaThumbnailController.php
@@ -56,7 +56,14 @@ final class MediaThumbnailController extends AbstractController
 
         /** @var User $user */
         $user = $this->getUser();
-        if (!$this->resourceAccessChecker->canRead($user, Share::RESOURCE_FILE, $media->getFile()->getId(), $media->getFile()->getOwner())) {
+        // Un Media détaché (#246) n'a plus de File : sa vignette doit rester
+        // consultable par son owner (c'est tout l'objet du détachement), mais
+        // le partage par fichier n'a alors plus de sens.
+        $file = $media->getFile();
+        $canRead = $file !== null
+            ? $this->resourceAccessChecker->canRead($user, Share::RESOURCE_FILE, $file->getId(), $file->getOwner())
+            : $media->isOwnedBy($user);
+        if (!$canRead) {
             throw $this->createAccessDeniedException('Vous ne pouvez pas voir ce média.');
         }
 

--- a/src/Controller/Web/ExplorerController.php
+++ b/src/Controller/Web/ExplorerController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller\Web;
 
 use App\Entity\User;
+use App\Interface\AlbumRepositoryInterface;
 use App\Repository\FileRepository;
 use App\Repository\FolderRepository;
 use App\Repository\MediaRepository;
@@ -26,6 +27,7 @@ final class ExplorerController extends AbstractController
         private readonly FolderRepository $folderRepository,
         private readonly FileRepository $fileRepository,
         private readonly MediaRepository $mediaRepository,
+        private readonly AlbumRepositoryInterface $albumRepository,
     ) {}
 
     #[Route('/explorer', name: 'app_explorer')]
@@ -60,8 +62,20 @@ final class ExplorerController extends AbstractController
         // aucun chemin vers la vignette. Une relation inverse lazy provoquerait un
         // N+1 sur chaque carte de la grille.
         $mediasByFileId = [];
-        foreach ($this->mediaRepository->findBy(['file' => $files]) as $media) {
+        $mediasInFolder = $this->mediaRepository->findBy(['file' => $files]);
+        foreach ($mediasInFolder as $media) {
             $mediasByFileId[$media->getFile()->getId()->toRfc4122()] = $media;
+        }
+
+        // Fichiers dont le Media est dans au moins un album (#246) : détermine
+        // si la modale de suppression propose l'option "conserver dans mes albums".
+        $mediaIds = array_map(static fn ($media) => $media->getId(), $mediasInFolder);
+        $albumNamesByMediaId = $this->albumRepository->findAlbumNamesByMediaIds($mediaIds);
+        $filesInAlbum = [];
+        foreach ($mediasByFileId as $fileId => $media) {
+            if (isset($albumNamesByMediaId[$media->getId()->toRfc4122()])) {
+                $filesInAlbum[] = $fileId;
+            }
         }
 
         // Construit le chemin complet (ancêtres) pour la breadcrumb
@@ -88,6 +102,7 @@ final class ExplorerController extends AbstractController
             'folders'            => $folders,
             'files'              => $files,
             'mediasByFileId'     => $mediasByFileId,
+            'filesInAlbum'       => $filesInAlbum,
             'folderCount'        => count($folders),
             'fileCount'          => count($files),
             'sidebarTree'        => $this->folderRepository->findAllAsTree($user, $currentFolder),

--- a/src/Controller/Web/FileWebController.php
+++ b/src/Controller/Web/FileWebController.php
@@ -6,9 +6,12 @@ namespace App\Controller\Web;
 
 use App\Entity\File;
 use App\Entity\Share;
+use App\Interface\MediaDeletionServiceInterface;
+use App\Interface\MediaDetachServiceInterface;
 use App\Interface\MediaProcessorInterface;
 use App\Interface\StorageServiceInterface;
 use App\Repository\FileRepository;
+use App\Repository\MediaRepository;
 use App\Interface\DefaultFolderServiceInterface;
 use App\Interface\SharedResourceCleanerInterface;
 use App\Security\GuestRestrictionChecker;
@@ -51,6 +54,9 @@ final class FileWebController extends AbstractController
         private readonly PendingMediaProcessingCollector $pendingMediaProcessingCollector,
         private readonly MediaProcessorInterface $mediaProcessor,
         private readonly PdfSignatureDetector $pdfSignatureDetector,
+        private readonly MediaRepository $mediaRepository,
+        private readonly MediaDetachServiceInterface $mediaDetachService,
+        private readonly MediaDeletionServiceInterface $mediaDeletionService,
     ) {}
 
     #[Route('/files/{id}/download', name: 'app_file_download', methods: ['GET'])]
@@ -206,9 +212,33 @@ final class FileWebController extends AbstractController
         }
 
         $folderId = $request->request->get('folder_id');
+        $keepInAlbums = (bool) $request->request->get('keep_in_albums', '0');
+        $media = $this->mediaRepository->findByFile($file);
+
+        if ($media !== null && $keepInAlbums) {
+            try {
+                $this->mediaDetachService->detachAndDeleteFile($media);
+            } catch (\Throwable) {
+                $this->addFlash('error', "Erreur lors de la suppression du fichier « {$file->getOriginalName()} ».");
+
+                return $this->redirect($folderId ? '/explorer?folder=' . $folderId : '/explorer');
+            }
+
+            $this->addFlash('success', "Fichier « {$file->getOriginalName()} » supprimé, conservé dans vos albums.");
+
+            return $this->redirect($folderId ? '/explorer?folder=' . $folderId : '/explorer');
+        }
 
         try {
-            $this->storage->delete($file->getPath());
+            if ($media !== null) {
+                // Media::$file est désormais onDelete: SET NULL (#246, plus de
+                // CASCADE) : la suppression complète doit retirer le Media
+                // explicitement, sinon il devient orphelin (file_id NULL) sans
+                // que l'utilisateur ait choisi de le conserver.
+                $this->mediaDeletionService->delete($media);
+            } else {
+                $this->storage->delete($file->getPath());
+            }
         } catch (\Throwable) {
             $this->addFlash('error', "Erreur lors de la suppression du fichier « {$file->getOriginalName()} ».");
 
@@ -216,7 +246,9 @@ final class FileWebController extends AbstractController
         }
 
         $this->sharedResourceCleaner->deleteByResource(Share::RESOURCE_FILE, $file->getId());
-        $this->em->remove($file);
+        if ($media === null) {
+            $this->em->remove($file);
+        }
         $this->em->flush();
 
         $this->addFlash('success', "Fichier « {$file->getOriginalName()} » supprimé.");

--- a/src/Controller/Web/MediaGalleryController.php
+++ b/src/Controller/Web/MediaGalleryController.php
@@ -132,6 +132,11 @@ final class MediaGalleryController extends AbstractController
         }
 
         $file = $media->getFile();
+        if ($file === null) {
+            // Media détaché (#246) : le fichier source a été supprimé
+            // volontairement, seule la vignette reste disponible.
+            throw $this->createNotFoundException("Fichier d'origine supprimé, seule la vignette reste disponible.");
+        }
         $absolutePath = $this->storageService->getAbsolutePath($file->getPath());
 
         if (!file_exists($absolutePath)) {

--- a/src/Controller/Web/MediaRenameController.php
+++ b/src/Controller/Web/MediaRenameController.php
@@ -9,6 +9,7 @@ use App\Interface\MediaRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Uid\Uuid;
@@ -41,9 +42,16 @@ final class MediaRenameController extends AbstractController
             throw $this->createNotFoundException('Média introuvable.');
         }
 
-        $newName = (string) $request->request->get('name', '');
-        $this->fileActionService->rename($media->getFile(), $newName);
+        $file = $media->getFile();
+        if ($file === null) {
+            // Media détaché (#246) : plus de File à renommer. Le bouton est
+            // masqué côté template, mais l'endpoint doit rester sûr.
+            throw new BadRequestHttpException('Impossible de renommer : le fichier source a été supprimé.');
+        }
 
-        return $this->json(['name' => $media->getFile()->getOriginalName()]);
+        $newName = (string) $request->request->get('name', '');
+        $this->fileActionService->rename($file, $newName);
+
+        return $this->json(['name' => $file->getOriginalName()]);
     }
 }

--- a/src/Controller/Web/PublicShareController.php
+++ b/src/Controller/Web/PublicShareController.php
@@ -166,7 +166,10 @@ final class PublicShareController extends AbstractController
         $media = $this->mediaRepository->findById(Uuid::fromString($mediaId))
             ?? throw new NotFoundHttpException();
 
-        if (!$this->sharedFileScopeChecker->isInScope($media->getFile(), $link->getResourceType(), $link->getResourceId(), $linkResource)) {
+        // Un Media détaché (#246) n'a plus de File : il ne peut plus être
+        // dans le périmètre d'un partage par fichier/dossier/album.
+        $file = $media->getFile();
+        if ($file === null || !$this->sharedFileScopeChecker->isInScope($file, $link->getResourceType(), $link->getResourceId(), $linkResource)) {
             throw new AccessDeniedHttpException('Ce média ne fait pas partie du partage.');
         }
 

--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -31,8 +31,12 @@ class Media
     private Uuid $id;
 
     #[ORM\OneToOne(targetEntity: File::class)]
-    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
-    private File $file;
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?File $file;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private User $owner;
 
     /** photo | video | unknown */
     #[ORM\Column(length: 20)]
@@ -91,6 +95,7 @@ class Media
     {
         $this->id = Uuid::v7();
         $this->file = $file;
+        $this->owner = $file->getOwner();
         $this->mediaType = $mediaType;
         $this->createdAt = new \DateTimeImmutable();
     }
@@ -99,18 +104,29 @@ class Media
     {
         return $this->id;
     }
-    public function getFile(): File
+    public function getFile(): ?File
     {
         return $this->file;
     }
 
     /**
+     * Détache ce Media de son File source (#246) : le fichier physique est
+     * supprimé mais le Media (et ses appartenances aux albums) survit,
+     * affichable via son thumbnail. Irréversible.
+     */
+    public function detach(): void
+    {
+        $this->file = null;
+    }
+
+    /**
      * Vérifie si ce média appartient à l'utilisateur donné.
-     * Encapsule la chaîne getFile()->getOwner()->getId() (Law of Demeter).
+     * Stocké directement sur Media (pas via getFile()->getOwner()) : un
+     * Media détaché (#246) doit rester vérifiable sans File source.
      */
     public function isOwnedBy(User $user): bool
     {
-        return $this->file->getOwner()->getId()->equals($user->getId());
+        return $this->owner->getId()->equals($user->getId());
     }
 
     public function getMediaType(): string

--- a/src/Interface/MediaDetachServiceInterface.php
+++ b/src/Interface/MediaDetachServiceInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+use App\Entity\Media;
+
+/**
+ * Détache un Media de son File source (#246) : supprime uniquement le
+ * fichier physique et son entité, en conservant le Media (et ses
+ * appartenances aux albums via AlbumMedia) intact.
+ */
+interface MediaDetachServiceInterface
+{
+    /**
+     * @throws \LogicException si le Media est déjà détaché
+     */
+    public function detachAndDeleteFile(Media $media): void;
+}

--- a/src/Repository/MediaRepository.php
+++ b/src/Repository/MediaRepository.php
@@ -43,10 +43,13 @@ class MediaRepository extends ServiceEntityRepository implements MediaRepository
      */
     public function findByOwner(User $user, ?string $type = null, array $orderBy = []): array
     {
+        // leftJoin (pas join) : un Media détaché (#246, file NULL) doit rester
+        // visible dans sa galerie — filtré directement sur m.owner, qui ne
+        // dépend pas de l'existence du File.
         $qb = $this->createQueryBuilder('m')
-            ->join('m.file', 'f')
-            ->join('f.owner', 'u')
-            ->where('u.id = :userId')
+            ->addSelect('COALESCE(f.createdAt, m.createdAt) AS HIDDEN sortCreatedAt')
+            ->leftJoin('m.file', 'f')
+            ->where('m.owner = :userId')
             ->setParameter('userId', $user->getId(), 'uuid');
 
         if ($type !== null) {
@@ -55,6 +58,9 @@ class MediaRepository extends ServiceEntityRepository implements MediaRepository
 
         // 'takenAt' trie par date de prise de vue (EXIF) : les médias sans date
         // de capture (takenAt NULL) se regroupent à une extrémité selon le SGBD.
+        // Un Media détaché n'a plus de f.originalName/size/createdAt (f est
+        // NULL) : ces tris le placent à une extrémité selon le SGBD, comme
+        // takenAt NULL — comportement accepté, pas de régression du tri lui-même.
         $allowed = ['originalName' => 'f.originalName', 'size' => 'f.size', 'createdAt' => 'f.createdAt', 'takenAt' => 'm.takenAt'];
         $applied = false;
         foreach ($orderBy as $field => $dir) {
@@ -65,7 +71,11 @@ class MediaRepository extends ServiceEntityRepository implements MediaRepository
         }
 
         if (!$applied) {
-            $qb->orderBy('f.createdAt', 'DESC');
+            // sortCreatedAt (HIDDEN, cf. addSelect ci-dessus) : un Media
+            // détaché n'a plus de f.createdAt (file NULL), on retombe alors
+            // sur sa propre date de création pour garder un tri par défaut
+            // cohérent (le plus récent en premier).
+            $qb->orderBy('sortCreatedAt', 'DESC');
         }
 
         return $qb->getQuery()->getResult();

--- a/src/Security/SharedFileScopeChecker.php
+++ b/src/Security/SharedFileScopeChecker.php
@@ -55,7 +55,9 @@ final readonly class SharedFileScopeChecker
         }
 
         foreach ($linkResource->getMedias() as $media) {
-            if ($media->getFile()->getId()->equals($file->getId())) {
+            // Un Media détaché (#246) n'a plus de File : il ne peut pas être
+            // la cible d'un accès par File, on l'ignore simplement.
+            if ($media->getFile()?->getId()->equals($file->getId()) === true) {
                 return true;
             }
         }

--- a/src/Service/MediaDeletionService.php
+++ b/src/Service/MediaDeletionService.php
@@ -18,8 +18,10 @@ use Doctrine\ORM\EntityManagerInterface;
  * La preview de RAW éventuellement mise en cache est évincée au passage : elle
  * pèse ~1 Mo et resterait sinon orpheline sur le disque.
  *
- * Le File et les associations AlbumMedia sont retirés en cascade au niveau
- * DB (onDelete: CASCADE sur Media::$file et AlbumMedia::$media) au flush.
+ * Media::$file est en onDelete: SET NULL (#246, plus de CASCADE) : File et
+ * Media sont donc retirés explicitement ici, tous les deux. Un Media déjà
+ * détaché (file null) est toléré — MediaBulkDeleteController peut alors
+ * supprimer définitivement un média conservé sans File source.
  */
 final class MediaDeletionService implements MediaDeletionServiceInterface
 {
@@ -31,18 +33,21 @@ final class MediaDeletionService implements MediaDeletionServiceInterface
 
     public function delete(Media $media): void
     {
-        $sourcePath = $media->getFile()->getPath();
+        $file = $media->getFile();
 
-        $this->deleteFromDiskGracefully($sourcePath);
+        if ($file !== null) {
+            $this->deleteFromDiskGracefully($file->getPath());
+            $this->rawPreviewCache->evict($file->getPath());
+        }
 
         if ($media->getThumbnailPath() !== null) {
             $this->deleteFromDiskGracefully($media->getThumbnailPath());
         }
 
-        // Sans effet pour un JPEG, qui n'a jamais de preview en cache.
-        $this->rawPreviewCache->evict($sourcePath);
-
         $this->em->remove($media);
+        if ($file !== null) {
+            $this->em->remove($file);
+        }
         $this->em->flush();
     }
 

--- a/src/Service/MediaDetachService.php
+++ b/src/Service/MediaDetachService.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Media;
+use App\Entity\Share;
+use App\Interface\MediaDetachServiceInterface;
+use App\Interface\SharedResourceCleanerInterface;
+use App\Interface\StorageServiceInterface;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Supprime le File source d'un Media en conservant le Media lui-même
+ * (SRP : orchestration disque + entité File, séparée de MediaDeletionService
+ * qui supprime tout — Media compris — et de FileActionService qui ne gère
+ * que File sans notion de Media/album).
+ */
+final class MediaDetachService implements MediaDetachServiceInterface
+{
+    public function __construct(
+        private readonly StorageServiceInterface $storageService,
+        private readonly SharedResourceCleanerInterface $sharedResourceCleaner,
+        private readonly EntityManagerInterface $em,
+    ) {}
+
+    public function detachAndDeleteFile(Media $media): void
+    {
+        $file = $media->getFile();
+        if ($file === null) {
+            throw new \LogicException('Media is already detached from its File.');
+        }
+
+        try {
+            $this->storageService->delete($file->getPath());
+        } catch (\Exception) {
+            // Fichier déjà absent du disque : pas bloquant, le détachement
+            // doit quand même s'appliquer.
+        }
+
+        $this->sharedResourceCleaner->deleteByResource(Share::RESOURCE_FILE, $file->getId());
+
+        // Ordre impératif : detach() avant remove($file), pour que
+        // l'UnitOfWork voie medias.file_id passer à NULL avant la
+        // suppression de la ligne files (onDelete: SET NULL côté DB).
+        $media->detach();
+        $this->em->remove($file);
+        $this->em->flush();
+    }
+}

--- a/src/State/MediaProvider.php
+++ b/src/State/MediaProvider.php
@@ -51,7 +51,14 @@ final class MediaProvider implements ProviderInterface
             $media = $this->repository->find(Uuid::fromString($uriVariables['id']))
                 ?? throw new NotFoundHttpException('Media not found');
 
-            if (!$this->resourceAccessChecker->canRead($currentUser, Share::RESOURCE_FILE, $media->getFile()->getId(), $media->getFile()->getOwner())) {
+            // Un Media détaché (#246) n'a plus de File : le partage par fichier
+            // (ResourceAccessChecker) n'a alors plus de sens, seul l'owner du
+            // Media garde l'accès.
+            $file = $media->getFile();
+            $canRead = $file !== null
+                ? $this->resourceAccessChecker->canRead($currentUser, Share::RESOURCE_FILE, $file->getId(), $file->getOwner())
+                : $media->isOwnedBy($currentUser);
+            if (!$canRead) {
                 throw new AccessDeniedHttpException();
             }
 
@@ -80,7 +87,7 @@ final class MediaProvider implements ProviderInterface
         return new MediaOutput(
             id: (string) $media->getId(),
             mediaType: $media->getMediaType(),
-            fileId: (string) $media->getFile()->getId(),
+            fileId: $media->getFile() !== null ? (string) $media->getFile()->getId() : null,
             width: $media->getWidth(),
             height: $media->getHeight(),
             takenAt: $media->getTakenAt()?->format(\DateTimeInterface::ATOM),

--- a/templates/components/DeleteFileModal.html.twig
+++ b/templates/components/DeleteFileModal.html.twig
@@ -1,0 +1,76 @@
+{# Modale de suppression de fichier (#246) — jamais de confirm() natif #}
+<div id="delete-file-modal"
+     class="hc-modal-overlay hidden fixed inset-0 z-50 flex items-center justify-center"
+     tabindex="-1"
+     aria-modal="true"
+     role="dialog">
+  <div class="hc-modal-card rounded-3xl p-6 w-full max-w-md mx-4">
+
+    <h2 class="hc-modal-title text-xl font-semibold mb-2">
+      Supprimer le fichier
+    </h2>
+
+    <form id="delete-file-form" method="POST" action="">
+      <input type="hidden" name="_token" value="{{ csrf_token('delete-file') }}">
+      <input type="hidden" name="keep_in_albums" id="delete-file-keep-in-albums-input" value="0">
+      <input type="hidden" name="folder_id" id="delete-file-folder-input" value="">
+
+      <div id="delete-file-album-option" class="hidden">
+        <p class="hc-modal-text text-sm mb-5">
+          <strong id="delete-file-name" class="hc-modal-title">ce fichier</strong> appartient
+          à un ou plusieurs albums. Que souhaitez-vous faire ?
+        </p>
+
+        <div class="flex flex-col gap-3 mb-5">
+          <button type="button"
+                  data-testid="delete-file-full-btn"
+                  onclick="submitDeleteFile(false)"
+                  class="hc-modal-option hc-modal-option--danger flex items-center gap-3 px-4 py-3 rounded-2xl
+                         transition-all text-left">
+            <span class="text-2xl"><svg width="32" height="32" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-trash"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg></span>
+            <div>
+              <div class="font-semibold text-sm">Supprimer définitivement</div>
+              <div class="hc-modal-option-desc text-xs mt-0.5">Le fichier disparaît aussi de vos albums.</div>
+            </div>
+          </button>
+
+          <button type="button"
+                  data-testid="delete-file-keep-in-albums-btn"
+                  onclick="submitDeleteFile(true)"
+                  class="hc-modal-option hc-modal-option--warn flex items-center gap-3 px-4 py-3 rounded-2xl
+                         transition-all text-left">
+            <span class="text-2xl"><svg width="32" height="32" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-package"><path d="M16.5 9.4l-9-5.19"/><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg></span>
+            <div>
+              <div class="font-semibold text-sm">Conserver dans mes albums</div>
+              <div class="hc-modal-option-desc text-xs mt-0.5">Le fichier est supprimé de « mes fichiers », mais la vignette reste visible dans vos albums (plus de téléchargement de l'original).</div>
+            </div>
+          </button>
+        </div>
+      </div>
+
+      <div id="delete-file-simple-confirm" class="hidden">
+        <p class="hc-modal-text text-sm mb-5">
+          Supprimer définitivement <strong class="hc-modal-title">ce fichier</strong> ?
+        </p>
+
+        <div class="flex justify-end gap-3 mb-5">
+          <button type="button"
+                  data-testid="delete-file-confirm-btn"
+                  onclick="submitDeleteFile(false)"
+                  class="hc-modal-option hc-modal-option--danger px-4 py-2 rounded-xl transition-colors">
+            Supprimer
+          </button>
+        </div>
+      </div>
+
+      <div class="flex justify-end">
+        <button type="button"
+                onclick="closeModal('delete-file-modal')"
+                class="hc-modal-btn-cancel px-4 py-2 rounded-xl transition-colors">
+          Annuler
+        </button>
+      </div>
+    </form>
+
+  </div>
+</div>

--- a/templates/components/FileCard.html.twig
+++ b/templates/components/FileCard.html.twig
@@ -72,14 +72,11 @@
 			   class="move-btn hc-item-action hc-item-action--move"
 			   title="Déplacer {{ (item.originalName ?? item.name)|e('html') }}"
 			   onclick="openGlobalMoveModal('file', '{{ item.id }}', '{{ (item.originalName ?? item.name)|e('js') }}'); return false;"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-arrow-up-right"><line x1="7" y1="17" x2="17" y2="7"/><polyline points="7 7 17 7 17 17"/></svg></a>
-			<form method="post" action="{{ path('app_file_delete', { id: item.id }) }}"
-			      onsubmit="return confirm('Supprimer « {{ item.originalName|e('js') }} » ?')">
-				<input type="hidden" name="_token" value="{{ csrf_token('delete-file') }}">
-				<input type="hidden" name="folder_id" value="{{ item.folderId ?? '' }}">
-				<button type="submit"
-					class="delete-btn hc-item-action hc-item-action--danger"
-					title="Supprimer {{ (item.originalName ?? item.name)|e('html') }}"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-trash"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg></button>
-			</form>
+			<button type="button"
+				data-testid="delete-file-btn-{{ item.id }}"
+				class="delete-btn hc-item-action hc-item-action--danger"
+				title="Supprimer {{ (item.originalName ?? item.name)|e('html') }}"
+				onclick="openDeleteFileModal('{{ item.id }}', '{{ (item.originalName ?? item.name)|e('js') }}', '{{ item.folderId ?? '' }}', {{ inAlbum ? 'true' : 'false' }})"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" class="hc-icon hc-icon-trash"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg></button>
 		{% endif %}
 	</div>
 </div>
@@ -87,4 +84,4 @@
 {% if item.id is defined %}
 <twig:ShareModal resourceType="file" resourceId="{{ item.id }}" />
 {% endif %}
-{# Props attendues : item (entité File) #}
+{# Props attendues : item (entité File), media (Media|null), inAlbum (bool) #}

--- a/templates/components/FoldersGrid.html.twig
+++ b/templates/components/FoldersGrid.html.twig
@@ -11,8 +11,8 @@
       <twig:FolderCard :item="folder" />
     {% endfor %}
     {% for file in files %}
-      <twig:FileCard :item="file" :media="mediasByFileId[file.id] ?? null" />
+      <twig:FileCard :item="file" :media="mediasByFileId[file.id] ?? null" :inAlbum="filesInAlbum is defined and file.id in filesInAlbum" />
     {% endfor %}
   {% endif %}
 </div>
-{# Props attendues : folders (liste Folder[]), files (liste File[]) #}
+{# Props attendues : folders (liste Folder[]), files (liste File[]), filesInAlbum (liste d'ids de File dont le Media est dans un album, optionnel) #}

--- a/templates/components/MediaThumbActions.html.twig
+++ b/templates/components/MediaThumbActions.html.twig
@@ -12,11 +12,13 @@
    par le template appelant, ce composant ne fournit que le bouton
    déclencheur. #}
 <div class="hc-media-thumb-actions">
+  {% if media.file is not null %}
   <button type="button" data-action="click->rename-media#prompt"
           class="hc-media-thumb-action hc-media-thumb-action--rename"
           title="Renommer" aria-label="Renommer">
     <svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
   </button>
+  {% endif %}
 
   {% if setCoverUrl is defined and setCoverUrl and not isCover %}
     <form method="post" action="{{ setCoverUrl }}" class="hc-media-thumb-action-form-cover">
@@ -33,7 +35,7 @@
   {% if removeUrl is defined and removeUrl %}
     <form method="post" action="{{ removeUrl }}"
           class="hc-media-thumb-action-form" data-controller="confirm-submit"
-          data-confirm-submit-message-value="Retirer « {{ media.file.originalName }} » de l'album ?">
+          data-confirm-submit-message-value="Retirer « {{ media.file is not null ? media.file.originalName : 'ce média' }} » de l'album ?">
       <input type="hidden" name="_token" value="{{ csrf_token('album-remove-media') }}">
       <button type="submit" class="hc-media-thumb-action hc-media-thumb-action--remove"
               data-testid="remove-media-from-album" title="Retirer de l'album" aria-label="Retirer de l'album"

--- a/templates/components/NewAlbumModal.html.twig
+++ b/templates/components/NewAlbumModal.html.twig
@@ -50,7 +50,7 @@
                      class="hc-new-album-media-checkbox">
               {% if media.thumbnailPath %}
                 <img src="{{ path('app_media_thumbnail', {id: media.id}) }}"
-                     alt="{{ media.file.originalName }}" loading="lazy"
+                     alt="{{ media.file is not null ? media.file.originalName : 'Média' }}" loading="lazy"
                      class="w-full h-full object-cover">
               {% else %}
                 <div class="hc-new-album-media-fallback w-full h-full flex items-center justify-center">

--- a/templates/web/album_detail.html.twig
+++ b/templates/web/album_detail.html.twig
@@ -90,10 +90,12 @@
              data-album-reorder-target="item"
              data-media-id="{{ media.id }}"
              data-action="dragstart->album-reorder#dragStart dragover->album-reorder#dragOver drop->album-reorder#drop dragend->album-reorder#dragEnd"
+             {% if media.file is not null %}
              data-controller="rename-media"
              data-rename-media-url-value="{{ path('app_media_rename', {id: media.id}) }}"
              data-rename-media-current-name-value="{{ media.file.originalName }}"
-             data-rename-media-csrf-token-value="{{ csrf_token('media-rename') }}">
+             data-rename-media-csrf-token-value="{{ csrf_token('media-rename') }}"
+             {% endif %}>
           <twig:MediaThumbActions
             :media="media"
             removeUrl="{{ path('app_album_remove_media', {id: album.id, mediaId: media.id}) }}"
@@ -113,7 +115,7 @@
              class="hc-media-thumb-link">
             {% if media.thumbnailPath %}
               <img src="{{ path('app_media_thumbnail', {id: media.id}) }}"
-                   alt="{{ media.file.originalName }}"
+                   alt="{{ media.file is not null ? media.file.originalName : 'Média' }}"
                    loading="lazy"
                    class="hc-media-thumb-img">
             {% else %}
@@ -127,7 +129,7 @@
             {% endif %}
           </a>
           <div class="hc-media-thumb-caption" data-rename-media-target="caption">
-            {{ media.file.originalName }}
+            {{ media.file is not null ? media.file.originalName : 'Média (fichier source supprimé)' }}
           </div>
         </div>
       {% endfor %}

--- a/templates/web/explorer.html.twig
+++ b/templates/web/explorer.html.twig
@@ -34,7 +34,7 @@
       <div class="flex-1" data-testid="file-list">
           {# === FoldersGrid component === #}
           {# Fusionne dossiers et fichiers pour affichage unifié #}
-          <twig:FoldersGrid :folders="folders" :files="files" :mediasByFileId="mediasByFileId" />
+          <twig:FoldersGrid :folders="folders" :files="files" :mediasByFileId="mediasByFileId" :filesInAlbum="filesInAlbum" />
       </div>
 
   </div>

--- a/templates/web/gallery.html.twig
+++ b/templates/web/gallery.html.twig
@@ -72,10 +72,12 @@
          data-gallery-selection-csrf-token-value="{{ csrf_token('gallery-bulk-delete') }}">
       {% for media in medias %}
         <div data-testid="media-thumbnail" class="hc-media-thumb" data-gallery-selection-target="thumb"
+             {% if media.file is not null %}
              data-controller="rename-media"
              data-rename-media-url-value="{{ path('app_media_rename', {id: media.id}) }}"
              data-rename-media-current-name-value="{{ media.file.originalName }}"
-             data-rename-media-csrf-token-value="{{ csrf_token('media-rename') }}">
+             data-rename-media-csrf-token-value="{{ csrf_token('media-rename') }}"
+             {% endif %}>
           <twig:MediaThumbActions :media="media" />
           {% set mediaAlbumNames = albumNamesByMediaId[media.id ~ ''] ?? [] %}
           {% if mediaAlbumNames is not empty %}
@@ -106,7 +108,7 @@
              class="hc-media-thumb-link">
             {% if media.thumbnailPath %}
               <img src="{{ path('app_media_thumbnail', {id: media.id}) }}"
-                   alt="{{ media.file.originalName }}"
+                   alt="{{ media.file is not null ? media.file.originalName : 'Média' }}"
                    loading="lazy"
                    class="hc-media-thumb-img">
             {% else %}
@@ -120,7 +122,7 @@
             {% endif %}
           </a>
           <div class="hc-media-thumb-caption" data-rename-media-target="caption">
-            {{ media.file.originalName }}
+            {{ media.file is not null ? media.file.originalName : 'Média (fichier source supprimé)' }}
           </div>
         </div>
       {% endfor %}

--- a/templates/web/layout.html.twig
+++ b/templates/web/layout.html.twig
@@ -2,6 +2,7 @@
 {# Modales globales #}
 <twig:MoveModal />
 <twig:DeleteFolderModal />
+<twig:DeleteFileModal />
 <twig:RenameModal />
 <twig:PdfViewerModal />
 <twig:MediaViewerModal />

--- a/tests/Api/MediaTest.php
+++ b/tests/Api/MediaTest.php
@@ -242,4 +242,40 @@ final class MediaTest extends AuthenticatedApiTestCase
         $this->assertResponseStatusCodeSame(204);
         $this->assertFileDoesNotExist($thumbFile);
     }
+
+    // --- Média détaché (#246) : non-régression API sur Media::$file nullable ---
+
+    public function testGetDetachedMediaReturnsNullFileId(): void
+    {
+        $owner = $this->createUser('test@homecloud.local', 'password123', 'Test');
+        $media = $this->createMedia(owner: $owner);
+        $media->detach();
+        $this->em->flush();
+
+        $client = $this->createAuthenticatedClient();
+        \App\Tests\Api\ApiTestHelper::withFakeJwt($client);
+        $response = $client->request('GET', '/api/v1/medias/' . $media->getId());
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertNull($response->toArray()['fileId']);
+    }
+
+    public function testGetMediaCollectionIncludesDetachedMedia(): void
+    {
+        $owner = $this->createUser('test@homecloud.local', 'password123', 'Test');
+        $media = $this->createMedia(owner: $owner);
+        $media->detach();
+        $this->em->flush();
+
+        $client = $this->createAuthenticatedClient();
+        \App\Tests\Api\ApiTestHelper::withFakeJwt($client);
+        $response = $client->request('GET', '/api/v1/medias', [
+            'headers' => ['Accept' => 'application/json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(200);
+        $data = $response->toArray();
+        $this->assertCount(1, $data);
+        $this->assertNull($data[0]['fileId']);
+    }
 }

--- a/tests/Api/MediaThumbnailOwnershipTest.php
+++ b/tests/Api/MediaThumbnailOwnershipTest.php
@@ -116,4 +116,35 @@ final class MediaThumbnailOwnershipTest extends AuthenticatedApiTestCase
 
         $this->assertSame(403, $browser->getResponse()->getStatusCode());
     }
+
+    public function testOwnerCanViewThumbnailOfDetachedMedia(): void
+    {
+        // Media détaché (#246) : plus de File, mais le thumbnail doit rester
+        // consultable par son owner — c'est tout l'objet du détachement.
+        $media = $this->makeStoredMedia('owner6@example.com');
+        $media->detach();
+        $this->em->flush();
+        $mediaId = (string) $media->getId();
+        $this->em->clear();
+
+        $browser = $this->createAuthenticatedKernelBrowser('owner6@example.com');
+        $browser->request('GET', '/api/v1/medias/' . $mediaId . '/thumbnail');
+
+        $this->assertSame(200, $browser->getResponse()->getStatusCode());
+    }
+
+    public function testOtherUserCannotViewThumbnailOfDetachedMedia(): void
+    {
+        $media = $this->makeStoredMedia('owner7@example.com');
+        $media->detach();
+        $this->em->flush();
+        $mediaId = (string) $media->getId();
+        $this->createUser('attacker7@example.com', 'password123', 'Attacker');
+        $this->em->clear();
+
+        $browser = $this->createAuthenticatedKernelBrowser('attacker7@example.com');
+        $browser->request('GET', '/api/v1/medias/' . $mediaId . '/thumbnail');
+
+        $this->assertSame(403, $browser->getResponse()->getStatusCode());
+    }
 }

--- a/tests/Entity/MediaTest.php
+++ b/tests/Entity/MediaTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Media;
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires — détachement d'un Media de son File source (#246).
+ * TDD RED → GREEN.
+ */
+final class MediaTest extends TestCase
+{
+    private function makeMedia(User $owner, string $name = 'photo.jpg'): Media
+    {
+        $folder = new Folder('Photos', $owner);
+        $file   = new File($name, 'image/jpeg', 1024, '2026/' . $name, $folder, $owner);
+
+        return new Media($file, 'photo');
+    }
+
+    public function testIsOwnedByReturnsTrueForOwner(): void
+    {
+        $owner = new User('owner@example.com', 'Owner');
+        $media = $this->makeMedia($owner);
+
+        $this->assertTrue($media->isOwnedBy($owner));
+    }
+
+    public function testIsOwnedByReturnsFalseForOtherUser(): void
+    {
+        $owner = new User('owner@example.com', 'Owner');
+        $other = new User('other@example.com', 'Other');
+        $media = $this->makeMedia($owner);
+
+        $this->assertFalse($media->isOwnedBy($other));
+    }
+
+    public function testIsOwnedByStillWorksAfterDetach(): void
+    {
+        // L'ownership doit rester vérifiable même quand le File source a
+        // disparu (Media conservé dans un album après détachement, #246) :
+        // isOwnedBy() ne doit donc jamais dépendre de getFile().
+        $owner = new User('owner@example.com', 'Owner');
+        $media = $this->makeMedia($owner);
+
+        $media->detach();
+
+        $this->assertTrue($media->isOwnedBy($owner));
+    }
+
+    public function testDetachSetsFileToNull(): void
+    {
+        $owner = new User('owner@example.com', 'Owner');
+        $media = $this->makeMedia($owner);
+
+        $media->detach();
+
+        $this->assertNull($media->getFile());
+    }
+}

--- a/tests/Service/MediaDeletionServiceTest.php
+++ b/tests/Service/MediaDeletionServiceTest.php
@@ -39,10 +39,55 @@ final class MediaDeletionServiceTest extends TestCase
         $storage->expects($this->once())->method('delete')->with('2026/02/photo.jpg');
 
         $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->once())->method('remove')->with($media);
+        $em->method('remove');
         $em->expects($this->once())->method('flush');
 
         $service = new MediaDeletionService($storage, $em, $this->createMock(RawPreviewCacheInterface::class));
+        $service->delete($media);
+    }
+
+    public function testDeleteRemovesBothMediaAndFileEntities(): void
+    {
+        // Media::$file est passé à onDelete: SET NULL (#246) : le CASCADE DB
+        // qui supprimait le File avec le Media n'existe plus, il faut donc
+        // supprimer les deux entités explicitement.
+        $media = $this->makeMedia();
+        $file  = $media->getFile();
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->exactly(2))->method('remove')
+            ->willReturnCallback(function (object $entity) use ($media, $file) {
+                static $expected = true;
+                $this->assertContains($entity, [$media, $file]);
+            });
+        $em->expects($this->once())->method('flush');
+
+        $service = new MediaDeletionService(
+            $this->createMock(StorageServiceInterface::class),
+            $em,
+            $this->createMock(RawPreviewCacheInterface::class),
+        );
+        $service->delete($media);
+    }
+
+    public function testDeleteIsGracefulWhenMediaAlreadyDetached(): void
+    {
+        // Un Media détaché (#246) n'a plus de File : MediaBulkDeleteController
+        // doit pouvoir le supprimer définitivement sans planter.
+        $media = $this->makeMedia('thumbs/abc.jpg');
+        $media->detach();
+
+        $storage = $this->createMock(StorageServiceInterface::class);
+        $storage->expects($this->once())->method('delete')->with('thumbs/abc.jpg');
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('remove')->with($media);
+        $em->expects($this->once())->method('flush');
+
+        $cache = $this->createMock(RawPreviewCacheInterface::class);
+        $cache->expects($this->never())->method('evict');
+
+        $service = new MediaDeletionService($storage, $em, $cache);
         $service->delete($media);
     }
 
@@ -104,7 +149,7 @@ final class MediaDeletionServiceTest extends TestCase
         $storage->method('delete')->willThrowException(new \RuntimeException('File not found'));
 
         $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->once())->method('remove')->with($media);
+        $em->method('remove');
         $em->expects($this->once())->method('flush');
 
         $service = new MediaDeletionService($storage, $em, $this->createMock(RawPreviewCacheInterface::class));

--- a/tests/Service/MediaDetachServiceTest.php
+++ b/tests/Service/MediaDetachServiceTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Media;
+use App\Entity\Share;
+use App\Entity\User;
+use App\Interface\SharedResourceCleanerInterface;
+use App\Interface\StorageServiceInterface;
+use App\Service\MediaDetachService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+final class MediaDetachServiceTest extends TestCase
+{
+    private function makeMedia(): Media
+    {
+        $owner  = new User('test@example.com', 'Test');
+        $folder = new Folder('Photos', $owner);
+        $file   = new File('photo.jpg', 'image/jpeg', 1024, '2026/02/photo.jpg', $folder, $owner);
+
+        return new Media($file, 'photo');
+    }
+
+    public function testDetachAndDeleteFileRemovesFileFromDisk(): void
+    {
+        $media = $this->makeMedia();
+
+        $storage = $this->createMock(StorageServiceInterface::class);
+        $storage->expects($this->once())->method('delete')->with('2026/02/photo.jpg');
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $sharedResourceCleaner = $this->createMock(SharedResourceCleanerInterface::class);
+
+        $service = new MediaDetachService($storage, $sharedResourceCleaner, $em);
+        $service->detachAndDeleteFile($media);
+    }
+
+    public function testDetachAndDeleteFileCleansSharedResource(): void
+    {
+        $media = $this->makeMedia();
+        $fileId = $media->getFile()->getId();
+
+        $storage = $this->createMock(StorageServiceInterface::class);
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        $sharedResourceCleaner = $this->createMock(SharedResourceCleanerInterface::class);
+        $sharedResourceCleaner->expects($this->once())
+            ->method('deleteByResource')
+            ->with(Share::RESOURCE_FILE, $fileId);
+
+        $service = new MediaDetachService($storage, $sharedResourceCleaner, $em);
+        $service->detachAndDeleteFile($media);
+    }
+
+    public function testDetachAndDeleteFileSetsMediaFileToNull(): void
+    {
+        $media = $this->makeMedia();
+
+        $service = new MediaDetachService(
+            $this->createMock(StorageServiceInterface::class),
+            $this->createMock(SharedResourceCleanerInterface::class),
+            $this->createMock(EntityManagerInterface::class),
+        );
+        $service->detachAndDeleteFile($media);
+
+        $this->assertNull($media->getFile());
+    }
+
+    public function testDetachAndDeleteFileRemovesFileEntityAndFlushesOnce(): void
+    {
+        $media = $this->makeMedia();
+        $file  = $media->getFile();
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('remove')->with($file);
+        $em->expects($this->once())->method('flush');
+
+        $service = new MediaDetachService(
+            $this->createMock(StorageServiceInterface::class),
+            $this->createMock(SharedResourceCleanerInterface::class),
+            $em,
+        );
+        $service->detachAndDeleteFile($media);
+    }
+
+    public function testDetachAndDeleteFileIsGracefulWhenFileMissingOnDisk(): void
+    {
+        $media = $this->makeMedia();
+
+        $storage = $this->createMock(StorageServiceInterface::class);
+        $storage->method('delete')->willThrowException(new \RuntimeException('File not found'));
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('remove');
+        $em->expects($this->once())->method('flush');
+
+        $service = new MediaDetachService(
+            $storage,
+            $this->createMock(SharedResourceCleanerInterface::class),
+            $em,
+        );
+        $service->detachAndDeleteFile($media);
+
+        $this->assertNull($media->getFile());
+    }
+
+    public function testDetachAndDeleteFileThrowsWhenMediaAlreadyDetached(): void
+    {
+        $media = $this->makeMedia();
+        $media->detach();
+
+        $service = new MediaDetachService(
+            $this->createMock(StorageServiceInterface::class),
+            $this->createMock(SharedResourceCleanerInterface::class),
+            $this->createMock(EntityManagerInterface::class),
+        );
+
+        $this->expectException(\LogicException::class);
+        $service->detachAndDeleteFile($media);
+    }
+}

--- a/tests/Web/ExplorerPageTest.php
+++ b/tests/Web/ExplorerPageTest.php
@@ -66,7 +66,7 @@ final class ExplorerPageTest extends WebTestCase
     {
         $crawler = $this->client->request('GET', '/explorer?folder=' . $folderId);
 
-        return $crawler->filter('.file-actions input[name="_token"]')->first()->attr('value');
+        return $crawler->filter('#delete-file-form input[name="_token"]')->attr('value');
     }
 
     private function login(string $email = 'explorer@example.com', string $password = 'secret123'): void

--- a/tests/Web/FileDeleteWebTest.php
+++ b/tests/Web/FileDeleteWebTest.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace App\Tests\Web;
 
+use App\Entity\AlbumMedia;
+use App\Entity\Album;
 use App\Entity\File;
 use App\Entity\Folder;
+use App\Entity\Media;
 use App\Entity\User;
 use App\Interface\StorageServiceInterface;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
@@ -19,6 +23,8 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
  */
 final class FileDeleteWebTest extends WebTestCase
 {
+    use WebFixturesTrait;
+
     private EntityManagerInterface $em;
     private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
 
@@ -28,6 +34,9 @@ final class FileDeleteWebTest extends WebTestCase
         $this->em = static::getContainer()->get(EntityManagerInterface::class);
         $conn = $this->em->getConnection();
         $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM album_media');
+        $conn->executeStatement('DELETE FROM albums');
+        $conn->executeStatement('DELETE FROM medias');
         $conn->executeStatement('DELETE FROM files');
         $conn->executeStatement('DELETE FROM folders');
         $conn->executeStatement('DELETE FROM users');
@@ -79,7 +88,7 @@ final class FileDeleteWebTest extends WebTestCase
     {
         $crawler = $this->client->request('GET', '/explorer?folder=' . $folderId);
 
-        return $crawler->filter('.file-actions input[name="_token"]')->first()->attr('value');
+        return $crawler->filter('#delete-file-form input[name="_token"]')->attr('value');
     }
 
     public function testDeleteFileFlashesSuccessMessage(): void
@@ -137,5 +146,123 @@ final class FileDeleteWebTest extends WebTestCase
         // Le fichier ne doit pas avoir été supprimé de la base si le storage a échoué
         $found = $this->em->getRepository(File::class)->find($fileId);
         $this->assertNotNull($found, 'Le fichier ne doit pas être supprimé en base si le storage échoue');
+    }
+
+
+    public function testDeleteWithKeepInAlbumsPreservesMediaAndAlbumMedia(): void
+    {
+        $user = $this->createUser();
+        $media = $this->createMediaFile($user, 'vacances.jpg', 'photo');
+        $file = $media->getFile();
+        $fileId = (string) $file->getId();
+        $folderId = $file->getFolder()->getId()->toRfc4122();
+
+        $album = new Album('Vacances', $user);
+        $this->em->persist($album);
+        $this->em->persist(new AlbumMedia($album, $media, 0));
+        $this->em->flush();
+        $mediaId = $media->getId();
+        $this->em->clear();
+
+        $this->login();
+        $token = $this->csrfToken($folderId);
+
+        $this->client->request('POST', '/files/' . $fileId . '/delete', [
+            '_token' => $token,
+            'folder_id' => $folderId,
+            'keep_in_albums' => '1',
+        ]);
+        $this->client->followRedirect();
+
+        $this->assertSelectorTextContains('.flash-success', 'conservé');
+
+        $this->assertNull(
+            $this->em->getRepository(File::class)->find($fileId),
+            'Le File doit être supprimé de la base',
+        );
+
+        $survivingMedia = $this->em->getRepository(Media::class)->find($mediaId);
+        $this->assertNotNull($survivingMedia, 'Le Media doit survivre au détachement');
+        $this->assertNull($survivingMedia->getFile(), 'Le Media détaché ne doit plus avoir de File');
+
+        $albumMediaCount = $this->em->getRepository(AlbumMedia::class)
+            ->count(['media' => $mediaId]);
+        $this->assertSame(1, $albumMediaCount, "L'appartenance à l'album doit survivre");
+    }
+
+    public function testDeleteWithoutKeepInAlbumsFlagRemovesMediaCompletely(): void
+    {
+        $user = $this->createUser();
+        $media = $this->createMediaFile($user, 'sans-album.jpg', 'photo');
+        $file = $media->getFile();
+        $fileId = (string) $file->getId();
+        $folderId = $file->getFolder()->getId()->toRfc4122();
+        $mediaId = $media->getId();
+        $this->em->clear();
+
+        $this->login();
+        $token = $this->csrfToken($folderId);
+
+        $this->client->request('POST', '/files/' . $fileId . '/delete', [
+            '_token' => $token,
+            'folder_id' => $folderId,
+        ]);
+        $this->client->followRedirect();
+
+        $this->assertSelectorTextContains('.flash-success', 'supprimé');
+        $this->assertNull($this->em->getRepository(File::class)->find($fileId));
+        $this->assertNull(
+            $this->em->getRepository(Media::class)->find($mediaId),
+            'Sans keep_in_albums, le Media doit disparaître comme avant (CASCADE)',
+        );
+    }
+
+    public function testDeleteRejectsFileNotOwnedByUser(): void
+    {
+        $owner = $this->createUser('owner@example.com');
+        $other = $this->createUser('other@example.com');
+        $folder = $this->createFolder('Docs', $owner);
+        $file = $this->createFile('secret.txt', $folder, $owner);
+        $fileId = (string) $file->getId();
+
+        // Le token CSRF de l'intention 'delete-file' ne dépend pas de la
+        // ressource ciblée : on le lit via un fichier possédé par l'attaquant
+        // dans son propre dossier, comme le ferait un navigateur légitime.
+        $otherFolder = $this->createFolder('OtherDocs', $other);
+        $this->createFile('decoy.txt', $otherFolder, $other);
+        $this->em->clear();
+
+        $this->login('other@example.com');
+        $token = $this->csrfToken($otherFolder->getId()->toRfc4122());
+
+        $this->client->request('POST', '/files/' . $fileId . '/delete', ['_token' => $token]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testDeleteRejectsInvalidCsrfToken(): void
+    {
+        $user = $this->createUser();
+        $folder = $this->createFolder('Docs', $user);
+        $file = $this->createFile('rapport.txt', $folder, $user);
+        $fileId = (string) $file->getId();
+        $this->em->clear();
+
+        $this->login();
+
+        $this->client->request('POST', '/files/' . $fileId . '/delete', ['_token' => 'invalid-token']);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testDeleteRequiresAuthentication(): void
+    {
+        $user = $this->createUser();
+        $folder = $this->createFolder('Docs', $user);
+        $file = $this->createFile('rapport.txt', $folder, $user);
+
+        $this->client->request('POST', '/files/' . $file->getId() . '/delete', ['_token' => 'whatever']);
+
+        $this->assertResponseRedirects('/login');
     }
 }

--- a/tests/Web/MediaGalleryTest.php
+++ b/tests/Web/MediaGalleryTest.php
@@ -462,4 +462,18 @@ final class MediaGalleryTest extends WebTestCase
         $this->assertResponseStatusCodeSame(403);
     }
 
+    public function testMediaFullReturns404ForDetachedMedia(): void
+    {
+        // Media détaché (#246) : plus de File, la vue plein écran doit
+        // renvoyer un 404 propre plutôt qu'une 500.
+        $user = $this->createUser();
+        $media = $this->createMediaFile($user, 'detached.jpg', 'photo');
+        $media->detach();
+        $this->em->flush();
+
+        $this->login();
+        $this->client->request('GET', '/gallery/' . $media->getId()->toRfc4122() . '/full');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
 }

--- a/tests/Web/MediaRenameTest.php
+++ b/tests/Web/MediaRenameTest.php
@@ -165,4 +165,29 @@ final class MediaRenameTest extends WebTestCase
 
         $this->assertResponseStatusCodeSame(403);
     }
+
+    public function testRenameDetachedMediaReturns400(): void
+    {
+        // Media détaché (#246) : plus de File à renommer. Le bouton est
+        // masqué côté template, mais l'endpoint doit rester sûr (défense en
+        // profondeur). Le token CSRF est lu via un autre média (l'intention
+        // 'media-rename' ne dépend pas de la ressource ciblée), le média
+        // détaché n'ayant plus l'attribut data-rename-media-csrf-token-value.
+        $user  = $this->createUser();
+        $this->createMediaFile($user, 'autre.jpg', 'photo');
+        $media = $this->createMediaFile($user, 'photo.jpg', 'photo');
+        $media->detach();
+        $this->em->flush();
+        $this->login();
+
+        $this->client->request(
+            'POST',
+            '/gallery/' . $media->getId()->toRfc4122() . '/rename',
+            ['name' => 'nouveau-nom.jpg', '_token' => $this->csrfToken()],
+            [],
+            ['HTTP_ACCEPT' => 'application/json'],
+        );
+
+        $this->assertResponseStatusCodeSame(400);
+    }
 }

--- a/tests/Web/MediaRenameTest.php
+++ b/tests/Web/MediaRenameTest.php
@@ -53,7 +53,7 @@ final class MediaRenameTest extends WebTestCase
     {
         $crawler = $this->client->request('GET', '/gallery');
 
-        return $crawler->filter('[data-testid="media-thumbnail"]')->first()->attr('data-rename-media-csrf-token-value');
+        return $crawler->filter('[data-rename-media-csrf-token-value]')->first()->attr('data-rename-media-csrf-token-value');
     }
 
     public function testRenameMediaReturnsJsonWithNewName(): void


### PR DESCRIPTION
## Résumé

Closes #246

`Media` avait une relation `OneToOne` vers `File` avec `onDelete: CASCADE` : supprimer un fichier depuis « mes fichiers » supprimait silencieusement le `Media` associé et toutes ses appartenances aux albums (`AlbumMedia`), sans aucun avertissement.

- `Media::$file` devient nullable (`onDelete: SET NULL`), avec une nouvelle colonne `Media::$owner` pour ne plus dépendre de `File::$owner` comme source d'autorité (ownership indépendant du File).
- Nouveau `MediaDetachService` : supprime uniquement le fichier source (disque + entité), en conservant le `Media` et ses `AlbumMedia` intacts.
- `MediaDeletionService` mis à jour : le CASCADE DB historique n'existe plus, il supprime donc explicitement `File` et `Media`.
- `FileWebController::delete` (route web `/files/{id}/delete`, utilisée par « mes fichiers ») propose désormais un choix via une nouvelle modale (`DeleteFileModal`, jamais de `confirm()` natif) : suppression totale, ou conserver dans les albums si le fichier a un `Media` rattaché à au moins un album.
- Guards de nullabilité sur tous les chemins de lecture existants (API `GET /api/v1/medias`, thumbnail, vue plein écran, partage public, renommage) pour tolérer un `Media` détaché sans régression.

Périmètre limité à la route web pour ce ticket — l'API publique (`DELETE /api/v1/files/{id}`) garde son comportement actuel de suppression totale (voir #354 pour l'alignement futur). Le renommage est masqué pour un média détaché (voir #355 pour les évolutions possibles).

## Test plan

- [x] `./vendor/bin/phpunit` — 922 tests, 0 échec (hors 1 échec Tailwind préexistant sans rapport)
- [x] `npm test` — 129 tests Jest, 0 échec
- [x] TDD strict (RED→GREEN) sur chaque composant : entité, service, contrôleur web, JS
- [x] Migration Doctrine appliquée et vérifiée sur home_cloud / home_cloud_test / home_cloud_test_test
- [ ] Vérification manuelle en dev : upload photo → ajout à un album → suppression depuis « mes fichiers » avec « conserver dans mes albums » → vignette toujours visible en galerie/album, fichier physique supprimé du disque