### PR TITLE
Espace « Mes partages » pour l'invité (#273)

### DIFF
--- a/.github/avancement.md
+++ b/.github/avancement.md
@@ -1,10 +1,20 @@
 # 📋 Avancement — HomeCloud API
 
-> Dernière mise à jour : 2026-07-22
+> Dernière mise à jour : 2026-07-23
 
 > **Status git :** `main` — dernière PR mergée #331 (`feat/311-media-viewer`)
 
 ---
+
+## ✅ Espace « Mes partages » pour l'invité (2026-07-23, #273, branche `feature/273-mes-partages`)
+
+- Nouvelle page `/mes-partages` listant les `Share` actifs (non révoqués, non expirés) dont l'utilisateur connecté est le `guest` — seule porte d'entrée jusqu'ici était le lien contenu dans l'email de notification.
+- `ShareRepository::findActiveByGuest(User $guest)` : nouvelle requête filtrée `guest = :user AND revokedAt IS NULL AND (expiresAt IS NULL OR expiresAt > now)`, triée par `createdAt DESC`. Aucune migration Doctrine nécessaire, l'index `idx_share_lookup(guest_id, resource_type, resource_id)` couvrait déjà ce besoin.
+- `MyReceivedSharesWebController` (nouveau) : lecture seule, réutilise le pattern `resolveResourceName`/`redirectUrlFor` déjà présent dans `ShareWebController` (dupliqué à l'identique plutôt que factorisé — 2 appelants seulement, règle des 3 occurrences).
+- Décisions de conception : page séparée de `/partages` (qui reste dédiée à l'owner) ; partages expirés/révoqués exclus de la liste (pas affichés grisés) ; route accessible à un compte `full` mais toujours liste vide (pas de 403 — cohérent avec l'absence de précédent pour bloquer une route selon `accountType`).
+- Lien de navigation conditionnel `{% if app.user.isGuest %}` ajouté dans la sidebar (`templates/web/layout.html.twig`), pas dans la tab-bar mobile fixe.
+- Correction d'un commentaire obsolète dans `ShareWebController::index()` qui affirmait à tort qu'un guest n'avait pas accès à `/partages`.
+- Tests : isolation stricte entre guests (un guest ne voit que ses propres partages reçus), exclusion expiré/révoqué, cas vide, lien direct vers la ressource, visibilité du lien nav selon `accountType`.
 
 ## 🚧 Vignettes médias — explorer et vidéo (en cours, #312, branche `feat/312-vignettes-medias`)
 

--- a/src/Controller/Web/MyReceivedSharesWebController.php
+++ b/src/Controller/Web/MyReceivedSharesWebController.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Web;
+
+use App\Entity\Album;
+use App\Entity\File;
+use App\Entity\Folder;
+use App\Entity\Share;
+use App\Entity\User;
+use App\Interface\ShareRepositoryInterface;
+use App\Security\ResourceLocator;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Page web « Mes partages » — liste, pour l'utilisateur connecté, les
+ * partages actifs dont il est le destinataire (guest). Cf. issue #273 :
+ * un invité n'a sinon aucun moyen de retrouver ses partages reçus en dehors
+ * du lien contenu dans l'email de notification.
+ */
+#[IsGranted('ROLE_USER')]
+final class MyReceivedSharesWebController extends AbstractController
+{
+    public function __construct(
+        private readonly ShareRepositoryInterface $shareRepository,
+        private readonly ResourceLocator $resourceLocator,
+    ) {}
+
+    #[Route('/mes-partages', name: 'app_my_received_shares')]
+    public function index(): Response
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $incoming = array_map(
+            fn (Share $share) => [
+                'share'        => $share,
+                'resourceName' => $this->resolveResourceName($share),
+                'targetUrl'    => $this->redirectUrlFor($share->getResourceType(), (string) $share->getResourceId()),
+            ],
+            $this->shareRepository->findActiveByGuest($user),
+        );
+
+        return $this->render('web/my_received_shares.html.twig', [
+            'incoming' => $incoming,
+        ]);
+    }
+
+    private function redirectUrlFor(string $resourceType, string $resourceId): string
+    {
+        return match ($resourceType) {
+            Share::RESOURCE_ALBUM  => '/albums/' . $resourceId,
+            Share::RESOURCE_FOLDER => '/explorer?folder=' . $resourceId,
+            default => '/explorer',
+        };
+    }
+
+    private function resolveResourceName(Share $share): string
+    {
+        try {
+            $resource = $this->resourceLocator->locate($share->getResourceType(), $share->getResourceId());
+        } catch (NotFoundHttpException) {
+            return 'Ressource supprimée';
+        }
+
+        return match (true) {
+            $resource instanceof File   => $resource->getOriginalName(),
+            $resource instanceof Folder => $resource->getName(),
+            $resource instanceof Album  => $resource->getName(),
+        };
+    }
+}

--- a/src/Controller/Web/ShareWebController.php
+++ b/src/Controller/Web/ShareWebController.php
@@ -53,10 +53,12 @@ final class ShareWebController extends AbstractController
         /** @var User $user */
         $user = $this->getUser();
 
-        // findByUser retourne owner OU guest, mais HomeCloud est mono-owner
-        // par instance : l'utilisateur connecté ici est toujours l'owner, il
-        // n'y a donc jamais de partage "reçu" à distinguer (cf. GuestRestrictionChecker,
-        // les invités n'ont pas accès à cette page).
+        // findByUser retourne owner OU guest, mais cette page n'affiche que
+        // le volet sortant (créé par l'utilisateur) : un guest peut y accéder
+        // (aucune restriction GuestRestrictionChecker ici, qui ne bloque que
+        // l'écriture), il y verrait simplement une liste vide côté sortant.
+        // Le volet "reçu" par un guest est exposé séparément par
+        // /mes-partages (cf. MyReceivedSharesWebController, issue #273).
         $outgoing = array_map(
             fn ($share) => [
                 'share'        => $share,

--- a/src/Interface/ShareRepositoryInterface.php
+++ b/src/Interface/ShareRepositoryInterface.php
@@ -24,6 +24,13 @@ interface ShareRepositoryInterface
 
     public function findActiveShare(User $guest, string $resourceType, Uuid $resourceId, string $permission): ?Share;
 
+    /**
+     * Partages actifs (non révoqués, non expirés) reçus par ce guest.
+     *
+     * @return Share[]
+     */
+    public function findActiveByGuest(User $guest): array;
+
     /** Supprime tous les shares pointant vers cette ressource (nettoyage à la suppression). */
     public function deleteByResource(string $resourceType, Uuid $resourceId): void;
 }

--- a/src/Repository/ShareRepository.php
+++ b/src/Repository/ShareRepository.php
@@ -76,6 +76,20 @@ class ShareRepository extends ServiceEntityRepository implements ShareRepository
         return $qb->getQuery()->getOneOrNullResult();
     }
 
+    /** Partages actifs (non révoqués, non expirés) reçus par ce guest. */
+    public function findActiveByGuest(User $guest): array
+    {
+        return $this->createQueryBuilder('s')
+            ->where('s.guest = :guest')
+            ->andWhere('s.revokedAt IS NULL')
+            ->andWhere('s.expiresAt IS NULL OR s.expiresAt > :now')
+            ->setParameter('guest', $guest->getId(), 'uuid')
+            ->setParameter('now', new \DateTimeImmutable())
+            ->orderBy('s.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
     /** Supprime tous les shares pointant vers cette ressource (nettoyage à la suppression). */
     public function deleteByResource(string $resourceType, Uuid $resourceId): void
     {

--- a/templates/web/layout.html.twig
+++ b/templates/web/layout.html.twig
@@ -86,6 +86,16 @@
                 Partages
             </a>
 
+            {% if app.user.isGuest %}
+            <a href="{{ path('app_my_received_shares') }}"
+               class="hc-nav-item {{ current_route == 'app_my_received_shares' ? 'active' : '' }}">
+                <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                    <path d="M18 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 22a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM8.6 13.5l6.8 4M15.4 6.5l-6.8 4"/>
+                </svg>
+                Mes partages
+            </a>
+            {% endif %}
+
             <a href="{{ path('app_guests') }}"
                class="hc-nav-item {{ current_route == 'app_guests' ? 'active' : '' }}">
                 <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">

--- a/templates/web/my_received_shares.html.twig
+++ b/templates/web/my_received_shares.html.twig
@@ -1,0 +1,53 @@
+{% extends 'web/layout.html.twig' %}
+
+{% block title %}Mes partages — HomeCloud{% endblock %}
+
+{% block content %}
+
+{% set shareIcon %}<svg width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M18 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 22a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM8.6 13.5l6.8 4M15.4 6.5l-6.8 4"/></svg>{% endset %}
+
+<div class="flex flex-col gap-7 max-w-[1100px] mx-auto h-full">
+
+  {# En-tête de page #}
+  <div class="flex items-center justify-between">
+    <div>
+      <h1 class="text-2xl font-black tracking-tight mb-1 flex items-center gap-2">
+        {{ shareIcon }}
+        Mes partages
+      </h1>
+      <p class="hc-page-sub">{{ incoming|length }} reçu{{ incoming|length != 1 ? 's' : '' }}</p>
+    </div>
+  </div>
+
+  {% if incoming is empty %}
+    <div data-testid="my-shares-empty">
+      <twig:EmptyState
+        title="Vous n'avez reçu aucun partage actif"
+        subtitle="Les ressources partagées avec vous par un autre utilisateur apparaîtront ici."
+        icon="<svg width='64' height='64' fill='none' stroke='currentColor' stroke-width='1.5' viewBox='0 0 24 24' class='hc-icon'><path d='M18 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 22a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM8.6 13.5l6.8 4M15.4 6.5l-6.8 4'/></svg>"
+      />
+    </div>
+  {% else %}
+    <div class="hc-item-card" style="display:flex; flex-direction:column; gap:0; padding:0;" data-testid="my-shares-list">
+      {% for row in incoming %}
+        <div class="flex items-center justify-between px-4 py-3" style="border-bottom:1px solid var(--hc-border);" data-testid="share-row-incoming">
+          <div>
+            <a href="{{ row.targetUrl }}" class="hc-item-name">{{ row.resourceName }}</a>
+            <div class="hc-item-meta">
+              Partagé par {{ row.share.owner.displayName }} ·
+              {{ row.share.permission == 'write' ? 'lecture/écriture' : 'lecture seule' }} ·
+              {% if row.share.expiresAt %}
+                expire le {{ row.share.expiresAt|date('d/m/Y') }}
+              {% else %}
+                permanent
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+
+</div>
+
+{% endblock %}

--- a/tests/Repository/ShareRepositoryTest.php
+++ b/tests/Repository/ShareRepositoryTest.php
@@ -76,4 +76,90 @@ final class ShareRepositoryTest extends KernelTestCase
         $this->assertNull($this->repository->find($targetShare->getId()));
         $this->assertNotNull($this->repository->find($otherShare->getId()));
     }
+
+    public function testFindActiveByGuestReturnsOnlyActiveSharesForThatGuest(): void
+    {
+        $owner  = $this->createUser('owner-find-active-guest@example.com');
+        $guestA = $this->createUser('guest-a-find-active@example.com');
+        $guestB = $this->createUser('guest-b-find-active@example.com');
+
+        $shareA = new Share($owner, $guestA, Share::RESOURCE_FOLDER, Uuid::v7(), Share::PERMISSION_READ);
+        $shareB = new Share($owner, $guestB, Share::RESOURCE_FOLDER, Uuid::v7(), Share::PERMISSION_READ);
+        $this->em->persist($shareA);
+        $this->em->persist($shareB);
+        $this->em->flush();
+
+        $result = $this->repository->findActiveByGuest($guestA);
+
+        $this->assertCount(1, $result);
+        $this->assertTrue($result[0]->getId()->equals($shareA->getId()));
+    }
+
+    public function testFindActiveByGuestExcludesExpiredShares(): void
+    {
+        $owner = $this->createUser('owner-expired-guest@example.com');
+        $guest = $this->createUser('guest-expired@example.com');
+
+        $expired = new Share(
+            $owner,
+            $guest,
+            Share::RESOURCE_FOLDER,
+            Uuid::v7(),
+            Share::PERMISSION_READ,
+            new \DateTimeImmutable('-1 day'),
+        );
+        $this->em->persist($expired);
+        $this->em->flush();
+
+        $result = $this->repository->findActiveByGuest($guest);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testFindActiveByGuestExcludesRevokedShares(): void
+    {
+        $owner = $this->createUser('owner-revoked-guest@example.com');
+        $guest = $this->createUser('guest-revoked@example.com');
+
+        $revoked = new Share($owner, $guest, Share::RESOURCE_FOLDER, Uuid::v7(), Share::PERMISSION_READ);
+        $revoked->revoke();
+        $this->em->persist($revoked);
+        $this->em->flush();
+
+        $result = $this->repository->findActiveByGuest($guest);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testFindActiveByGuestReturnsEmptyArrayWhenNoShares(): void
+    {
+        $guest = $this->createUser('guest-no-shares@example.com');
+
+        $result = $this->repository->findActiveByGuest($guest);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testFindActiveByGuestOrdersByCreatedAtDescending(): void
+    {
+        $owner = $this->createUser('owner-order-guest@example.com');
+        $guest = $this->createUser('guest-order@example.com');
+
+        $older = new Share($owner, $guest, Share::RESOURCE_FOLDER, Uuid::v7(), Share::PERMISSION_READ);
+        $newer = new Share($owner, $guest, Share::RESOURCE_FOLDER, Uuid::v7(), Share::PERMISSION_READ);
+        $this->em->persist($older);
+        $this->em->persist($newer);
+        $this->em->flush();
+
+        $reflection = new \ReflectionProperty(Share::class, 'createdAt');
+        $reflection->setValue($older, new \DateTimeImmutable('-2 days'));
+        $reflection->setValue($newer, new \DateTimeImmutable('-1 day'));
+        $this->em->flush();
+
+        $result = $this->repository->findActiveByGuest($guest);
+
+        $this->assertCount(2, $result);
+        $this->assertTrue($result[0]->getId()->equals($newer->getId()));
+        $this->assertTrue($result[1]->getId()->equals($older->getId()));
+    }
 }

--- a/tests/Web/MyReceivedSharesWebTest.php
+++ b/tests/Web/MyReceivedSharesWebTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\Folder;
+use App\Entity\Share;
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class MyReceivedSharesWebTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM shares');
+        $conn->executeStatement('DELETE FROM medias');
+        $conn->executeStatement('DELETE FROM files');
+        $conn->executeStatement('DELETE FROM folders');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createGuestUser(string $email): User
+    {
+        $guest = $this->createWebUser($email, 'secret123', 'Guest User');
+        $guest->markAsGuest();
+        $this->em->flush();
+
+        return $guest;
+    }
+
+    private function createFolder(User $owner, string $name = 'Documents'): Folder
+    {
+        $folder = new Folder($name, $owner);
+        $this->em->persist($folder);
+        $this->em->flush();
+
+        return $folder;
+    }
+
+    public function testMyReceivedSharesPageRequiresLogin(): void
+    {
+        $this->client->request('GET', '/mes-partages');
+
+        $this->assertResponseRedirects('/login');
+    }
+
+    public function testMyReceivedSharesPageListsActiveIncomingShares(): void
+    {
+        $owner = $this->createWebUser('owner-my-shares@example.com', 'secret123', 'Owner User');
+        $guest = $this->createGuestUser('guest-my-shares@example.com');
+        $folder = $this->createFolder($owner, 'Partage reçu');
+        $share = new Share($owner, $guest, Share::RESOURCE_FOLDER, $folder->getId(), Share::PERMISSION_READ);
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $this->loginAs('guest-my-shares@example.com');
+
+        $crawler = $this->client->request('GET', '/mes-partages');
+
+        $this->assertResponseIsSuccessful();
+        $text = $crawler->filter('body')->text();
+        $this->assertStringContainsString('Partage reçu', $text);
+        $this->assertStringContainsString('Owner User', $text);
+    }
+
+    public function testMyReceivedSharesPageShowsResourceTypeOwnerPermissionAndExpiry(): void
+    {
+        $owner = $this->createWebUser('owner-details@example.com', 'secret123', 'Owner Details');
+        $guest = $this->createGuestUser('guest-details@example.com');
+        $folder = $this->createFolder($owner, 'Dossier détaillé');
+        $expiresAt = new \DateTimeImmutable('+7 days');
+        $share = new Share($owner, $guest, Share::RESOURCE_FOLDER, $folder->getId(), Share::PERMISSION_WRITE, $expiresAt);
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $this->loginAs('guest-details@example.com');
+
+        $crawler = $this->client->request('GET', '/mes-partages');
+        $this->assertResponseIsSuccessful();
+
+        $row = $crawler->filter('[data-testid="share-row-incoming"]')->text();
+        $this->assertStringContainsString('Dossier détaillé', $row);
+        $this->assertStringContainsString('Owner Details', $row);
+        $this->assertStringContainsString('lecture/écriture', $row);
+        $this->assertStringContainsString($expiresAt->format('d/m/Y'), $row);
+    }
+
+    public function testMyReceivedSharesPageExcludesExpiredShares(): void
+    {
+        $owner = $this->createWebUser('owner-expired@example.com', 'secret123', 'Owner Expired');
+        $guest = $this->createGuestUser('guest-expired-page@example.com');
+        $folder = $this->createFolder($owner, 'Dossier expiré');
+        $share = new Share(
+            $owner,
+            $guest,
+            Share::RESOURCE_FOLDER,
+            $folder->getId(),
+            Share::PERMISSION_READ,
+            new \DateTimeImmutable('-1 day'),
+        );
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $this->loginAs('guest-expired-page@example.com');
+
+        $crawler = $this->client->request('GET', '/mes-partages');
+        $this->assertResponseIsSuccessful();
+        $this->assertStringNotContainsString('Dossier expiré', $crawler->filter('body')->text());
+    }
+
+    public function testMyReceivedSharesPageExcludesRevokedShares(): void
+    {
+        $owner = $this->createWebUser('owner-revoked@example.com', 'secret123', 'Owner Revoked');
+        $guest = $this->createGuestUser('guest-revoked-page@example.com');
+        $folder = $this->createFolder($owner, 'Dossier révoqué');
+        $share = new Share($owner, $guest, Share::RESOURCE_FOLDER, $folder->getId(), Share::PERMISSION_READ);
+        $share->revoke();
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $this->loginAs('guest-revoked-page@example.com');
+
+        $crawler = $this->client->request('GET', '/mes-partages');
+        $this->assertResponseIsSuccessful();
+        $this->assertStringNotContainsString('Dossier révoqué', $crawler->filter('body')->text());
+    }
+
+    public function testMyReceivedSharesPageShowsEmptyStateWhenNoShares(): void
+    {
+        $this->createGuestUser('guest-empty@example.com');
+        $this->loginAs('guest-empty@example.com');
+
+        $crawler = $this->client->request('GET', '/mes-partages');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-testid="my-shares-empty"]');
+    }
+
+    public function testGuestOnlySeesTheirOwnReceivedShares(): void
+    {
+        $owner = $this->createWebUser('owner-isolation@example.com', 'secret123', 'Owner Isolation');
+        $guestA = $this->createGuestUser('guest-a-isolation@example.com');
+        $guestB = $this->createGuestUser('guest-b-isolation@example.com');
+
+        $folderA = $this->createFolder($owner, 'Dossier de A');
+        $folderB = $this->createFolder($owner, 'Dossier de B');
+
+        $shareA = new Share($owner, $guestA, Share::RESOURCE_FOLDER, $folderA->getId(), Share::PERMISSION_READ);
+        $shareB = new Share($owner, $guestB, Share::RESOURCE_FOLDER, $folderB->getId(), Share::PERMISSION_READ);
+        $this->em->persist($shareA);
+        $this->em->persist($shareB);
+        $this->em->flush();
+
+        $this->loginAs('guest-a-isolation@example.com');
+
+        $crawler = $this->client->request('GET', '/mes-partages');
+        $this->assertResponseIsSuccessful();
+
+        $text = $crawler->filter('body')->text();
+        $this->assertStringContainsString('Dossier de A', $text);
+        $this->assertStringNotContainsString('Dossier de B', $text);
+    }
+
+    public function testFullAccountSeesEmptyListOnMyReceivedSharesPage(): void
+    {
+        $this->createWebUser('full-account@example.com', 'secret123', 'Full Account');
+        $this->loginAs('full-account@example.com');
+
+        $crawler = $this->client->request('GET', '/mes-partages');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-testid="my-shares-empty"]');
+    }
+
+    public function testMyReceivedSharesLinkPointsToResource(): void
+    {
+        $owner = $this->createWebUser('owner-link@example.com', 'secret123', 'Owner Link');
+        $guest = $this->createGuestUser('guest-link@example.com');
+        $folder = $this->createFolder($owner, 'Dossier cible');
+        $share = new Share($owner, $guest, Share::RESOURCE_FOLDER, $folder->getId(), Share::PERMISSION_READ);
+        $this->em->persist($share);
+        $this->em->flush();
+
+        $this->loginAs('guest-link@example.com');
+
+        $crawler = $this->client->request('GET', '/mes-partages');
+        $this->assertResponseIsSuccessful();
+
+        $link = $crawler->filter('[data-testid="share-row-incoming"] a')->first();
+        $this->assertStringContainsString('/explorer?folder=' . $folder->getId()->toRfc4122(), $link->attr('href'));
+    }
+
+    public function testNavShowsMyReceivedSharesLinkForGuestAccount(): void
+    {
+        $this->createGuestUser('guest-nav@example.com');
+        $this->loginAs('guest-nav@example.com');
+
+        $crawler = $this->client->request('GET', '/');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('a[href="/mes-partages"]');
+    }
+
+    public function testNavHidesMyReceivedSharesLinkForFullAccount(): void
+    {
+        $this->createWebUser('full-nav@example.com', 'secret123', 'Full Nav');
+        $this->loginAs('full-nav@example.com');
+
+        $crawler = $this->client->request('GET', '/');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorNotExists('a[href="/mes-partages"]');
+    }
+}


### PR DESCRIPTION
## Résumé

- Nouvelle page `/mes-partages` listant, pour l'utilisateur connecté, les `Share` actifs (non révoqués, non expirés) dont il est le destinataire (`guest`) — jusqu'ici la seule porte d'entrée était le lien contenu dans l'email de notification.
- `ShareRepository::findActiveByGuest()` : requête filtrée guest + active, triée par date décroissante. Aucune migration Doctrine (l'index `idx_share_lookup` couvrait déjà le besoin).
- `MyReceivedSharesWebController` (lecture seule) + `templates/web/my_received_shares.html.twig`, réutilisant le pattern `resolveResourceName`/`redirectUrlFor` existant dans `ShareWebController`.
- Lien de navigation conditionnel `{% if app.user.isGuest %}` ajouté à la sidebar.
- Décisions de conception : page séparée de `/partages` (dédiée à l'owner) ; partages expirés/révoqués exclus (pas grisés) ; route accessible à un compte `full` mais toujours liste vide (pas de 403).
- Correction d'un commentaire obsolète dans `ShareWebController` qui affirmait à tort qu'un guest n'avait pas accès à `/partages`.

Closes #273

## Test plan

- [x] `./vendor/bin/phpunit --filter ShareRepositoryTest` — 7 tests (isolation guest, exclusion expiré/révoqué, vide, tri)
- [x] `./vendor/bin/phpunit --filter MyReceivedSharesWebTest` — 11 tests (accès non autorisé, happy path, cas limites, lien nav)
- [x] Suite complète `./vendor/bin/phpunit` — 940 tests, GREEN
- [x] `composer build-assets` (Tailwind) relancé après modification des templates