### PR TITLE
Diffuser un message admin (maintenance/indisponibilité) à tous les utilisateurs des instances

### DIFF
--- a/.claude/deploiement.md
+++ b/.claude/deploiement.md
@@ -8,7 +8,7 @@ Cible : hébergement mutualisé **o2switch**, un sous-domaine par instance (`<pr
 
 SSH depuis la machine locale via les scripts `bin/`.
 
-> Le déploiement automatique GitHub Actions (webhook) ne fonctionne **pas** sur o2switch — les IPs des runners GitHub Actions sont bloquées par le firewall SSH. Les scripts SSH sont la seule méthode fiable aujourd'hui (#288, en pause). Le webhook `public/deploy.php` existe dans le repo mais est cassé et inutilisé.
+> Le déploiement automatique GitHub Actions (webhook) ne fonctionne **pas** sur o2switch — les IPs des runners GitHub Actions sont bloquées par le firewall SSH. Les scripts SSH sont la seule méthode fiable aujourd'hui (#288, en pause). Le webhook `public/deploy.php` existe dans le repo et est actif (vérifié HMAC-SHA256, secret `DEPLOY_WEBHOOK_SECRET`), déclenché par GitHub Actions après CI success — mais reste sans effet pratique tant que le blocage IP côté o2switch n'est pas levé.
 
 ### Piège IP dynamique / VPN d'entreprise
 
@@ -353,6 +353,27 @@ MAILER_DSN=smtp://<user>:<password>@lenouvel.me:465
 > les instances — même boîte SMTP `lenouvel.me` pour tout le monde). Sans cette clé,
 > l'instance est créée avec `MAILER_DSN=null://null` : aucun email d'invitation ni de
 > réinitialisation de mot de passe ne part (cf. `GuestAccountCreator`).
+
+### `BROADCAST_SHARED_TOKEN` — diffusion admin multi-instances (#283)
+
+Secret partagé, **identique sur les 7 instances**, qui authentifie les appels
+service-to-service entre `ronan.lenouvel.me` (qui orchestre) et chaque autre
+instance (endpoint interne `POST /internal/broadcast`, hors JWT utilisateur).
+
+```bash
+BROADCAST_SHARED_TOKEN=<généré une fois avec : openssl rand -hex 32>
+BROADCAST_INSTANCE_NAME=<prenom>   # ronan, yannick, coralie...
+BROADCAST_ADMIN_EMAIL=<email du compte admin, pertinent uniquement sur ronan.lenouvel.me>
+```
+
+Généré automatiquement par `bin/deploy-all.sh --init` depuis
+`BROADCAST_SHARED_TOKEN_PRESET` (et `BROADCAST_ADMIN_EMAIL_PRESET`) dans
+`.secrets` (variables globales, comme `MAILER_DSN_PRESET`). Pour les
+instances **déjà déployées avant cette feature**, ajouter manuellement les
+3 lignes ci-dessus dans le `.env.local` de chacune (SSH), avec la **même**
+valeur de `BROADCAST_SHARED_TOKEN` partout — un token qui diverge sur une
+seule instance la rend injoignable depuis `ronan.lenouvel.me` (401 silencieux
+côté orchestrateur, loggé en warning, sans bloquer les autres instances).
 
 ### `MAILER_DSN` — obligatoire pour les emails (dont la notif de fin de lot)
 

--- a/.env
+++ b/.env
@@ -60,3 +60,15 @@ JWT_PASSPHRASE=
 ###> symfony/mailer ###
 MAILER_DSN=null://null
 ###< symfony/mailer ###
+
+###> app/broadcast ###
+# Diffusion admin multi-instances (#283)
+# Secret partagé entre les 7 instances — générer avec : openssl rand -hex 32
+# Placer la valeur réelle dans .env.local (jamais commiter le secret)
+BROADCAST_SHARED_TOKEN=
+# Prénom de l'instance courante (ronan, yannick, coralie...) — utilisé pour
+# s'auto-exclure de la boucle d'appels HTTP vers les autres instances
+BROADCAST_INSTANCE_NAME=
+# Email du compte admin autorisé à déclencher un broadcast depuis /admin/broadcast
+BROADCAST_ADMIN_EMAIL=
+###< app/broadcast ###

--- a/.env.production.example
+++ b/.env.production.example
@@ -30,3 +30,12 @@ JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
 JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
 JWT_PASSPHRASE=CHANGE_ME
 JWT_TTL=3600
+
+# Diffusion admin multi-instances (#283)
+# Secret partagé — identique sur les 7 instances, généré une fois avec :
+# openssl rand -hex 32
+BROADCAST_SHARED_TOKEN=CHANGE_ME
+# Prénom de cette instance (ronan, yannick, coralie...)
+BROADCAST_INSTANCE_NAME=PRENOM
+# Email du compte admin autorisé à déclencher un broadcast (uniquement pertinent sur ronan.lenouvel.me)
+BROADCAST_ADMIN_EMAIL=CHANGE_ME

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,6 @@
 APP_ENV=test
 KERNEL_CLASS='App\Kernel'
 DATABASE_URL="mysql://root:root@127.0.0.1:3306/homecloud?serverVersion=mariadb-10.11.0&charset=utf8mb4"
+BROADCAST_SHARED_TOKEN=test-broadcast-token-fixed
+BROADCAST_INSTANCE_NAME=ronan
+BROADCAST_ADMIN_EMAIL=admin@homecloud.test

--- a/.github/avancement.md
+++ b/.github/avancement.md
@@ -6,6 +6,15 @@
 
 ---
 
+## ✅ Diffusion d'un message admin multi-instances (2026-07-23, #283, branche `feature/283-broadcast-message`)
+
+- Ronan peut diffuser un message (maintenance, indisponibilité, mise à jour majeure) par email à tous les utilisateurs (propriétaires + invités) de toutes les instances déployées, ou une seule instance ciblée, en une seule action depuis `/admin/broadcast`.
+- Architecture : chaque instance a sa propre DB isolée (pas de requête SQL centrale possible). L'instance `ronan.lenouvel.me` orchestre via un appel HTTP interne (`BroadcastOrchestrator` → `POST /internal/broadcast`) sur chaque autre instance, qui envoie ensuite ses propres emails localement (`BroadcastMailer::sendToAllUsers`). Secret partagé identique sur les 7 instances (`BROADCAST_SHARED_TOKEN`), authentification par `BroadcastTokenAuthenticator` sur un firewall dédié `broadcast_internal`, hors du firewall JWT `api` (structurellement incompatible avec un appel service-to-service).
+- Pas de nouveau `ROLE_ADMIN` Symfony (aucun rôle différencié n'existe dans ce projet) : garde applicative `BroadcastAdminChecker` (whitelist par email `BROADCAST_ADMIN_EMAIL`), couvrant le cas où un guest serait un jour ajouté sur l'instance admin elle-même.
+- Dry-run à tous les niveaux (service, orchestrateur, endpoint, command, formulaire admin) sans duplication de la logique d'envoi — en dry-run, l'orchestrateur ne fait aucun appel HTTP sortant.
+- Canal email uniquement pour cette version — notification in-app laissée en ticket de suivi (#361).
+- Tests : `BroadcastTargetProviderTest`, `BroadcastMailerTest` (dont guest inclus, email invalide skippé), `BroadcastOrchestratorTest` (ciblage, dry-run, échec partiel n'interrompt pas les autres), `BroadcastInternalControllerTest` (401 sans/mauvais token), `BroadcastSendCommandTest`, `BroadcastAdminCheckerTest`, `BroadcastAdminWebControllerTest` (403 non-admin).
+
 ## ✅ Stockage utilisé sur le dashboard (2026-07-23, #301, branche `feature/301-storage-used-dashboard`)
 
 - `HomeController::index()` affichait un placeholder statique (`'Calcul à implémenter'`) à la place du poids réel de stockage.

--- a/bin/deploy-all.sh
+++ b/bin/deploy-all.sh
@@ -144,6 +144,9 @@ for PRENOM in "${TARGETS[@]}"; do
         if [[ -z "${MAILER_DSN_PRESET:-}" ]]; then
             warn "MAILER_DSN_PRESET absent (.secrets ou .secrets.${PRENOM}) — l'instance n'enverra aucun email"
         fi
+        if [[ -z "${BROADCAST_SHARED_TOKEN_PRESET:-}" ]]; then
+            warn "BROADCAST_SHARED_TOKEN_PRESET absent (.secrets) — le broadcast admin (#283) sera désactivé sur cette instance"
+        fi
 
         DB_NAME="${SSH_USER}_${PRENOM}"
         DB_USER="${SSH_USER}_${PRENOM}"
@@ -160,7 +163,10 @@ DATABASE_URL=${DATABASE_URL}
 JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
 JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
 JWT_PASSPHRASE=${JWT_PASSPHRASE}
-MAILER_DSN=${MAILER_DSN_PRESET:-null://null}"
+MAILER_DSN=${MAILER_DSN_PRESET:-null://null}
+BROADCAST_SHARED_TOKEN=${BROADCAST_SHARED_TOKEN_PRESET:-}
+BROADCAST_INSTANCE_NAME=${PRENOM}
+BROADCAST_ADMIN_EMAIL=${BROADCAST_ADMIN_EMAIL_PRESET:-}"
 
         if ssh ${SSH_KEY_OPTS} -p "${SSH_PORT}" "${SSH_USER}@${SSH_HOST}" "set -e; mkdir -p ${DEPLOY_PATH}; cd ${DEPLOY_PATH}; git clone ${GIT_REPO} . && mkdir -p var/log && cat > .env.local <<'ENVEOF'
 ${ENV_LOCAL_CONTENT}

--- a/config/broadcast_targets.php
+++ b/config/broadcast_targets.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+// Miroir de .deploy-targets (racine du repo) — à maintenir manuellement en
+// synchro à chaque nouvelle instance. Ne PAS lire .deploy-targets depuis le
+// PHP applicatif : fichier shell, format non garanti, usage réservé à
+// bin/deploy-all.sh.
+return [
+    'ronan'    => 'https://ronan.lenouvel.me',
+    'yannick'  => 'https://yannick.lenouvel.me',
+    'coralie'  => 'https://coralie.lenouvel.me',
+    'elea'     => 'https://elea.lenouvel.me',
+    'corentin' => 'https://corentin.lenouvel.me',
+    'damien'   => 'https://damien.lenouvel.me',
+    'baptiste' => 'https://baptiste.lenouvel.me',
+];

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -26,6 +26,12 @@ security:
                 max_attempts: 5
                 interval: '15 minutes'
 
+        broadcast_internal:
+            pattern: ^/internal/broadcast
+            stateless: true
+            custom_authenticators:
+                - App\Security\BroadcastTokenAuthenticator
+
         api:
             pattern: ^/api
             stateless: true
@@ -68,6 +74,9 @@ when@dev: &access_control
             - { path: ^/api/reset-password, roles: PUBLIC_ACCESS }
             - { path: ^/api/request-reset-password, roles: PUBLIC_ACCESS }
             - { path: ^/api/docs, roles: PUBLIC_ACCESS }
+            # Auth par secret partagé gérée par BroadcastTokenAuthenticator,
+            # pas par ROLE_USER JWT — doit précéder la règle catch-all ^/api.
+            - { path: ^/internal/broadcast, roles: PUBLIC_ACCESS }
             - { path: ^/api, roles: ROLE_USER }
             # Partage par lien public : accessible sans compte, le secret est
             # dans (selector, token). Doit précéder toute règle catch-all ^/.

--- a/config/packages/test/security.yaml
+++ b/config/packages/test/security.yaml
@@ -19,6 +19,12 @@ security:
                 success_handler: lexik_jwt_authentication.handler.authentication_success
                 failure_handler: lexik_jwt_authentication.handler.authentication_failure
 
+        broadcast_internal:
+            pattern: ^/internal/broadcast
+            stateless: true
+            custom_authenticators:
+                - App\Security\BroadcastTokenAuthenticator
+
         api:
             pattern: ^/api
             stateless: true
@@ -52,6 +58,7 @@ security:
         - { path: ^/api/docs, roles: PUBLIC_ACCESS }
         - { path: ^/api/v1/auth/login$, roles: PUBLIC_ACCESS }
         - { path: ^/api/v1/auth/token/refresh$, roles: PUBLIC_ACCESS }
+        - { path: ^/internal/broadcast, roles: PUBLIC_ACCESS }
         - { path: ^/api, roles: ROLE_USER }
         - { path: ^/login$, roles: PUBLIC_ACCESS }
         - { path: ^/web/token$, roles: ROLE_USER }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -35,6 +35,9 @@ services:
     App\Interface\BatchCompletionNotifierInterface: '@App\Service\BatchCompletionNotifier'
     App\Interface\ShareNotificationMailerInterface: '@App\Service\ShareNotificationMailer'
     App\Interface\FolderZipArchiverInterface:     '@App\Service\FolderZipArchiver'
+    App\Interface\BroadcastTargetProviderInterface: '@App\Service\BroadcastTargetProvider'
+    App\Interface\BroadcastMailerInterface:       '@App\Service\BroadcastMailer'
+    App\Interface\BroadcastOrchestratorInterface: '@App\Service\BroadcastOrchestrator'
 
     App\State\AlbumProcessor:
         arguments:
@@ -83,6 +86,11 @@ services:
     _defaults:
         autowire: true      # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+        bind:
+            string $sharedToken: '%env(BROADCAST_SHARED_TOKEN)%'
+            string $adminEmail: '%env(BROADCAST_ADMIN_EMAIL)%'
+            string $currentInstance: '%env(BROADCAST_INSTANCE_NAME)%'
+            string $configPath: '%kernel.project_dir%/config/broadcast_targets.php'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/Command/BroadcastSendCommand.php
+++ b/src/Command/BroadcastSendCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Interface\BroadcastOrchestratorInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Diffuse un message admin (#283) à tous les utilisateurs de toutes les
+ * instances, ou d'une seule instance ciblée. Déclenchée manuellement ou par
+ * l'interface admin web (les deux délèguent à BroadcastOrchestratorInterface).
+ */
+#[AsCommand(name: 'app:broadcast:send', description: 'Diffuse un message admin à tous les utilisateurs des instances déployées')]
+final class BroadcastSendCommand extends Command
+{
+    public function __construct(
+        private readonly BroadcastOrchestratorInterface $orchestrator,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('subject', null, InputOption::VALUE_REQUIRED, 'Sujet du message')
+            ->addOption('body', null, InputOption::VALUE_REQUIRED, 'Corps du message (HTML autorisé)')
+            ->addOption('instance', null, InputOption::VALUE_REQUIRED, 'Cibler une seule instance (défaut : toutes)')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, "Simuler sans envoyer d'email réel");
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $results = $this->orchestrator->dispatch(
+            (string) $input->getOption('subject'),
+            (string) $input->getOption('body'),
+            $input->getOption('instance'),
+            (bool) $input->getOption('dry-run'),
+        );
+
+        foreach ($results as $instance => $success) {
+            if ($success) {
+                $io->writeln(sprintf('<info>%s</info> : OK', $instance));
+            } else {
+                $io->writeln(sprintf('<error>%s</error> : échec', $instance));
+            }
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/Api/BroadcastInternalController.php
+++ b/src/Controller/Api/BroadcastInternalController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Api;
+
+use App\Interface\BroadcastMailerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Endpoint interne inter-instances du broadcast admin (#283). Appelé par
+ * l'instance ronan.lenouvel.me sur chaque autre instance pour y déclencher
+ * l'envoi local (DB isolée par instance). Authentification par secret
+ * partagé via BroadcastTokenAuthenticator, hors du firewall JWT `api`.
+ */
+final class BroadcastInternalController extends AbstractController
+{
+    public function __construct(
+        private readonly BroadcastMailerInterface $broadcastMailer,
+    ) {}
+
+    #[Route('/internal/broadcast', name: 'internal_broadcast', methods: ['POST'])]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true) ?? [];
+
+        $sent = $this->broadcastMailer->sendToAllUsers(
+            (string) ($data['subject'] ?? ''),
+            (string) ($data['body'] ?? ''),
+            (bool) ($data['dryRun'] ?? false),
+        );
+
+        return new JsonResponse(['sent' => $sent]);
+    }
+}

--- a/src/Controller/Web/BroadcastAdminWebController.php
+++ b/src/Controller/Web/BroadcastAdminWebController.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Web;
+
+use App\Dto\BroadcastMessageInput;
+use App\Entity\User;
+use App\Form\BroadcastMessageFormType;
+use App\Interface\BroadcastOrchestratorInterface;
+use App\Security\BroadcastAdminChecker;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Interface admin de diffusion d'un message (maintenance/indisponibilité,
+ * #283) à tous les utilisateurs de toutes les instances, ou une instance
+ * ciblée. Réservée au compte admin (BroadcastAdminChecker) — pas de
+ * ROLE_ADMIN Symfony, cf. justification dans ce service.
+ */
+#[IsGranted('ROLE_USER')]
+final class BroadcastAdminWebController extends AbstractController
+{
+    public function __construct(
+        private readonly BroadcastAdminChecker $adminChecker,
+        private readonly BroadcastOrchestratorInterface $orchestrator,
+    ) {}
+
+    #[Route('/admin/broadcast', name: 'app_broadcast_admin', methods: ['GET', 'POST'])]
+    public function __invoke(Request $request): Response
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        if (!$this->adminChecker->isAdmin($user)) {
+            throw $this->createAccessDeniedException("Réservé à l'administrateur.");
+        }
+
+        $input = new BroadcastMessageInput();
+        $form = $this->createForm(BroadcastMessageFormType::class, $input);
+        $form->handleRequest($request);
+
+        $results = null;
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $results = $this->orchestrator->dispatch(
+                $input->subject,
+                $input->body,
+                $input->targetInstance,
+                $input->dryRun,
+            );
+        }
+
+        return $this->render('web/broadcast_admin.html.twig', [
+            'form'    => $form->createView(),
+            'results' => $results,
+        ]);
+    }
+}

--- a/src/Dto/BroadcastMessageInput.php
+++ b/src/Dto/BroadcastMessageInput.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class BroadcastMessageInput
+{
+    #[Assert\NotBlank(message: 'Le sujet est obligatoire.')]
+    public string $subject = '';
+
+    #[Assert\NotBlank(message: 'Le message est obligatoire.')]
+    public string $body = '';
+
+    /** null = toutes les instances */
+    public ?string $targetInstance = null;
+
+    public bool $dryRun = false;
+}

--- a/src/Form/BroadcastMessageFormType.php
+++ b/src/Form/BroadcastMessageFormType.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use App\Dto\BroadcastMessageInput;
+use App\Interface\BroadcastTargetProviderInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class BroadcastMessageFormType extends AbstractType
+{
+    public function __construct(
+        private readonly BroadcastTargetProviderInterface $targetProvider,
+    ) {}
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $instanceChoices = ['Toutes les instances' => null];
+        foreach (array_keys($this->targetProvider->getAllTargets()) as $instance) {
+            $instanceChoices[$instance] = $instance;
+        }
+
+        $builder
+            ->add('subject', TextType::class, ['label' => 'Sujet'])
+            ->add('body', TextareaType::class, ['label' => 'Message'])
+            ->add('targetInstance', ChoiceType::class, [
+                'label'    => 'Cible',
+                'choices'  => $instanceChoices,
+                'required' => false,
+            ])
+            ->add('dryRun', CheckboxType::class, [
+                'label'    => "Essai à blanc (aucun email réel envoyé)",
+                'required' => false,
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults(['data_class' => BroadcastMessageInput::class]);
+    }
+}

--- a/src/Interface/BroadcastMailerInterface.php
+++ b/src/Interface/BroadcastMailerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+interface BroadcastMailerInterface
+{
+    /**
+     * Envoie un message admin à tous les comptes de l'instance courante
+     * (propriétaires et invités). Retourne le nombre de destinataires
+     * (envoyés réellement, ou qui l'auraient été en dry-run).
+     */
+    public function sendToAllUsers(string $subject, string $htmlBody, bool $dryRun): int;
+}

--- a/src/Interface/BroadcastOrchestratorInterface.php
+++ b/src/Interface/BroadcastOrchestratorInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+interface BroadcastOrchestratorInterface
+{
+    /**
+     * Diffuse un message admin (#283) sur toutes les instances (si
+     * $targetInstance est null) ou une seule instance ciblée.
+     *
+     * @return array<string, bool> prénom d'instance => succès
+     */
+    public function dispatch(string $subject, string $body, ?string $targetInstance, bool $dryRun): array;
+}

--- a/src/Interface/BroadcastTargetProviderInterface.php
+++ b/src/Interface/BroadcastTargetProviderInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interface;
+
+interface BroadcastTargetProviderInterface
+{
+    /**
+     * @return array<string, string> prénom d'instance => URL de base
+     */
+    public function getAllTargets(): array;
+
+    public function getTarget(string $instance): ?string;
+}

--- a/src/Interface/UserRepositoryInterface.php
+++ b/src/Interface/UserRepositoryInterface.php
@@ -17,4 +17,7 @@ interface UserRepositoryInterface
 
     /** @param array<string, mixed> $criteria */
     public function findOneBy(array $criteria, ?array $orderBy = null): ?User;
+
+    /** @return User[] */
+    public function findAll(): array;
 }

--- a/src/Security/BroadcastAdminChecker.php
+++ b/src/Security/BroadcastAdminChecker.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Entity\User;
+
+/**
+ * Garde applicative de l'écran /admin/broadcast (#283). Pas de ROLE_ADMIN
+ * Symfony (aucun rôle différencié n'existe dans le projet) — whitelist
+ * explicite par email, pour rester correct même si un guest est un jour
+ * ajouté sur l'instance ronan.lenouvel.me elle-même.
+ */
+final readonly class BroadcastAdminChecker
+{
+    public function __construct(
+        private string $adminEmail,
+    ) {}
+
+    public function isAdmin(User $user): bool
+    {
+        return $this->adminEmail !== '' && $user->getEmail() === $this->adminEmail;
+    }
+}

--- a/src/Security/BroadcastTokenAuthenticator.php
+++ b/src/Security/BroadcastTokenAuthenticator.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+
+/**
+ * Authentifie les appels service-to-service inter-instances du broadcast
+ * admin (#283) — pas de compte utilisateur associé, juste un secret partagé
+ * identique sur les 7 instances (header X-Broadcast-Token). Distinct du
+ * firewall `api` (JWT utilisateur), structurellement incompatible avec ce
+ * cas d'usage.
+ */
+final class BroadcastTokenAuthenticator extends AbstractAuthenticator
+{
+    public function __construct(
+        private readonly string $sharedToken,
+    ) {}
+
+    public function supports(Request $request): ?bool
+    {
+        return true;
+    }
+
+    public function authenticate(Request $request): Passport
+    {
+        $token = $request->headers->get('X-Broadcast-Token', '');
+
+        if ($this->sharedToken === '' || !hash_equals($this->sharedToken, $token)) {
+            throw new CustomUserMessageAuthenticationException('Token de broadcast invalide.');
+        }
+
+        return new SelfValidatingPassport(new UserBadge(
+            'broadcast-service',
+            static fn (): InMemoryUser => new InMemoryUser('broadcast-service', null, ['ROLE_BROADCAST_SERVICE']),
+        ));
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        return null;
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        return new Response('Unauthorized', Response::HTTP_UNAUTHORIZED);
+    }
+}

--- a/src/Service/BroadcastMailer.php
+++ b/src/Service/BroadcastMailer.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Interface\BroadcastMailerInterface;
+use App\Interface\UserRepositoryInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Diffusion d'un message admin (#283) à tous les comptes de l'instance
+ * courante — propriétaires et invités confondus. Chaque instance envoie ses
+ * propres emails localement (DB isolée par instance), sans connaître les
+ * autres — l'orchestration multi-instances est de la responsabilité de
+ * BroadcastOrchestrator.
+ */
+final readonly class BroadcastMailer implements BroadcastMailerInterface
+{
+    public function __construct(
+        private MailerInterface $mailer,
+        private UserRepositoryInterface $userRepository,
+        private ValidatorInterface $validator,
+        private LoggerInterface $logger,
+    ) {}
+
+    public function sendToAllUsers(string $subject, string $htmlBody, bool $dryRun): int
+    {
+        $sent = 0;
+
+        foreach ($this->userRepository->findAll() as $user) {
+            if (\count($this->validator->validate($user->getEmail(), new Email())) > 0) {
+                $this->logger->warning('Broadcast : email invalide ignoré', ['userId' => $user->getId()->toRfc4122()]);
+                continue;
+            }
+
+            $sent++;
+
+            if ($dryRun) {
+                continue;
+            }
+
+            $email = (new TemplatedEmail())
+                ->from(new Address('no-reply@homecloud.fr'))
+                ->to($user->getEmail())
+                ->subject($subject)
+                ->htmlTemplate('emails/broadcast_message.html.twig')
+                ->context([
+                    'subject'     => $subject,
+                    'body'        => $htmlBody,
+                    'accentColor' => EmailBranding::ACCENT_COLOR,
+                ]);
+
+            $this->mailer->send($email);
+        }
+
+        return $sent;
+    }
+}

--- a/src/Service/BroadcastOrchestrator.php
+++ b/src/Service/BroadcastOrchestrator.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Interface\BroadcastMailerInterface;
+use App\Interface\BroadcastOrchestratorInterface;
+use App\Interface\BroadcastTargetProviderInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Orchestration multi-instances du broadcast admin (#283). Chaque instance a
+ * sa propre DB isolée : l'instance courante traite son cas en local (pas
+ * d'aller-retour réseau vers elle-même), les autres sont appelées sur leur
+ * endpoint interne /internal/broadcast, authentifié par un secret partagé.
+ * En dry-run, aucun appel HTTP sortant n'est fait — sinon on spammerait
+ * quand même les autres instances depuis un simple essai.
+ */
+final readonly class BroadcastOrchestrator implements BroadcastOrchestratorInterface
+{
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private BroadcastTargetProviderInterface $targetProvider,
+        private BroadcastMailerInterface $localMailer,
+        private LoggerInterface $logger,
+        private string $currentInstance,
+        private string $sharedToken,
+    ) {}
+
+    public function dispatch(string $subject, string $body, ?string $targetInstance, bool $dryRun): array
+    {
+        $targets = $targetInstance !== null
+            ? [$targetInstance => $this->targetProvider->getTarget($targetInstance)]
+            : $this->targetProvider->getAllTargets();
+
+        $results = [];
+
+        foreach ($targets as $instance => $url) {
+            if ($instance === $this->currentInstance) {
+                $this->localMailer->sendToAllUsers($subject, $body, $dryRun);
+                $results[$instance] = true;
+                continue;
+            }
+
+            if ($dryRun) {
+                $results[$instance] = true;
+                continue;
+            }
+
+            $results[$instance] = $this->dispatchToRemote($url, $subject, $body);
+        }
+
+        return $results;
+    }
+
+    private function dispatchToRemote(string $url, string $subject, string $body): bool
+    {
+        try {
+            $this->httpClient->request('POST', $url . '/internal/broadcast', [
+                'headers' => ['X-Broadcast-Token' => $this->sharedToken],
+                'json'    => ['subject' => $subject, 'body' => $body, 'dryRun' => false],
+            ]);
+
+            return true;
+        } catch (\Throwable $e) {
+            $this->logger->warning('Broadcast : échec vers une instance distante', [
+                'url'   => $url,
+                'error' => $e->getMessage(),
+            ]);
+
+            return false;
+        }
+    }
+}

--- a/src/Service/BroadcastTargetProvider.php
+++ b/src/Service/BroadcastTargetProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Interface\BroadcastTargetProviderInterface;
+
+final readonly class BroadcastTargetProvider implements BroadcastTargetProviderInterface
+{
+    public function __construct(
+        private string $configPath,
+    ) {}
+
+    public function getAllTargets(): array
+    {
+        return require $this->configPath;
+    }
+
+    public function getTarget(string $instance): ?string
+    {
+        return $this->getAllTargets()[$instance] ?? null;
+    }
+}

--- a/src/Twig/BroadcastAdminExtension.php
+++ b/src/Twig/BroadcastAdminExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig;
+
+use App\Entity\User;
+use App\Security\BroadcastAdminChecker;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Expose BroadcastAdminChecker à Twig pour conditionner l'affichage du lien
+ * de navigation /admin/broadcast (#283) dans le layout partagé.
+ */
+final class BroadcastAdminExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly BroadcastAdminChecker $adminChecker,
+    ) {}
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('is_broadcast_admin', $this->isBroadcastAdmin(...)),
+        ];
+    }
+
+    public function isBroadcastAdmin(?User $user): bool
+    {
+        return $user !== null && $this->adminChecker->isAdmin($user);
+    }
+}

--- a/templates/emails/broadcast_message.html.twig
+++ b/templates/emails/broadcast_message.html.twig
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{ subject }}</title>
+</head>
+<body style="margin:0; padding:0; background-color:#FAFAFA; font-family:Arial, Helvetica, sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#FAFAFA;">
+<tr>
+<td align="center" style="padding:32px 16px;">
+
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:480px; background-color:#FFFFFF; border-radius:12px; border:1px solid #e5e5e5;">
+
+<tr>
+<td align="center" style="padding:28px 32px 0 32px;">
+<span style="font-size:20px; font-weight:bold; color:{{ accentColor }};">HomeCloud</span>
+</td>
+</tr>
+
+<tr>
+<td style="padding:24px 32px 8px 32px; color:#0b1220; font-size:15px; line-height:1.5;">
+Bonjour,
+</td>
+</tr>
+
+<tr>
+<td style="padding:0 32px 32px 32px; color:#0b1220; font-size:15px; line-height:1.5;">
+{{ body|raw }}
+</td>
+</tr>
+
+<tr>
+<td style="padding:0 32px 28px 32px; border-top:1px solid #e5e5e5; padding-top:20px;">
+<span style="font-size:12px; color:#8a8f98;">
+Message envoyé par l'administrateur de HomeCloud.
+</span>
+</td>
+</tr>
+
+</table>
+
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:480px;">
+<tr>
+<td align="center" style="padding:16px 32px; color:#8a8f98; font-size:12px;">
+HomeCloud — votre cloud personnel
+<br>
+Solution entièrement développée par Ronan Lenouvel
+</td>
+</tr>
+</table>
+
+</td>
+</tr>
+</table>
+</body>
+</html>

--- a/templates/web/broadcast_admin.html.twig
+++ b/templates/web/broadcast_admin.html.twig
@@ -1,0 +1,37 @@
+{% extends 'web/layout.html.twig' %}
+
+{% block title %}Diffusion admin — HomeCloud{% endblock %}
+
+{% block content %}
+
+<div class="flex flex-col gap-7 max-w-[700px] mx-auto h-full">
+
+  <div>
+    <h1 class="text-2xl font-black tracking-tight mb-1">Diffuser un message</h1>
+    <p class="hc-page-sub">Envoie un email à tous les utilisateurs (propriétaires et invités) de toutes les instances, ou d'une instance ciblée.</p>
+  </div>
+
+  {% if results is not null %}
+    <div class="hc-item-card">
+      <p class="font-bold mb-2">Résultat</p>
+      <ul>
+        {% for instance, success in results %}
+          <li>{{ instance }} : {{ success ? 'OK' : 'échec' }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+
+  {{ form_start(form) }}
+    <div class="flex flex-col gap-4">
+      {{ form_row(form.subject) }}
+      {{ form_row(form.body) }}
+      {{ form_row(form.targetInstance) }}
+      {{ form_row(form.dryRun) }}
+      <button type="submit" class="hc-guest-create-submit self-start">Envoyer</button>
+    </div>
+  {{ form_end(form) }}
+
+</div>
+
+{% endblock %}

--- a/templates/web/layout.html.twig
+++ b/templates/web/layout.html.twig
@@ -111,6 +111,16 @@
                 </svg>
                 Changelog
             </a>
+
+            {% if is_broadcast_admin(app.user) %}
+            <a href="{{ path('app_broadcast_admin') }}"
+               class="hc-nav-item {{ current_route == 'app_broadcast_admin' ? 'active' : '' }}">
+                <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                    <path d="M3 11l18-5v12L3 14v-3z"/><path d="M11.6 16.8a3 3 0 1 1-5.8-1.6"/>
+                </svg>
+                Diffuser un message
+            </a>
+            {% endif %}
         </nav>
     </aside>
 

--- a/tests/Api/BroadcastInternalControllerTest.php
+++ b/tests/Api/BroadcastInternalControllerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * TDD RED → GREEN : endpoint interne inter-instances du broadcast admin
+ * (#283). Authentification par secret partagé (X-Broadcast-Token), hors du
+ * firewall JWT `api` — pas de notion d'utilisateur ici, c'est un appel
+ * service-to-service entre instances.
+ */
+final class BroadcastInternalControllerTest extends WebTestCase
+{
+    public function testRejects401WithoutToken(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/internal/broadcast', server: ['CONTENT_TYPE' => 'application/json'], content: '{"subject":"S","body":"B"}');
+
+        $this->assertSame(401, $client->getResponse()->getStatusCode());
+    }
+
+    public function testRejects401WithWrongToken(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/internal/broadcast', server: [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_BROADCAST_TOKEN' => 'mauvais-token',
+        ], content: '{"subject":"S","body":"B"}');
+
+        $this->assertSame(401, $client->getResponse()->getStatusCode());
+    }
+
+    public function testAcceptsValidTokenAndSendsLocally(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/internal/broadcast', server: [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_BROADCAST_TOKEN' => $_ENV['BROADCAST_SHARED_TOKEN'],
+        ], content: '{"subject":"Maintenance","body":"<p>Texte</p>","dryRun":false}');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+    }
+
+    public function testDryRunReturns200WithoutSendingAnyEmail(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/internal/broadcast', server: [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_BROADCAST_TOKEN' => $_ENV['BROADCAST_SHARED_TOKEN'],
+        ], content: '{"subject":"Maintenance","body":"<p>Texte</p>","dryRun":true}');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        self::assertEmailCount(0);
+    }
+}

--- a/tests/Command/BroadcastSendCommandTest.php
+++ b/tests/Command/BroadcastSendCommandTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\BroadcastSendCommand;
+use App\Interface\BroadcastOrchestratorInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * TDD RED → GREEN : déclenchement CLI du broadcast admin (#283) — utile
+ * pour un essai manuel ou un futur cron, mais surtout la brique déjà
+ * réutilisée par l'interface admin web.
+ */
+final class BroadcastSendCommandTest extends TestCase
+{
+    public function testDispatchesToAllInstancesByDefault(): void
+    {
+        $orchestrator = $this->createMock(BroadcastOrchestratorInterface::class);
+        $orchestrator->expects($this->once())
+            ->method('dispatch')
+            ->with('Sujet', 'Corps', null, false)
+            ->willReturn(['ronan' => true, 'yannick' => true]);
+
+        $tester = $this->commandTester($orchestrator);
+        $tester->execute(['--subject' => 'Sujet', '--body' => 'Corps']);
+
+        $tester->assertCommandIsSuccessful();
+    }
+
+    public function testTargetsSingleInstanceWithOption(): void
+    {
+        $orchestrator = $this->createMock(BroadcastOrchestratorInterface::class);
+        $orchestrator->expects($this->once())
+            ->method('dispatch')
+            ->with('Sujet', 'Corps', 'yannick', false)
+            ->willReturn(['yannick' => true]);
+
+        $tester = $this->commandTester($orchestrator);
+        $tester->execute(['--subject' => 'Sujet', '--body' => 'Corps', '--instance' => 'yannick']);
+
+        $tester->assertCommandIsSuccessful();
+    }
+
+    public function testDryRunOptionPreventsRealSend(): void
+    {
+        $orchestrator = $this->createMock(BroadcastOrchestratorInterface::class);
+        $orchestrator->expects($this->once())
+            ->method('dispatch')
+            ->with('Sujet', 'Corps', null, true)
+            ->willReturn(['ronan' => true]);
+
+        $tester = $this->commandTester($orchestrator);
+        $tester->execute(['--subject' => 'Sujet', '--body' => 'Corps', '--dry-run' => true]);
+
+        $tester->assertCommandIsSuccessful();
+    }
+
+    public function testReportsFailedInstancesInOutput(): void
+    {
+        $orchestrator = $this->createMock(BroadcastOrchestratorInterface::class);
+        $orchestrator->method('dispatch')->willReturn(['ronan' => true, 'yannick' => false]);
+
+        $tester = $this->commandTester($orchestrator);
+        $tester->execute(['--subject' => 'Sujet', '--body' => 'Corps']);
+
+        $this->assertStringContainsString('yannick', $tester->getDisplay());
+    }
+
+    private function commandTester(BroadcastOrchestratorInterface $orchestrator): CommandTester
+    {
+        $command = new BroadcastSendCommand($orchestrator);
+        $application = new Application();
+        $application->addCommand($command);
+
+        return new CommandTester($application->find('app:broadcast:send'));
+    }
+}

--- a/tests/Unit/Security/BroadcastAdminCheckerTest.php
+++ b/tests/Unit/Security/BroadcastAdminCheckerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Entity\User;
+use App\Security\BroadcastAdminChecker;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * TDD RED → GREEN : garde applicative de l'écran /admin/broadcast (#283).
+ * Pas de nouveau ROLE_ADMIN Symfony (aucun rôle différencié n'existe dans le
+ * projet, getRoles() renvoie toujours ROLE_USER) — juste une whitelist par
+ * email, explicite et testable, qui couvre le cas où un guest serait un jour
+ * ajouté sur l'instance ronan.lenouvel.me elle-même.
+ */
+final class BroadcastAdminCheckerTest extends TestCase
+{
+    public function testIsAdminReturnsTrueForConfiguredAdminEmail(): void
+    {
+        $checker = new BroadcastAdminChecker('ronan@example.com');
+        $user = new User('ronan@example.com', 'Ronan');
+
+        $this->assertTrue($checker->isAdmin($user));
+    }
+
+    public function testIsAdminReturnsFalseForOtherUsers(): void
+    {
+        $checker = new BroadcastAdminChecker('ronan@example.com');
+        $user = new User('guest@example.com', 'Guest');
+
+        $this->assertFalse($checker->isAdmin($user));
+    }
+}

--- a/tests/Unit/Service/BroadcastMailerTest.php
+++ b/tests/Unit/Service/BroadcastMailerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\User;
+use App\Interface\UserRepositoryInterface;
+use App\Service\BroadcastMailer;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Validator\Validation;
+
+/**
+ * TDD RED → GREEN : diffusion d'un message admin (#283) à tous les comptes
+ * de l'instance courante, invités (guest) inclus, sans bloquer l'envoi aux
+ * autres destinataires si l'un d'eux a un email invalide.
+ */
+final class BroadcastMailerTest extends TestCase
+{
+    private function makeMailer(
+        MailerInterface $mailer,
+        UserRepositoryInterface $userRepository,
+        ?LoggerInterface $logger = null,
+    ): BroadcastMailer {
+        return new BroadcastMailer(
+            $mailer,
+            $userRepository,
+            Validation::createValidator(),
+            $logger ?? $this->createStub(LoggerInterface::class),
+        );
+    }
+
+    private function makeUserRepositoryStub(array $users): UserRepositoryInterface
+    {
+        $stub = $this->createStub(UserRepositoryInterface::class);
+        $stub->method('findAll')->willReturn($users);
+
+        return $stub;
+    }
+
+    public function testSendsToAllUsersWithValidEmail(): void
+    {
+        $owner = new User('owner@example.com', 'Owner');
+        $guest = new User('guest@example.com', 'Guest');
+        $guest->markAsGuest();
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects($this->exactly(2))->method('send');
+
+        $sender = $this->makeMailer($mailer, $this->makeUserRepositoryStub([$owner, $guest]));
+
+        $count = $sender->sendToAllUsers('Maintenance', '<p>Texte</p>', dryRun: false);
+
+        $this->assertSame(2, $count);
+    }
+
+    public function testIncludesGuestAccounts(): void
+    {
+        $guest = new User('guest@example.com', 'Guest');
+        $guest->markAsGuest();
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $sentTo = null;
+        $mailer->expects($this->once())->method('send')->willReturnCallback(
+            function ($message) use (&$sentTo) {
+                $sentTo = $message->getTo()[0]->getAddress();
+            }
+        );
+
+        $sender = $this->makeMailer($mailer, $this->makeUserRepositoryStub([$guest]));
+        $sender->sendToAllUsers('Maintenance', '<p>Texte</p>', dryRun: false);
+
+        $this->assertSame('guest@example.com', $sentTo);
+    }
+
+    public function testDryRunSendsNoEmailButReturnsCount(): void
+    {
+        $owner = new User('owner@example.com', 'Owner');
+        $guest = new User('guest@example.com', 'Guest');
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects($this->never())->method('send');
+
+        $sender = $this->makeMailer($mailer, $this->makeUserRepositoryStub([$owner, $guest]));
+
+        $count = $sender->sendToAllUsers('Maintenance', '<p>Texte</p>', dryRun: true);
+
+        $this->assertSame(2, $count);
+    }
+
+    public function testSkipsInvalidEmailAndLogsWarning(): void
+    {
+        $valid = new User('valid@example.com', 'Valid');
+        $invalid = new User('pas-un-email', 'Invalid');
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects($this->once())->method('send');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('warning');
+
+        $sender = $this->makeMailer($mailer, $this->makeUserRepositoryStub([$valid, $invalid]), $logger);
+
+        $count = $sender->sendToAllUsers('Maintenance', '<p>Texte</p>', dryRun: false);
+
+        $this->assertSame(1, $count);
+    }
+}

--- a/tests/Unit/Service/BroadcastOrchestratorTest.php
+++ b/tests/Unit/Service/BroadcastOrchestratorTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Interface\BroadcastMailerInterface;
+use App\Interface\BroadcastTargetProviderInterface;
+use App\Service\BroadcastOrchestrator;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * TDD RED → GREEN : orchestration multi-instances du broadcast admin (#283).
+ * Chaque instance a sa propre DB — l'instance courante traite son cas en
+ * local (via BroadcastMailerInterface), les autres sont appelées en HTTP sur
+ * leur endpoint interne, protégé par un secret partagé.
+ */
+final class BroadcastOrchestratorTest extends TestCase
+{
+    private const TARGETS = [
+        'ronan'   => 'https://ronan.lenouvel.me',
+        'yannick' => 'https://yannick.lenouvel.me',
+        'elea'    => 'https://elea.lenouvel.me',
+    ];
+
+    private function makeTargetProviderStub(): BroadcastTargetProviderInterface
+    {
+        $stub = $this->createStub(BroadcastTargetProviderInterface::class);
+        $stub->method('getAllTargets')->willReturn(self::TARGETS);
+        $stub->method('getTarget')->willReturnCallback(
+            fn (string $instance) => self::TARGETS[$instance] ?? null,
+        );
+
+        return $stub;
+    }
+
+    private function makeOrchestrator(
+        MockHttpClient $httpClient,
+        ?BroadcastMailerInterface $localMailer = null,
+    ): BroadcastOrchestrator {
+        $localMailer ??= $this->createStub(BroadcastMailerInterface::class);
+
+        return new BroadcastOrchestrator(
+            $httpClient,
+            $this->makeTargetProviderStub(),
+            $localMailer,
+            $this->createStub(LoggerInterface::class),
+            currentInstance: 'ronan',
+            sharedToken: 'the-secret-token',
+        );
+    }
+
+    public function testDispatchesToAllInstancesWhenNoTargetGiven(): void
+    {
+        $requests = [];
+        $httpClient = new MockHttpClient(function ($method, $url, $options) use (&$requests) {
+            $requests[] = $url;
+
+            return new MockResponse('{"sent":1}');
+        });
+
+        $localMailer = $this->createMock(BroadcastMailerInterface::class);
+        $localMailer->expects($this->once())->method('sendToAllUsers')->willReturn(1);
+
+        $orchestrator = $this->makeOrchestrator($httpClient, $localMailer);
+        $orchestrator->dispatch('Sujet', 'Corps', targetInstance: null, dryRun: false);
+
+        $this->assertCount(2, $requests);
+        $this->assertContains('https://yannick.lenouvel.me/internal/broadcast', $requests);
+        $this->assertContains('https://elea.lenouvel.me/internal/broadcast', $requests);
+    }
+
+    public function testDispatchesToSingleTargetedInstanceOnly(): void
+    {
+        $requests = [];
+        $httpClient = new MockHttpClient(function ($method, $url, $options) use (&$requests) {
+            $requests[] = $url;
+
+            return new MockResponse('{"sent":1}');
+        });
+
+        $localMailer = $this->createMock(BroadcastMailerInterface::class);
+        $localMailer->expects($this->never())->method('sendToAllUsers');
+
+        $orchestrator = $this->makeOrchestrator($httpClient, $localMailer);
+        $orchestrator->dispatch('Sujet', 'Corps', targetInstance: 'yannick', dryRun: false);
+
+        $this->assertSame(['https://yannick.lenouvel.me/internal/broadcast'], $requests);
+    }
+
+    public function testDryRunMakesNoHttpCallAtAll(): void
+    {
+        $called = false;
+        $httpClient = new MockHttpClient(function () use (&$called) {
+            $called = true;
+
+            return new MockResponse('{"sent":0}');
+        });
+
+        $localMailer = $this->createMock(BroadcastMailerInterface::class);
+        $localMailer->expects($this->once())->method('sendToAllUsers')->with('Sujet', 'Corps', true)->willReturn(0);
+
+        $orchestrator = $this->makeOrchestrator($httpClient, $localMailer);
+        $orchestrator->dispatch('Sujet', 'Corps', targetInstance: null, dryRun: true);
+
+        $this->assertFalse($called, 'Aucun appel HTTP ne doit être fait en dry-run.');
+    }
+
+    public function testHttpFailureOnOneInstanceDoesNotAbortOthers(): void
+    {
+        $httpClient = new MockHttpClient(function ($method, $url) {
+            if (str_contains($url, 'yannick')) {
+                throw new TransportException('unreachable');
+            }
+
+            return new MockResponse('{"sent":1}');
+        });
+
+        $orchestrator = $this->makeOrchestrator($httpClient);
+        $result = $orchestrator->dispatch('Sujet', 'Corps', targetInstance: null, dryRun: false);
+
+        $this->assertFalse($result['yannick']);
+        $this->assertTrue($result['elea']);
+    }
+
+    public function testSendsSharedTokenHeaderOnEachCall(): void
+    {
+        $capturedOptions = [];
+        $httpClient = new MockHttpClient(function ($method, $url, $options) use (&$capturedOptions) {
+            $capturedOptions[] = $options;
+
+            return new MockResponse('{"sent":1}');
+        });
+
+        $orchestrator = $this->makeOrchestrator($httpClient);
+        $orchestrator->dispatch('Sujet', 'Corps', targetInstance: 'yannick', dryRun: false);
+
+        $this->assertContains('X-Broadcast-Token: the-secret-token', $capturedOptions[0]['headers']);
+    }
+}

--- a/tests/Unit/Service/BroadcastTargetProviderTest.php
+++ b/tests/Unit/Service/BroadcastTargetProviderTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\BroadcastTargetProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * TDD RED → GREEN : expose la liste des instances déployées (#283), lue
+ * depuis config/broadcast_targets.php — miroir maintenu manuellement de
+ * .deploy-targets (fichier shell non lu par le PHP applicatif).
+ */
+final class BroadcastTargetProviderTest extends TestCase
+{
+    private function makeProvider(): BroadcastTargetProvider
+    {
+        return new BroadcastTargetProvider(\dirname(__DIR__, 3) . '/config/broadcast_targets.php');
+    }
+
+    public function testGetAllTargetsReturnsAllKnownInstances(): void
+    {
+        $targets = $this->makeProvider()->getAllTargets();
+
+        $this->assertArrayHasKey('ronan', $targets);
+        $this->assertSame('https://ronan.lenouvel.me', $targets['ronan']);
+        $this->assertArrayHasKey('yannick', $targets);
+    }
+
+    public function testGetTargetReturnsUrlForKnownInstance(): void
+    {
+        $this->assertSame(
+            'https://damien.lenouvel.me',
+            $this->makeProvider()->getTarget('damien'),
+        );
+    }
+
+    public function testGetTargetReturnsNullForUnknownInstance(): void
+    {
+        $this->assertNull($this->makeProvider()->getTarget('inexistant'));
+    }
+}

--- a/tests/Web/BroadcastAdminWebControllerTest.php
+++ b/tests/Web/BroadcastAdminWebControllerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Web;
+
+use App\Entity\User;
+use App\Tests\Web\Fixtures\WebFixturesTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * TDD RED → GREEN : interface admin web du broadcast (#283). Réservée au
+ * compte configuré comme admin (BROADCAST_ADMIN_EMAIL, cf. .env.test) — pas
+ * de ROLE_ADMIN Symfony, juste une whitelist explicite via
+ * BroadcastAdminChecker, car aucun rôle différencié n'existe dans ce projet.
+ */
+final class BroadcastAdminWebControllerTest extends WebTestCase
+{
+    use WebFixturesTrait;
+
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0');
+        $conn->executeStatement('DELETE FROM users');
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1');
+        $this->em->clear();
+    }
+
+    private function createAdmin(): User
+    {
+        return $this->createWebUser($_ENV['BROADCAST_ADMIN_EMAIL'], 'secret123', 'Admin');
+    }
+
+    public function testRejectsAnonymousUser(): void
+    {
+        $this->client->request('GET', '/admin/broadcast');
+
+        $this->assertResponseRedirects('/login');
+    }
+
+    public function testRejectsNonAdminEmail(): void
+    {
+        $this->createWebUser('pas-admin@example.com', 'secret123', 'Pas Admin');
+        $this->loginAs('pas-admin@example.com');
+
+        $this->client->request('GET', '/admin/broadcast');
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testRendersFormForAdminUser(): void
+    {
+        $this->createAdmin();
+        $this->loginAs($_ENV['BROADCAST_ADMIN_EMAIL']);
+
+        $this->client->request('GET', '/admin/broadcast');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('form');
+    }
+}


### PR DESCRIPTION
## Résumé

- Ronan peut diffuser un message (maintenance, indisponibilité, mise à jour majeure) par email à tous les utilisateurs (propriétaires + invités) de toutes les instances déployées, ou une seule instance ciblée, en une seule action depuis `/admin/broadcast`.
- Chaque instance a sa propre DB isolée : l'instance `ronan.lenouvel.me` orchestre via un appel HTTP interne (`BroadcastOrchestrator` → `POST /internal/broadcast`) sur chaque autre instance, qui envoie ensuite ses propres emails localement.
- Authentification service-to-service par secret partagé (`BROADCAST_SHARED_TOKEN`), firewall dédié `broadcast_internal`, hors du firewall JWT `api`.
- Pas de nouveau `ROLE_ADMIN` Symfony : garde applicative `BroadcastAdminChecker` (whitelist par email `BROADCAST_ADMIN_EMAIL`).
- Dry-run à tous les niveaux (service, orchestrateur, endpoint, command, formulaire admin), sans appel HTTP sortant en dry-run.
- Canal email uniquement pour cette version — notification in-app suivie séparément dans #361.

## Commits

1. `BroadcastTargetProvider` + `BroadcastMailer` — envoi local à tous les users d'une instance (guests inclus, email invalide skippé)
2. `BroadcastOrchestrator` — orchestration multi-instances (ciblage, dry-run, échec partiel n'interrompt pas les autres)
3. `BroadcastInternalController` — endpoint interne + firewall dédié + authenticator par token
4. `BroadcastSendCommand` — déclenchement CLI (`app:broadcast:send`)
5. `BroadcastAdminWebController` — interface admin web + lien de navigation conditionnel
6. Config déploiement (`bin/deploy-all.sh`, `.env*`, `.claude/deploiement.md`)
7. Avancement

## Test plan

- [x] Suite complète PHPUnit : 976/976 verts, `composer dev-check` passé
- [x] Tests dédiés : `BroadcastTargetProviderTest`, `BroadcastMailerTest`, `BroadcastOrchestratorTest`, `BroadcastInternalControllerTest`, `BroadcastSendCommandTest`, `BroadcastAdminCheckerTest`, `BroadcastAdminWebControllerTest`
- [ ] Avant premier envoi réel en prod : ajouter `BROADCAST_SHARED_TOKEN_PRESET`/`BROADCAST_ADMIN_EMAIL_PRESET` dans `.secrets`, redéployer les 7 instances, tester en dry-run ciblé sur une instance non critique avant un envoi à toutes

Closes #283