### PR TITLE
Corrige l'option « conserver dans mes albums » jamais affichée dans la modale

### DIFF
--- a/templates/components/FoldersGrid.html.twig
+++ b/templates/components/FoldersGrid.html.twig
@@ -11,7 +11,7 @@
       <twig:FolderCard :item="folder" />
     {% endfor %}
     {% for file in files %}
-      <twig:FileCard :item="file" :media="mediasByFileId[file.id] ?? null" :inAlbum="filesInAlbum is defined and file.id in filesInAlbum" />
+      <twig:FileCard :item="file" :media="mediasByFileId[file.id] ?? null" :inAlbum="filesInAlbum is defined and (file.id ~ '') in filesInAlbum" />
     {% endfor %}
   {% endif %}
 </div>

--- a/tests/Web/FileDeleteWebTest.php
+++ b/tests/Web/FileDeleteWebTest.php
@@ -265,4 +265,43 @@ final class FileDeleteWebTest extends WebTestCase
 
         $this->assertResponseRedirects('/login');
     }
+
+    public function testExplorerRendersDeleteButtonWithInAlbumTrueWhenFileHasMediaInAlbum(): void
+    {
+        // Non-régression rendu HTML (#246) : file.id (objet Uuid) doit être
+        // comparé correctement à filesInAlbum (strings RFC4122) côté Twig,
+        // sinon le bouton reçoit toujours inAlbum=false et la modale
+        // n'affiche jamais l'option "conserver dans mes albums".
+        $user = $this->createUser();
+        $media = $this->createMediaFile($user, 'vacances.jpg', 'photo');
+        $file = $media->getFile();
+        $folderId = $file->getFolder()->getId()->toRfc4122();
+
+        $album = new Album('Vacances', $user);
+        $this->em->persist($album);
+        $this->em->persist(new AlbumMedia($album, $media, 0));
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->login();
+        $crawler = $this->client->request('GET', '/explorer?folder=' . $folderId);
+
+        $this->assertResponseIsSuccessful();
+        $button = $crawler->filter('[data-testid="delete-file-btn-' . $file->getId() . '"]');
+        $this->assertStringContainsString('true)', $button->attr('onclick'));
+    }
+
+    public function testExplorerRendersDeleteButtonWithInAlbumFalseWhenFileHasNoMedia(): void
+    {
+        $user = $this->createUser();
+        $folder = $this->createFolder('Docs', $user);
+        $file = $this->createFile('rapport.txt', $folder, $user);
+
+        $this->login();
+        $crawler = $this->client->request('GET', '/explorer?folder=' . $folder->getId()->toRfc4122());
+
+        $this->assertResponseIsSuccessful();
+        $button = $crawler->filter('[data-testid="delete-file-btn-' . $file->getId() . '"]');
+        $this->assertStringContainsString('false)', $button->attr('onclick'));
+    }
 }


### PR DESCRIPTION
## Résumé

Suite au merge de #356 (#246), la modale de suppression n'affichait jamais l'option « conserver dans mes albums », même pour un fichier appartenant à un album — comportement observé en test manuel sur `/explorer`.

Cause : `templates/components/FoldersGrid.html.twig` comparait `file.id` (objet `Symfony\Component\Uid\Uuid`) directement à `filesInAlbum` (tableau de strings RFC4122) via l'opérateur Twig `in`, qui ne caste pas automatiquement l'objet — la comparaison échouait donc toujours silencieusement.

Fix : cast explicite `(file.id ~ '')` avant la comparaison.

## Test plan

- [x] Nouveau test RED confirmé (reproduit le bug avant fix) puis GREEN après fix : `testExplorerRendersDeleteButtonWithInAlbumTrueWhenFileHasMediaInAlbum`
- [x] `./vendor/bin/phpunit` — 924 tests, 0 échec (hors 1 échec Tailwind préexistant sans rapport)