### PR TITLE
Aligner le formulaire de diffusion admin sur le design system

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -20,6 +20,7 @@
 @import "./new-album-modal.css";
 @import "./new-menu.css";
 @import "./guests.css";
+@import "./broadcast-admin.css";
 @import "./main.css";
 
 nav .navbar-logo .navbar-logo-cloud {

--- a/assets/styles/broadcast-admin.css
+++ b/assets/styles/broadcast-admin.css
@@ -1,0 +1,110 @@
+/*
+ * assets/styles/broadcast-admin.css
+ * Styles pour la page admin de diffusion (templates/web/broadcast_admin.html.twig)
+ */
+
+.hc-broadcast-field {
+  margin-bottom: 1.1rem;
+}
+
+.hc-broadcast-label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--hc-text-2);
+  margin-bottom: 0.4rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.hc-broadcast-input,
+.hc-broadcast-textarea,
+.hc-broadcast-select {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.55rem 0.85rem;
+  border: 1px solid var(--hc-border);
+  border-radius: 0.6rem;
+  font-size: 0.875rem;
+  color: var(--hc-text);
+  background: var(--hc-surface);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.hc-broadcast-input:focus,
+.hc-broadcast-textarea:focus,
+.hc-broadcast-select:focus {
+  border-color: var(--hc-accent);
+}
+
+.hc-broadcast-textarea {
+  min-height: 140px;
+  resize: vertical;
+  font-family: inherit;
+}
+
+.hc-broadcast-select {
+  cursor: pointer;
+}
+
+.hc-broadcast-checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.hc-broadcast-checkbox-row .hc-broadcast-label {
+  margin-bottom: 0;
+  text-transform: none;
+  letter-spacing: normal;
+  font-size: 0.875rem;
+}
+
+.hc-broadcast-submit {
+  padding: 0.6rem 1.5rem;
+  background: var(--hc-accent);
+  color: #fff;
+  border: none;
+  border-radius: 0.6rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+  align-self: flex-start;
+}
+
+.hc-broadcast-submit:hover {
+  background: var(--hc-accent-2);
+}
+
+.hc-broadcast-error {
+  color: var(--hc-err);
+  font-size: 0.8rem;
+  margin-top: 0.35rem;
+}
+
+.hc-broadcast-results {
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--hc-border);
+  border-radius: 0.75rem;
+  background: var(--hc-surface);
+}
+
+.hc-broadcast-results-title {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: var(--hc-text);
+}
+
+.hc-broadcast-results ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  color: var(--hc-text-2);
+}

--- a/templates/web/broadcast_admin.html.twig
+++ b/templates/web/broadcast_admin.html.twig
@@ -12,8 +12,8 @@
   </div>
 
   {% if results is not null %}
-    <div class="hc-item-card">
-      <p class="font-bold mb-2">Résultat</p>
+    <div class="hc-broadcast-results">
+      <p class="hc-broadcast-results-title">Résultat</p>
       <ul>
         {% for instance, success in results %}
           <li>{{ instance }} : {{ success ? 'OK' : 'échec' }}</li>
@@ -23,13 +23,35 @@
   {% endif %}
 
   {{ form_start(form) }}
-    <div class="flex flex-col gap-4">
-      {{ form_row(form.subject) }}
-      {{ form_row(form.body) }}
-      {{ form_row(form.targetInstance) }}
-      {{ form_row(form.dryRun) }}
-      <button type="submit" class="hc-guest-create-submit self-start">Envoyer</button>
+
+    <div class="hc-broadcast-field">
+      {{ form_label(form.subject, null, {label_attr: {class: 'hc-broadcast-label'}}) }}
+      {{ form_widget(form.subject, {attr: {class: 'hc-broadcast-input'}}) }}
+      {% if not form.subject.vars.valid %}
+        <div class="hc-broadcast-error">{{ form_errors(form.subject) }}</div>
+      {% endif %}
     </div>
+
+    <div class="hc-broadcast-field">
+      {{ form_label(form.body, null, {label_attr: {class: 'hc-broadcast-label'}}) }}
+      {{ form_widget(form.body, {attr: {class: 'hc-broadcast-textarea'}}) }}
+      {% if not form.body.vars.valid %}
+        <div class="hc-broadcast-error">{{ form_errors(form.body) }}</div>
+      {% endif %}
+    </div>
+
+    <div class="hc-broadcast-field">
+      {{ form_label(form.targetInstance, null, {label_attr: {class: 'hc-broadcast-label'}}) }}
+      {{ form_widget(form.targetInstance, {attr: {class: 'hc-broadcast-select'}}) }}
+    </div>
+
+    <div class="hc-broadcast-checkbox-row">
+      {{ form_widget(form.dryRun, {attr: {style: 'accent-color:var(--hc-accent)'}}) }}
+      {{ form_label(form.dryRun, null, {label_attr: {class: 'hc-broadcast-label'}}) }}
+    </div>
+
+    <button type="submit" class="hc-broadcast-submit">Envoyer</button>
+
   {{ form_end(form) }}
 
 </div>


### PR DESCRIPTION
## Résumé

- Le formulaire `/admin/broadcast` (#283) rendait les champs Symfony Form par défaut (`form_row`), sans classes du design system HomeCloud : label et champ sur la même ligne, pas de style clair/sombre cohérent.
- Nouveau fichier `assets/styles/broadcast-admin.css` sur le pattern de `new-folder-modal.css` (label bloc au-dessus, champ pleine largeur, variables `--hc-*`).
- Template réécrit en `form_label`/`form_widget`/`form_errors` explicites par champ, cohérent avec le seul autre formulaire "à la main" du projet (`reset_password/confirm.html.twig`).

Closes: aucune (correctif visuel de suivi sur #283, déjà fermée)